### PR TITLE
Strip HTTPS port

### DIFF
--- a/oauthlib/signature.py
+++ b/oauthlib/signature.py
@@ -59,9 +59,13 @@ def normalize_base_string_uri(uri):
     netloc = netloc.lower()
 
     # strip port 80 from host if expliticly present (3.4.1.2 #3)
+    default_ports = (
+        (u'http', u'80'),
+        (u'https', u'443'),
+    )
     if u':' in netloc:
         host, port = netloc.split(u':', 1)
-        if port == u'80' or port == u'443':
+        if (scheme, port) in default_ports:
             netloc = host
 
     return urlparse.urlunparse((scheme, netloc, path, '', '', ''))


### PR DESCRIPTION
Tiny addition. 
1.  The port MUST be included if it is not the default port for the scheme, and MUST be excluded if it is the default.  Specifically, the port MUST be excluded when making an HTTP request [RFC2616] to port 80 **or when making an HTTPS request [RFC2818] to port 443**. All other non-default port numbers MUST be included.
