### PR TITLE
Changed secrets and resource owner key to optional

### DIFF
--- a/oauthlib/oauth.py
+++ b/oauthlib/oauth.py
@@ -178,7 +178,7 @@ class OAuth1aServer(object):
         timestamp = params.get(u'oauth_timestamp')
         callback_uri = params.get(u'oauth_callback')
         verifier = params.get(u'oauth_verifier')
-        if not all((signature, client_key, nonce, timestamp)):
+        if not all((request_signature, client_key, nonce, timestamp)):
             return False
 
         # if version is supplied, it must be "1.0"


### PR DESCRIPTION
Client secret and resource owner secret are both optional per spec (http://tools.ietf.org/html/rfc5849#section-3.4.2, see key 2) even if it would make no sense to not use at least one. Both secrets can safely be set to None without affecting HMAC. Also if the request is signed with RSA-SHA1 then none of the secrets will be used.

Resource owner key is only available in step 2 & 3 of the 3 step authentication (http://tools.ietf.org/html/rfc5849#section-2). While it could still be submitted with an empty string as a value I think it is a better idea to leave it out of the parameters altogether.
