### PR TITLE
generate_token test was not running

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -118,7 +118,7 @@ class UtilsTests(TestCase):
         for i in range(50):
             self.assertTrue(nonce != generate_nonce())
 
-    def generate_token(self):
+    def test_generate_token(self):
         token = generate_token()
         self.assertEqual(len(token), 20)
 
@@ -127,7 +127,7 @@ class UtilsTests(TestCase):
 
         token = generate_token(length=6, chars="python")
         self.assertEqual(len(token), 6)
-        self.assertTrue("a" in token)
+        self.assertFalse("a" in token)
 
     def test_escape(self):
         self.assertRaises(ValueError, escape, "I am a string type. Not a unicode type.")


### PR DESCRIPTION
Added 'test' prefix to make the test run using normal test discovery and nosetests. Fixed a small assert error.
