### PR TITLE
OAuth 2 parameter handlers

### DIFF
--- a/oauthlib/oauth2_draft25/parameters.py
+++ b/oauthlib/oauth2_draft25/parameters.py
@@ -1,0 +1,164 @@
+from __future__ import absolute_import
+"""
+oauthlib.oauth2_draft25.parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This module contains methods related to `section 4`_ of the OAuth 2 draft.
+
+.. _`section 4`: http://tools.ietf.org/html/draft-ietf-oauth-v2-25#section-4
+"""
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
+import urlparse
+from . import utils
+
+def prepare_grant_uri(uri, client_id, response_type, redirect_uri=None,
+            scope=None, state=None, **kwargs):
+    """Prepare the authorization grant request URI.
+
+    Per `section 4.1.1`_ and `section 4.2.1`_ of the spec.
+
+    .. _`section 4.1.1`: http://tools.ietf.org/html/draft-ietf-oauth-v2-25#section-4.1.1
+    .. _`section 4.2.1`: http://tools.ietf.org/html/draft-ietf-oauth-v2-25#section-4.2.1
+
+    :param uri: Authorization endpoint URI.
+    :param client_id: Client identifier given by service provider.
+    :param response_type: u'code' or u'token' (implicit grant)
+    :param redirect_uri: URI to redirect resource owner back to. 
+    :param scope:  Resources access scope, i.e. "photos".
+    :param state: Per request state.
+    :param kwargs: Extra arguments to include in the URI.
+    :returns: request uri with added OAuth parameters
+    """
+    
+    params = [((u'response_type', response_type)),
+              ((u'client_id', client_id))]
+
+    if redirect_uri:
+        params.append((u'redirect_uri', redirect_uri))
+    if scope:
+        params.append((u'scope', scope))
+    if state:
+        params.append((u'state', state))
+    
+    for k in kwargs:
+        params.append((unicode(k), kwargs[k]))
+
+    return utils.add_params_to_uri(uri, params)
+
+def prepare_token_request(grant_type, body=u'', **kwargs):
+    """Prepare the access token request.
+
+    Common arguments for different client profiles (in addition to grant_type):
+
+        Authorization code grant: 'code', 'redirect_uri'
+        Resource owner password credentials grant: 'username', 'password', 'scope'
+        Client credentials grant: 'scope'
+
+    Per section `4.1.3`_, `4.3.2`_, `4.4.2`_ of the spec.
+
+    .. _`4.1.3`: http://tools.ietf.org/html/draft-ietf-oauth-v2-25#section-4.1.3
+    .. _`4.3.2`: http://tools.ietf.org/html/draft-ietf-oauth-v2-25#section-4.3.2
+    .. _`4.4.2`: http://tools.ietf.org/html/draft-ietf-oauth-v2-25#section-4.4.2
+
+    :param grant_type: Usually one of u'code', u'password', u'client_credentials'
+    :param body: Request body.
+    :param kwargs: Extra arguments to include in the body.
+    :return: request body with added OAuth 2 and extra parameters
+    """
+    params = [(u'grant_type', grant_type)]
+    for k in kwargs:
+        params.append((unicode(k), kwargs[k]))
+
+    return utils.add_params_to_qs(body, params)
+
+def parse_grant_uri(uri):
+    """Parse authorization grant response URI into a dict.
+
+    Per `section 4.1.2`_ of the spec.
+
+    .. _`section 4.1.2`: http://tools.ietf.org/html/draft-ietf-oauth-v2-25#section-4.1.2
+    """
+    params = urlparse.urlparse(uri).query
+    return dict(urlparse.parse_qsl(params))
+
+def validate_grant_params(params, state=None):
+    """Ensure code precence and correct state in params. 
+    Returns False if the redirection URI query is an `Error Response`_.
+    
+    Per `section 4.1.2`_ and `section 5.2`_ of the spec.
+
+    .. _`section 4.1.2`: http://tools.ietf.org/html/draft-ietf-oauth-v2-25#section-4.1.2
+    .. _`Error Response`: http://tools.ietf.org/html/draft-ietf-oauth-v2-25#section-4.1.2.1
+    """
+    if u'error' in params:
+        #raise ValueError("Error. Response was %s" % params)
+        return False
+
+    if state and params.get(u'state', None) != state:
+        #raise ValueError("Mismatching or missing state in response, possible CSRF.")
+        return False
+
+    if not u'code' in params:
+        #raise ValueError("Missing code parameter in response.")
+        return False
+
+    return True
+
+def parse_token_uri(uri):
+    """Parse the implicit token response URI into a dict.
+    
+    Per `section 4.2.2`_ of the spec.
+    
+    .. _`section 4.2.2`: http://tools.ietf.org/html/draft-ietf-oauth-v2-25#section-4.2.2
+    """
+    fragment = urlparse.urlparse(uri).fragment
+    return dict(urlparse.parse_qsl(fragment, keep_blank_values=True))
+
+def parse_token_body(body):
+    """Parse the JSON token response body into a dict. 
+    
+    Per `section 5.1` of the spec.
+    
+    .. _`section 5.1`: http://tools.ietf.org/html/draft-ietf-oauth-v2-25#section-5.1
+    """
+    return json.loads(body)
+    
+def validate_token_params(params, state=None, scope=None):
+    """Ensures token precence, token type, expiration and scope in params.
+    Will also return False if params is a parsed error type per `section 5.2`_.
+
+    Per `section 5.1` and `section 4.2.2`_ of the spec.
+
+    .. _`section 5.1`: http://tools.ietf.org/html/draft-ietf-oauth-v2-25#section-5.1
+    .. _`section 4.2.2`: http://tools.ietf.org/html/draft-ietf-oauth-v2-25#section-4.2.2
+    .. _`section 5.2`: http://tools.ietf.org/html/draft-ietf-oauth-v2-25#section-5.2
+    """
+    if u'error' in params:
+        #raise ValueError("Error. Response was %s" % params)
+        return False
+
+    if not u'access_token' in params:
+        #raise ValueError("Missing access token parameter.")
+        return False
+
+    if not u'token_type' in params:
+        #raise ValueError("Missing token type parameter.")
+        return False
+
+    # Implicit grant state check
+    if state and params.get(u'state', None) != state:
+        #raise ValueError("Mismatching or missing state in params, possible CSRF.")
+        return False
+
+    # Warn user if the token endpoint grants a different scope
+    # http://tools.ietf.org/html/draft-ietf-oauth-v2-25#section-3.3
+    new_scope = params.get(u'scope', None)
+    if scope and new_scope and scope != new_scope:
+        raise Warning("Scope has changed to %s." % new_scope)
+
+    return True

--- a/tests/oauth2_draft25/test_parameters.py
+++ b/tests/oauth2_draft25/test_parameters.py
@@ -1,0 +1,152 @@
+from __future__ import absolute_import
+
+from ..unittest import TestCase
+
+from oauthlib.oauth2_draft25.parameters import *
+
+class ParameterTests(TestCase):
+
+    auth_grant = { 
+        u'uri' : u'http://server.example.com/authorize',
+        u'client_id' : u's6BhdRkqt3',
+        u'response_type' : u'code',
+        u'redirect_uri' : u'https://client.example.com/cb',
+        u'scope' : u'photos',
+        u'state' : u'xyz'
+    }
+    auth_grant_uri = u'http://server.example.com/authorize?response_type=code&client_id=s6BhdRkqt3&redirect_uri=https%3A%2F%2Fclient.example.com%2Fcb&scope=photos&state=xyz'
+
+    auth_implicit = { 
+        u'uri' : u'http://server.example.com/authorize',
+        u'client_id' : u's6BhdRkqt3',
+        u'response_type' : u'token',
+        u'redirect_uri' : u'https://client.example.com/cb',
+        u'state' : u'xyz',
+        u'extra' : u'extra'
+    }
+    auth_implicit_uri = u'http://server.example.com/authorize?response_type=token&client_id=s6BhdRkqt3&redirect_uri=https%3A%2F%2Fclient.example.com%2Fcb&state=xyz&extra=extra'
+
+    grant_body = {
+        u'grant_type' : u'authorization_code',
+        u'code' : u'SplxlOBeZQQYbYS6WxSbIA',
+        u'redirect_uri': u'https://client.example.com/cb'
+    }
+    auth_grant_body = u'grant_type=authorization_code&code=SplxlOBeZQQYbYS6WxSbIA&redirect_uri=https%3A%2F%2Fclient.example.com%2Fcb'
+
+    pwd_body = {
+        u'grant_type' : u'password',
+        u'username' : u'johndoe',
+        u'password' : u'A3ddj3w'
+    }
+    password_body = u'grant_type=password&username=johndoe&password=A3ddj3w'
+
+    cred_grant = {
+        u'grant_type' : u'client_credentials'
+    }
+    cred_body = u'grant_type=client_credentials'
+
+    grant_response = u'https://client.example.com/cb?code=SplxlOBeZQQYbYS6WxSbIA&state=xyz'
+    grant_dict = {
+        u'code' : u'SplxlOBeZQQYbYS6WxSbIA',
+        u'state' : u'xyz'
+    }
+
+    error_nocode = u'https://client.example.com/cb?state=xyz'
+    error_nostate = u'https://client.example.com/cb?code=SplxlOBeZQQYbYS6WxSbIA'
+    error_wrongstate = u'https://client.example.com/cb?code=SplxlOBeZQQYbYS6WxSbIA&state=abc'
+    error_response = u'https://client.example.com/cb?error=access_denied&state=xyz'
+
+    state = u'xyz'
+
+    implicit_response = u'http://example.com/cb#access_token=2YotnFZFEjr1zCsicMWpAA&state=xyz&token_type=example&expires_in=3600'
+    implicit_notoken = u'http://example.com/cb#state=xyz&token_type=example&expires_in=3600'
+    implicit_notype = u'http://example.com/cb#access_token=2YotnFZFEjr1zCsicMWpAA&state=xyz&expires_in=3600'
+    implicit_nostate = u'http://example.com/cb#access_token=2YotnFZFEjr1zCsicMWpAA&token_type=example&expires_in=3600'
+    implicit_wrongstate = u'http://example.com/cb#access_token=2YotnFZFEjr1zCsicMWpAA&state=abc&token_type=example&expires_in=3600'
+    implicit_dict = {
+        u'access_token' : u'2YotnFZFEjr1zCsicMWpAA',
+        u'state' : u'xyz',
+        u'token_type' : 'example',
+        u'expires_in' : u'3600',
+    }
+
+    json_response = u'{"access_token":"2YotnFZFEjr1zCsicMWpAA","token_type":"example","expires_in":3600,"refresh_token":"tGzv3JOkF0XG5Qx2TlKWIA","example_parameter":"example_value","scope":"abc"}'
+    json_error = u'{"error":"invalid_request"}'
+    json_notoken = u'{"token_type":"example","expires_in":3600,"refresh_token":"tGzv3JOkF0XG5Qx2TlKWIA","example_parameter":"example_value"}'
+    json_notype = u'{"access_token":"2YotnFZFEjr1zCsicMWpAA","expires_in":3600,"refresh_token":"tGzv3JOkF0XG5Qx2TlKWIA","example_parameter":"example_value"}'
+    json_dict = {
+       u'access_token' : u'2YotnFZFEjr1zCsicMWpAA',
+       u'token_type' : u'example',
+       u'expires_in' : 3600,
+       u'refresh_token' : u'tGzv3JOkF0XG5Qx2TlKWIA',
+       u'example_parameter' : u'example_value',
+       u'scope' : u'abc'
+    }
+
+
+    def test_prepare_grant_uri(self):
+        """Verify correct authorization URI construction."""
+        self.assertEqual(prepare_grant_uri(**self.auth_grant), self.auth_grant_uri) 
+        self.assertEqual(prepare_grant_uri(**self.auth_implicit), self.auth_implicit_uri) 
+
+    def test_prepare_token_request(self):
+        """Verify correct access token request body construction."""
+        self.assertEqual(prepare_token_request(**self.grant_body), self.auth_grant_body)
+        self.assertEqual(prepare_token_request(**self.pwd_body), self.password_body)
+        self.assertEqual(prepare_token_request(**self.cred_grant), self.cred_body)
+
+    def test_grant_response(self):
+        """Verify correct parameter parsing and validation for auth code responses."""
+        params = parse_grant_uri(self.grant_response)
+        self.assertEqual(params, self.grant_dict)
+        self.assertTrue(validate_grant_params(params, state=self.state))
+
+        params = parse_grant_uri(self.error_nocode)
+        self.assertFalse(validate_grant_params(params))
+
+        params = parse_grant_uri(self.error_nostate)
+        self.assertFalse(validate_grant_params(params, state=self.state))
+
+        params = parse_grant_uri(self.error_wrongstate)
+        self.assertFalse(validate_grant_params(params, state=self.state))
+
+        params = parse_grant_uri(self.error_response)
+        self.assertFalse(validate_grant_params(params))
+
+    def test_implicit_token_response(self):
+        """Verify correct parameter parsing and validation for implicit responses."""
+        params = parse_token_uri(self.implicit_response)
+        self.assertEqual(params, self.implicit_dict)
+        self.assertTrue(validate_token_params(params))
+
+        params = parse_token_uri(self.implicit_notoken)
+        self.assertFalse(validate_token_params(params))
+
+        params = parse_token_uri(self.implicit_notype)
+        self.assertFalse(validate_token_params(params))
+
+        params = parse_token_uri(self.implicit_nostate)
+        self.assertFalse(validate_token_params(params, state=self.state))
+
+        params = parse_token_uri(self.implicit_wrongstate)
+        self.assertFalse(validate_token_params(params, state=self.state))
+
+    def test_json_token_response(self):
+        """Verify correct parameter parsing and validation for token responses. """
+        params = parse_token_body(self.json_response)
+        self.assertEqual(params, self.json_dict)
+        self.assertTrue(validate_token_params(params))
+
+        params = parse_token_body(self.json_error)
+        self.assertFalse(validate_token_params(params))
+
+        params = parse_token_body(self.json_notoken)
+        self.assertFalse(validate_token_params(params))
+
+        params = parse_token_body(self.json_notype)
+        self.assertFalse(validate_token_params(params))
+
+        params = parse_token_body(self.json_response)
+        self.assertRaises(Warning, validate_token_params, params, scope=u'aaa')
+
+


### PR DESCRIPTION
Methods for preparing requests and parsing responses. They are all related to different client profiles although many of these profiles share functionality.

The reason I have included parsing methods too is simply to have a convenient way to get from uri or json response body to a dict of parameters for validation. The client validation is quite basic but strongly recommended by the spec to avoid CSRF and open redirection. The server validation (on its way) will contain more tricky parts.

A 10k overview of the 4 auth workflows (extensions not yet supported):

Authorization Code Grant:

```
   uri = prepare_grant_uri(...., u'code',...)
   # redirect user to uri, similar to oauth 1
   # user returns, params added to redirection uri query
   params = parse_grant_uri(redirection_uri)
   if validate_grant_params(params):
       body = prepare_token_request(u'authorization_code')
       # send post request to token endpoint
       params = parse_token_body(response.content)
       if validate_token_params(params):
            # everything worked, we now have an access token
            print params.get(u'access_token')
```

Implicit Code Grant:

```
   uri = prepare_grant_uri(...., u'token',...)
   # redirect user, similar to oauth 1
   # user returns, params added to redirection uri fragment
   params = parse_token_uri(redirection_uri)
   if validate_token_params(params):
      # everything worked, we now have an access token
      print params.get(u'access_token')    
```

Resource Owner Password Credentials Grant:

```
 body = prepare_token_request(u'password', username=username, 
                              password=password)
 # post request to token endpoint
 params = parse_token_body(response.content)
 if validate_token_params(params):
      # everything worked, we now have an access token
      print params.get(u'access_token')
```

Client Credentials Grant: 

```
 body = prepare_token_request(u'client_credentials')
 # post request to token endpoint
 params = parse_token_body(response.content)
 if validate_token_params(params):
      # everything worked, we now have an access token
      print params.get(u'access_token')
```

Some method renaming might be necessary. Tests also included.
