### PR TITLE
Fix the failing server tests.

### DIFF
--- a/oauthlib/oauth1/rfc5849/__init__.py
+++ b/oauthlib/oauth1/rfc5849/__init__.py
@@ -308,8 +308,10 @@ class Server(object):
                 signature_type=signature_type,
                 verifier=verifier)
 
-        client_signature = oauth_client.get_oauth_signature(uri,
-            http_method=http_method, body=body, headers=headers)
+        request = Request(uri, http_method, body, headers)
+        request.oauth_params = params
+
+        client_signature = oauth_client.get_oauth_signature(request)
 
         # FIXME: use near constant time string compare to avoid timing attacks
         return client_signature == request_signature

--- a/tests/oauth1/rfc5849/test_server.py
+++ b/tests/oauth1/rfc5849/test_server.py
@@ -38,7 +38,7 @@ class ServerTests(TestCase):
             resource_owner_secret=self.RESOURCE_OWNER_SECRET,
         )
 
-        uri, body, headers = c.sign(u'http://server.example.com:80/init')
+        uri, headers, body  = c.sign(u'http://server.example.com:80/init')
 
         s = self.TestServer()
         self.assertTrue(s.check_request_signature(uri, body=body,
@@ -52,7 +52,7 @@ class ServerTests(TestCase):
             callback_uri=u'http://client.example.com/callback'
         )
 
-        uri, body, headers = c.sign(u'http://server.example.com:80/init')
+        uri, headers, body = c.sign(u'http://server.example.com:80/init')
 
         s = self.TestServer()
         self.assertTrue(s.check_request_signature(uri, body=body,


### PR DESCRIPTION
I went through the latest changes and made some fixes so the server tests started working again.

The two changes I needed to make were:
1. Order of values returned from client.sign() were changed
2. Call to `Client.get_oauth_signature()` in `Server.check_request_signature()` needed to take a Request() instance.
