### PR TITLE
Toxification step 1 #25

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py26,py27
+[testenv]
+deps=nose
+     unittest2
+     pycrypto
+commands=nosetests


### PR DESCRIPTION
#25) Running tests in virtualenvs and different versions of python is super simple with Tox.

```
$~: pip install tox
$oauthlib/: tox
```

It now runs both python 2.6 and 2.7 which must both be installed on your system. Only tried it against 2.7 since getting 2.6 onto fedora seems like a pita and ive not got ubuntu installed atm.

Available environments are:
py24
py25
py26
py27
py30
py31
py32
jython
pypy
