### PR TITLE
Please provide tests as a package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     author_email='idan@gazit.me',
     url='https://github.com/idangazit/oauthlib',
     license=fread('LICENSE'),
-    packages=find_packages(exclude=('tests', 'docs')),
+    packages=find_packages(exclude=('docs')),
     test_suite='nose.collector',
     tests_require=tests_require,
     extras_require={'test': tests_require},


### PR DESCRIPTION
Hello,
I'm a member of the Debian Python Module Team and I'm packaging oauthlib for Debian[¹]. The package is
quite ready, you can find it in the team SVN[²]. I only have to enable testing at build time, but right now tests shipped in sdist are not complete: tests/**init**.py and tests/test_common.py are missing.

Please, can you ship them? As a workaround I will put missing files inside the packaging stuff but only you can fix properly this.

Many thanks in advance!

Kind regards,
Daniele Tricoli

[¹] http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=671487
[²] http://anonscm.debian.org/viewvc/python-modules/packages/python-oauthlib/trunk/
