### PR TITLE
Use python-rsa instead of pycrypto

### DIFF
--- a/oauthlib/oauth1/rfc5849/signature.py
+++ b/oauthlib/oauth1/rfc5849/signature.py
@@ -450,7 +450,7 @@ def sign_rsa_sha1(base_string, rsa_private_key):
     with the server that included its RSA public key (in a manner that is
     beyond the scope of this specification).
 
-    NOTE: this method requires the PyCrypto library.
+    NOTE: this method requires the python-rsa library.
 
     .. _`section 3.4.3`: http://tools.ietf.org/html/rfc5849#section-3.4.3
     .. _`RFC3447, Section 8.2`: http://tools.ietf.org/html/rfc3447#section-8.2
@@ -459,14 +459,10 @@ def sign_rsa_sha1(base_string, rsa_private_key):
 
     # TODO: finish RSA documentation
 
-    from Crypto.PublicKey import RSA
-    from Crypto.Signature import PKCS1_v1_5
-    from Crypto.Hash import SHA
-
-    key = RSA.importKey(rsa_private_key)
-    h = SHA.new(base_string)
-    p = PKCS1_v1_5.new(key)
-    return binascii.b2a_base64(p.sign(h))[:-1].decode('utf-8')
+    import rsa
+    key = rsa.PrivateKey.load_pkcs1(rsa_private_key)
+    sig = rsa.sign(base_string, key, 'SHA-1')
+    return binascii.b2a_base64(sig)[:-1]
 
 
 def sign_plaintext(client_secret, resource_owner_secret):

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,9 @@ def fread(fn):
     with open(join(dirname(__file__), fn), 'r') as f:
         return f.read()
 
-tests_require = ['nose', 'unittest2', 'pycrypto']
+tests_require = ['nose', 'unittest2', 'rsa']
 
-requires = ['pycrypto']
+requires = ['rsa']
 
 setup(
     name='oauthlib',


### PR DESCRIPTION
Switched because pycrypto has binary bits which require compilation, making
usage of oauthlib on windows more painful than necessary.
