### PR TITLE
Improve tests, fixing issue #40

### DIFF
--- a/tests/oauth1/rfc5849/test_signatures.py
+++ b/tests/oauth1/rfc5849/test_signatures.py
@@ -141,14 +141,14 @@ class SignatureTests(TestCase):
         normalized = normalize_parameters(parameters)
 
         # check the parameters type
-        self.assertTrue(isinstance(normalized, unicode))
+        self.assertIsInstance(normalized, unicode)
 
         # Lets see if things are in order
         # check to see that querystring keys come in alphanumeric order:
         querystring_keys = ['a2', 'a3', 'b5', 'content', 'oauth_consumer_key', 'oauth_nonce', 'oauth_signature_method', 'oauth_timestamp', 'oauth_token']
         index = -1  # start at -1 because the 'a2' key starts at index 0
         for key in querystring_keys:
-            self.assertTrue(normalized.index(key) > index)
+            self.assertGreater(normalized.index, index)
             index = normalized.index(key)
 
     def test_sign_hmac_sha1(self):

--- a/tests/oauth1/rfc5849/test_utils.py
+++ b/tests/oauth1/rfc5849/test_utils.py
@@ -57,10 +57,10 @@ class UtilsTests(TestCase):
         #   Any param that does not start with 'oauth'
         #   should not be present in the filtered params
         filtered_params = special_test_function(self.sample_params_list)
-        self.assertFalse("notoauth" in filtered_params)
-        self.assertTrue("oauth_consumer_key" in filtered_params)
-        self.assertTrue("oauth_token" in filtered_params)
-        self.assertFalse("notoautheither" in filtered_params)
+        self.assertNotIn("notoauth", filtered_params)
+        self.assertIn("oauth_consumer_key", filtered_params)
+        self.assertIn("oauth_token", filtered_params)
+        self.assertNotIn("notoautheither", filtered_params)
 
     def test_filter_oauth_params(self):
 
@@ -93,16 +93,16 @@ class UtilsTests(TestCase):
     def test_generate_timestamp(self):
         """ TODO: Better test here """
         timestamp = generate_timestamp()
-        self.assertTrue(isinstance(timestamp, unicode))
+        self.assertIsInstance(timestamp, unicode)
         self.assertTrue(int(timestamp))
-        self.assertTrue(int(timestamp) > 1331672335)  # is this increasing?
+        self.assertGreater(int(timestamp), 1331672335)  # is this increasing?
 
     def test_generate_nonce(self):
         """ TODO: better test here """
 
         nonce = generate_nonce()
         for i in range(50):
-            self.assertTrue(nonce != generate_nonce())
+            self.assertNotEqual(nonce, generate_nonce())
 
     def test_generate_token(self):
         token = generate_token()
@@ -113,7 +113,7 @@ class UtilsTests(TestCase):
 
         token = generate_token(length=6, chars="python")
         self.assertEqual(len(token), 6)
-        self.assertFalse("a" in token)
+        self.assertNotIn("a", token)
 
     def test_escape(self):
         self.assertRaises(ValueError, escape, "I am a string type. Not a unicode type.")
@@ -134,16 +134,16 @@ class UtilsTests(TestCase):
         authorization_headers = parse_authorization_header(self.authorization_header)
 
         # is it a list?
-        self.assertTrue(isinstance(authorization_headers, list))
+        self.assertIsInstance(authorization_headers, list)
 
         # are the internal items tuples?
         for header in authorization_headers:
-            self.assertTrue(isinstance(header, tuple))
+            self.assertIsInstance(header, tuple)
 
         # are the internal components of each tuple unicode?
         for k, v in authorization_headers:
-            self.assertTrue(isinstance(k, unicode))
-            self.assertTrue(isinstance(v, unicode))
+            self.assertIsInstance(k, unicode)
+            self.assertIsInstance(v, unicode)
 
         # let's check the parsed headers created
         correct_headers = [


### PR DESCRIPTION
This makes the changes suggested in issue #40 to make a couple of tests not depend on the order of dicts. I've also made a second commit that replaces several assertTrue/assertFalse calls with more specific test methods. This second commit is completely optional, but it seemed an obvious improvement to make while I was there. This works when using cpython 2.7 or pypy 1.8 with or without unittest2 installed. I have not tested it with python 2.6, but I see no reason for it to fail as long as unittest2 is installed.
