### PR TITLE
Fix OAuth1 Server so that it will work with initial oauth requests

### DIFF
--- a/oauthlib/oauth1/rfc5849/__init__.py
+++ b/oauthlib/oauth1/rfc5849/__init__.py
@@ -863,12 +863,14 @@ class Server(object):
             #   client via the "oauth_signature" parameter.
             # .. _`Section 3.4`: http://tools.ietf.org/html/rfc5849#section-3.4
             client_secret = self.get_client_secret(client_key)
-            if require_verifier:
-                resource_owner_secret = self.get_request_token_secret(
-                    client_key, resource_owner_key)
-            else:
-                resource_owner_secret = self.get_access_token_secret(
-                    client_key, resource_owner_key)
+            resource_owner_secret = None
+            if require_resource_owner:
+                if require_verifier:
+                    resource_owner_secret = self.get_request_token_secret(
+                        client_key, resource_owner_key)
+                else:
+                    resource_owner_secret = self.get_access_token_secret(
+                        client_key, resource_owner_key)
 
             if signature_method == SIGNATURE_HMAC:
                 valid_signature = signature.verify_hmac_sha1(request,


### PR DESCRIPTION
According to the RFC, oauth1 Temporary Credential Requests don't include a resource owner credential (an oauth_token parameter), but Server.verify doesn't correctly handle this case, despite having a flag (require_resource_owner).

This patch fixes that oversight.
