### PR TITLE
Make it possible to pass extra parameters to prepare_refresh_body

### DIFF
--- a/oauthlib/oauth2/draft25/__init__.py
+++ b/oauthlib/oauth2/draft25/__init__.py
@@ -99,7 +99,7 @@ class Client(object):
         return self.token_types[self.token_type](uri, http_method, body,
                     headers, token_placement)
 
-    def prepare_refresh_body(self, body='', refresh_token=None, scope=None):
+    def prepare_refresh_body(self, body='', refresh_token=None, scope=None, **kwargs):
         """Prepare an access token request, using a refresh token.
 
         If the authorization server issued a refresh token to the client, the
@@ -120,7 +120,7 @@ class Client(object):
         """
         refresh_token = refresh_token or self.refresh_token
         return prepare_token_request('refresh_token', body=body, scope=scope,
-                refresh_token=refresh_token)
+                refresh_token=refresh_token, **kwargs)
 
     def _add_bearer_token(self, uri, http_method='GET', body=None,
             headers=None, token_placement=None):


### PR DESCRIPTION
The current code allows extra parameters to be passed to authorization requests. This is useful if I want to for example add `client_id`/`client_secret` to the request. I needed the same functionality for token refresh requests, so I changed `prepare_refresh_body` to pass unknown keyword arguments directly to `prepare_token_request`.
