### PR TITLE
Fix link (Was displaying trailing underscore)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Documentation
 
 Full documentation is available on `Read the Docs`_.
 
-.. _`readthedocs`: https://oauthlib.readthedocs.org/en/latest/index.html
+.. _`Read the Docs`: https://oauthlib.readthedocs.org/en/latest/index.html
 
 Interested in making OAuth requests?
 ------------------------------------


### PR DESCRIPTION
Tedious pull req to fix up the link to match the text so it doesn't display a trailing underscore.
