### PR TITLE
Fix broken setup.py bdist_rpm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     author='Idan Gazit',
     author_email='idan@gazit.me',
     url='https://github.com/idan/oauthlib',
-    license=fread('LICENSE'),
+    license='BSD',
     packages=find_packages(exclude=('docs','tests','tests.*')),
     test_suite='nose.collector',
     tests_require=tests_require,


### PR DESCRIPTION
I've fixed the setup file's license field, so that oauthlib can be built as an RPM with 'python setup.py bdist_rpm'
