### PR TITLE
Issue86

### DIFF
--- a/oauthlib/oauth1/rfc5849/__init__.py
+++ b/oauthlib/oauth1/rfc5849/__init__.py
@@ -48,7 +48,8 @@ class Client(object):
             signature_method=SIGNATURE_HMAC,
             signature_type=SIGNATURE_TYPE_AUTH_HEADER,
             rsa_key=None, verifier=None, realm=None,
-            convert_to_unicode=False, encoding='utf-8'):
+            convert_to_unicode=False, encoding='utf-8',
+            nonce=None, timestamp=None):
         if convert_to_unicode:
             if isinstance(client_key, bytes_type):
                 client_key = client_key.decode(encoding)
@@ -70,6 +71,10 @@ class Client(object):
                 verifier = verifier.decode(encoding)
             if isinstance(realm, bytes_type):
                 realm = realm.decode(encoding)
+            if isinstance(nonce, bytes_type):
+                nonce = nonce.decode(encoding)
+            if isinstance(timestamp, bytes_type):
+                timestamp = timestamp.decode(encoding)
 
         self.client_key = client_key
         self.client_secret = client_secret
@@ -83,6 +88,8 @@ class Client(object):
         self.realm = realm
         self.convert_to_unicode = convert_to_unicode
         self.encoding = encoding
+        self.nonce = nonce
+        self.timestamp = timestamp
 
         if self.signature_method == SIGNATURE_RSA and self.rsa_key is None:
             raise ValueError('rsa_key is required when using RSA signature method.')
@@ -128,9 +135,13 @@ class Client(object):
     def get_oauth_params(self):
         """Get the basic OAuth parameters to be used in generating a signature.
         """
+        nonce = (generate_nonce()
+                 if self.nonce is None else self.nonce)
+        timestamp = (generate_timestamp() 
+                     if self.timestamp is None else self.timestamp)
         params = [
-            ('oauth_nonce', generate_nonce()),
-            ('oauth_timestamp', generate_timestamp()),
+            ('oauth_nonce', nonce),
+            ('oauth_timestamp', timestamp),
             ('oauth_version', '1.0'),
             ('oauth_signature_method', self.signature_method),
             ('oauth_consumer_key', self.client_key),

--- a/tests/oauth1/rfc5849/test_client.py
+++ b/tests/oauth1/rfc5849/test_client.py
@@ -37,3 +37,13 @@ class ClientConstructorTests(TestCase):
                         convert_to_unicode=True)
         self.assertFalse(isinstance(client.resource_owner_key, bytes_type))
         self.assertEqual(client.resource_owner_key, 'owner key')
+
+    def test_give_explicit_timestamp(self):
+        client = Client('client-key', timestamp='1')
+        params = dict(client.get_oauth_params())
+        self.assertEqual(params['oauth_timestamp'], '1')
+        
+    def test_give_explicit_nonce(self):
+        client = Client('client-key', nonce='1')
+        params = dict(client.get_oauth_params())
+        self.assertEqual(params['oauth_nonce'], '1')


### PR DESCRIPTION
Fix issue #86 as described by ib-lundgren's comment.  This adds `nonce` and `timestamp` arguments to the Client constructor and uses them in .get_oauth_params() if given.  I even added tests and fixed another typo. :)
