### PR TITLE
Add generate_client_id to common

### DIFF
--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -30,6 +30,10 @@ UNICODE_ASCII_CHARACTER_SET = ('abcdefghijklmnopqrstuvwxyz'
                                'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
                                '0123456789')
 
+CLIENT_ID_CHARACTER_SET = (r' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMN'
+                            'OPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}')
+
+
 always_safe = ('ABCDEFGHIJKLMNOPQRSTUVWXYZ'
                'abcdefghijklmnopqrstuvwxyz'
                '0123456789' '_.-')
@@ -197,6 +201,15 @@ def generate_token(length=30, chars=UNICODE_ASCII_CHARACTER_SET):
     """
     rand = random.SystemRandom()
     return ''.join(rand.choice(chars) for x in range(length))
+
+
+def generate_client_id(length=30, chars=CLIENT_ID_CHARACTER_SET):
+    """Generates an OAuth client_id
+
+    OAuth 2 specify the format of client_id in
+    http://tools.ietf.org/html/rfc6749#appendix-A.
+    """
+    return generate_token(length, chars)
 
 
 def add_params_to_qs(query, params):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -122,6 +122,17 @@ class CommonTests(TestCase):
         self.assertEqual(len(token), 6)
         self.assertNotIn("a", token)
 
+    def test_generate_client_id(self):
+        client_id = generate_client_id()
+        self.assertEqual(len(client_id), 30)
+
+        client_id = generate_client_id(length=44)
+        self.assertEqual(len(client_id), 44)
+
+        client_id = generate_client_id(length=6, chars="python")
+        self.assertEqual(len(client_id), 6)
+        self.assertNotIn("a", client_id)
+
 
 class CaseInsensitiveDictTest(TestCase):
 


### PR DESCRIPTION
What's about the inclusion of a function to create client ids?
