### PR TITLE
Avoid escape string twice.

### DIFF
--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -123,7 +123,6 @@ def urldecode(query):
     if len(re.findall(invalid_hex, query)):
         raise ValueError('Invalid hex encoding in query string.')
 
-    query = query.encode('utf-8') if isinstance(query, unicode_type) else query
     # We want to allow queries such as "c2" whereas urlparse.parse_qsl
     # with the strict_parsing flag will not.
     params = urlparse.parse_qsl(query, keep_blank_values=True)
@@ -315,7 +314,7 @@ class Request(object):
         self.uri = encode(uri)
         self.http_method = encode(http_method)
         self.headers = CaseInsensitiveDict(encode(headers or {}))
-        self.body = encode(body)
+        self.body = body
         self.decoded_body = extract_params(encode(body))
         self.oauth_params = []
 


### PR DESCRIPTION
Current design will escape string twice.
If we use `status=%E5%95%A6%E5%95%A6` as post body input, `Request.__init__` will make it `u"status=%E5%95%A6%E5%95%A6"`,
then `oauth1.rfc5849.signature.collect_parameters()` will call `bodyparams = extract_params(body) or []`,
then call `common.urldecode()`,
then call `urlparse.parse_qsl(query, keep_blank_values=True)`.
Here, `u"status=%E5%95%A6%E5%95%A6"` will become `[(u'status', u'\xe5\x95\xa6\xe5\x95\xa6')]`, now troubles comes in because `u'\xe5\x95\xa6\xe5\x95\xa6'` is a problematic unicode string.
When normalizing it, it will be utf8-encoded again (from `common.quote` called by `oauth1.rfc5849.utils.escape`) and become `'\xc3\xa5\xc2\x95\xc2\xa6\xc3\xa5\xc2\x95\xc2\xa6'`.
Now everything messed up, and calculated signature is wrong.

So we must abandan unnecessary body encode because body in unicode only cause problem, also we should remove `query = query.decode('utf-8') if isinstance(query, bytes_type) else query` to keep our `str` result away from converting to `unicode`. `decode_params_utf8` will decode the `str` result to correct one, and make the final calculation right.

The issue is not obvious because english words only use ascii characters which are safe after multple escaping.
