### PR TITLE
Consistent Client and Server parameter normalization for OAuth1

### DIFF
--- a/oauthlib/oauth1/rfc5849/__init__.py
+++ b/oauthlib/oauth1/rfc5849/__init__.py
@@ -1047,8 +1047,7 @@ class Server(object):
 
         # Parameters to Client depend on signature method which may vary
         # for each request. Note that HMAC-SHA1 and PLAINTEXT share parameters
-
-        request.params = filter(lambda x: x[0] not in ("oauth_signature", "realm"), params)
+        request.params = params
 
         # ---- RSA Signature verification ----
         if request.signature_method == SIGNATURE_RSA:

--- a/oauthlib/oauth1/rfc5849/signature.py
+++ b/oauthlib/oauth1/rfc5849/signature.py
@@ -370,11 +370,15 @@ def normalize_parameters(params):
     #
     # .. _`Section 3.4.1.3`: http://tools.ietf.org/html/rfc5849#section-3.4.1.3
 
+    #  - The header's content is parsed into a list of name/value pairs excluding the "realm" parameter if present.
+    #  - The "oauth_signature" parameter MUST be excluded from the signature base string if present.
+    key_values = [(k, v) for k, v in params if k not in ("realm", "oauth_signature")]
+
     # 1.  First, the name and value of each parameter are encoded
     #     (`Section 3.6`_).
     #
     # .. _`Section 3.6`: http://tools.ietf.org/html/rfc5849#section-3.6
-    key_values = [(utils.escape(k), utils.escape(v)) for k, v in params]
+    key_values = [(utils.escape(k), utils.escape(v)) for k, v in key_values]
 
     # 2.  The parameters are sorted by name, using ascending byte value
     #     ordering.  If two or more parameters share the same name, they


### PR DESCRIPTION
Fix for #139

Make Client and Server parameter normalization consistent by moving the filtration of `oauth_signature` and `realm` arguments into `normalize_parameters()`, as specified by RFC5849, section 3.4.1.3.
