### PR TITLE
Fix a copy-paste-o in a link to RFC 3986

### DIFF
--- a/oauthlib/oauth1/rfc5849/signature.py
+++ b/oauthlib/oauth1/rfc5849/signature.py
@@ -129,7 +129,7 @@ def normalize_base_string_uri(uri):
     # are included by constructing an "http" or "https" URI representing
     # the request resource (without the query or fragment) as follows:
     #
-    # .. _`RFC2616`: http://tools.ietf.org/html/rfc3986
+    # .. _`RFC3986`: http://tools.ietf.org/html/rfc3986
 
     # 1.  The scheme and host MUST be in lowercase.
     scheme = scheme.lower()


### PR DESCRIPTION
Some text mistakenly says `RFC2616` where it should say `RFC3986`.
