### PR TITLE
Fix Sphinx warnings in oauth_1_versus_oauth_2 documentation

### DIFF
--- a/docs/oauth_1_versus_oauth_2.rst
+++ b/docs/oauth_1_versus_oauth_2.rst
@@ -20,21 +20,24 @@ taken to restrict non authenticated clients access to resources appropriately.
   able to use SSL/TLS and you are willing to risk unknowingly granting
   access to your users resources to a malicious third party which has
   stolen tokens (but not authentication secrets) from one of your clients.
+
     **(Provider)** Offer :doc:`authcode`. Impact can be limited by not
-    providing refresh tokens. 
+    providing refresh tokens.
     Default in :doc:`WebApplicationServer <preconfigured_servers>`.
 
     **(Client)** Use :doc:`Web Application Client <webapplicationclient>`.
 
 * Similar to above, but you are unwilling to risk malicious access based on
   stolen tokens alone.
+
     **(Provider)** Offer :doc:`OAuth 1 <server>`.
 
     **(Client)** Use :doc:`OAuth 1 Client <client>`.
 
 * Your clients reside in user controlled devices with the ability to authorize
   through a web based workflow. This workflow is inherently insecure, restrict
-  the privileges associated with tokens accordingly. 
+  the privileges associated with tokens accordingly.
+
     **(Provider)** Offer :doc:`implicit`.
     Default in :doc:`MobileApplicationServer <preconfigured_servers>`.
 
@@ -43,6 +46,7 @@ taken to restrict non authenticated clients access to resources appropriately.
 * Similar to above but without the ability to use web authorization. These
   clients must have a strong trust relationship with the users although
   they offer no additional security.
+
     **(Provider)** Offer non authenticated :doc:`password`.
     Default in :doc:`LegacyApplicationServer <preconfigured_servers>`.
 
@@ -52,6 +56,7 @@ taken to restrict non authenticated clients access to resources appropriately.
   API to using OAuth tokens but for various reasons don't wish to use the web based
   authorization workflow. The clients reside in secure environments and have a strong
   trust relationship with their users.
+
     **(Provider)** Offer authenticated :doc:`password`.
     Default in :doc:`LegacyApplicationServer <preconfigured_servers>`.
 
@@ -59,6 +64,7 @@ taken to restrict non authenticated clients access to resources appropriately.
 
 * You wish to run an internal, highly trusted, job acting on protected
   resources but not interacting with users.
+
     **(Provider)** Offer :doc:`credentials`.
     Default in :doc:`BackendApplicationServer <preconfigured_servers>`.
 


### PR DESCRIPTION
Easy fixes to avoid a few 'ERROR: Unexpected indentation' from Sphinx v1.2b1 and remove trailing spaces.
