### PR TITLE
fix keyword error for required_realm

### DIFF
--- a/oauthlib/oauth1/rfc5849/endpoints/resource.py
+++ b/oauthlib/oauth1/rfc5849/endpoints/resource.py
@@ -42,7 +42,7 @@ class ResourceEndpoint(BaseEndpoint):
                             http_method=request.method,
                             body=request.data,
                             headers=request.headers,
-                            valid_realms=realms or [])
+                            required_realm=realms or [])
                     if v:
                         return f(*args, **kwargs)
                     else:
@@ -50,14 +50,14 @@ class ResourceEndpoint(BaseEndpoint):
     """
 
     def validate_protected_resource_request(self, uri, http_method='GET',
-            body=None, headers=None, valid_realms=None):
+            body=None, headers=None, required_realm=None):
         """Create a request token response, with a new request token if valid.
 
         :param uri: The full URI of the token request.
         :param http_method: A valid HTTP verb, i.e. GET, POST, PUT, HEAD, etc.
         :param body: The request body as a string.
         :param headers: The request headers as a dict.
-        :param valid_realms: A list of realms the resource is protected under.
+        :param require_realm: A list of realms the resource is protected under.
                              This will be supplied to the ``validate_realm``
                              method of the request validator.
         :returns: A tuple of 2 elements.
@@ -135,7 +135,7 @@ class ResourceEndpoint(BaseEndpoint):
         # the client.
         valid_realm = self.request_validator.validate_realm(request.client_key,
                 request.resource_owner_key, request, uri=request.uri,
-                valid_realms=valid_realms)
+                required_realm=required_realm)
 
         valid_signature = self._check_signature(request)
 


### PR DESCRIPTION
The keyword on request validator is `required_realm`, but it is called with a keyword `valid_realms` which could raise a KeywordError.

**Suggestion**:

There are `realm` and `realms`, it is not clear to see if it is a list or not. Let's make `realm` a string with whitespace and `realms` a list. Which means:

```
realm = 'email article'
realms = ['email', 'article']
```
