### PR TITLE
Add comma to the set of safe characters in urls

### DIFF
--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -118,7 +118,7 @@ def decode_params_utf8(params):
     return decoded
 
 
-urlencoded = set(always_safe) | set('=&;%+~')
+urlencoded = set(always_safe) | set('=&;%+~,')
 
 
 def urldecode(query):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -24,6 +24,7 @@ class CommonTests(TestCase):
         self.assertItemsEqual(urldecode('c2='), [('c2', '')])
         self.assertItemsEqual(urldecode('foo=bar'), [('foo', 'bar')])
         self.assertItemsEqual(urldecode('foo_%20~=.bar-'), [('foo_ ~', '.bar-')])
+        self.assertItemsEqual(urldecode('foo=1,2,3'), [('foo', '1,2,3')])
         self.assertRaises(ValueError, urldecode, 'foo bar')
         self.assertRaises(ValueError, urldecode, '?')
         self.assertRaises(ValueError, urldecode, '%R')


### PR DESCRIPTION
Avoid raising `ValueError` exception in `urldecode` method in `common` module for query strings like `foo=1,2,3`
