### PR TITLE
fix scopes normalization in validate_scopes method

### DIFF
--- a/oauthlib/oauth2/rfc6749/grant_types/base.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/base.py
@@ -27,9 +27,10 @@ class GrantTypeBase(object):
             raise errors.UnauthorizedClientError(request=request)
 
     def validate_scopes(self, request):
-        if not request.scopes:
-            request.scopes = utils.scope_to_list(request.scope) or utils.scope_to_list(
-                    self.request_validator.get_default_scopes(request.client_id, request))
+        scopes = request.scopes or self.request_validator.get_default_scopes(
+            request.client_id, request)
+        request.scopes = utils.scope_to_list(scopes)
+
         log.debug('Validating access to scopes %r for client %r (%r).',
                   request.scopes, request.client_id, request.client)
         if not self.request_validator.validate_scopes(request.client_id,


### PR DESCRIPTION
It seems to be an error in validate_scopes inside GrantTypeBase when user passes in request.scopes variable:
the first part of the request.scopes assignment, the one before the _or_, will never be assigned. 
This fix let my tests pass, does it sound reasonable?
