### PR TITLE
Add star to the set of safe characters in urls

### DIFF
--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -118,7 +118,7 @@ def decode_params_utf8(params):
     return decoded
 
 
-urlencoded = set(always_safe) | set('=&;%+~,')
+urlencoded = set(always_safe) | set('=&;%+~,*')
 
 
 def urldecode(query):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -25,6 +25,7 @@ class CommonTests(TestCase):
         self.assertItemsEqual(urldecode('foo=bar'), [('foo', 'bar')])
         self.assertItemsEqual(urldecode('foo_%20~=.bar-'), [('foo_ ~', '.bar-')])
         self.assertItemsEqual(urldecode('foo=1,2,3'), [('foo', '1,2,3')])
+        self.assertItemsEqual(urldecode('foo=bar.*'), [('foo', 'bar.*')])
         self.assertRaises(ValueError, urldecode, 'foo bar')
         self.assertRaises(ValueError, urldecode, '?')
         self.assertRaises(ValueError, urldecode, '%R')


### PR DESCRIPTION
Avoid raising ValueError exception in urldecode method in common module fors query strings like foo=bar.*

IMHO, as pointed by masci, rfc3986 (2.2.  Reserved Characters), the list should be extended up to:
=&;%+~,!$'()*
