### PR TITLE
Added documentation for save_access_token, temporary credentials must not be reused.

### DIFF
--- a/oauthlib/oauth1/rfc5849/request_validator.py
+++ b/oauthlib/oauth1/rfc5849/request_validator.py
@@ -703,6 +703,9 @@ class RequestValidator(object):
 
         Client key can be obtained from ``request.client_key``.
 
+        At this point, the request token used for this request should be made invalid.
+        The request token's key can be obtained from ``request.resource_owner_key``.
+
         The list of realms (not joined string) can be obtained from
         ``request.realm``.
 


### PR DESCRIPTION
```
The server MUST ... ensure that the temporary
credentials have not expired or been used before.
```

[RFC 5849 section-2.3](http://tools.ietf.org/html/rfc5849#section-2.3)
