### PR TITLE
Fixed single typo in documentation

### DIFF
--- a/oauthlib/oauth2/rfc6749/request_validator.py
+++ b/oauthlib/oauth2/rfc6749/request_validator.py
@@ -222,7 +222,7 @@ class RequestValidator(object):
                             convenient, access control.
 
         A powerful way to use scopes would mimic UNIX ACLs and see a scope
-        as a group with certain privilegues. For a restful API these might
+        as a group with certain privileges. For a restful API these might
         map to HTTP verbs instead of read, write and execute.
 
         Note, the request.user attribute can be set to the resource owner


### PR DESCRIPTION
Very simple change ;) But it was bugging me.

Fixed the typo:
privilegues -> privileges
