### PR TITLE
Remove travis install scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
   - "pypy"
 
 install:
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors unittest2; fi
   - pip install nose pycrypto mock
-  - python .travis_install.py
 
 script:
   - nosetests -w tests

--- a/.travis_install.py
+++ b/.travis_install.py
@@ -1,5 +1,0 @@
-import sys
-import subprocess
-
-if sys.version_info[0] == 2:
-    subprocess.call(['pip', 'install', 'unittest2'])


### PR DESCRIPTION
Remove the `.travis_install.py` script.

We can detect python version with environment variable.
