### PR TITLE
Include the request object in the returned dict

### DIFF
--- a/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
@@ -326,6 +326,7 @@ class AuthorizationCodeGrant(GrantTypeBase):
                 'redirect_uri': request.redirect_uri,
                 'response_type': request.response_type,
                 'state': request.state,
+                'request': request,
         }
 
     def validate_token_request(self, request):

--- a/oauthlib/oauth2/rfc6749/grant_types/implicit.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/implicit.py
@@ -331,4 +331,5 @@ class ImplicitGrant(GrantTypeBase):
                 'redirect_uri': request.redirect_uri,
                 'response_type': request.response_type,
                 'state': request.state,
+                'request': request,
         }


### PR DESCRIPTION
By including the `request` object in the returned dict we make it possible to cache information that will be used later in the process. This, however, prevents the dict from being serialised to json. 
