### PR TITLE
Correct interface

### DIFF
--- a/oauthlib/oauth2/rfc6749/request_validator.py
+++ b/oauthlib/oauth2/rfc6749/request_validator.py
@@ -89,7 +89,7 @@ class RequestValidator(object):
         raise NotImplementedError('Subclasses must implement this method.')
 
     def confirm_redirect_uri(self, client_id, code, redirect_uri, client,
-            request, *args, **kwargs):
+            *args, **kwargs):
         """Ensure client is authorized to redirect to the redirect_uri requested.
 
         If the client specifies a redirect_uri when obtaining code then


### PR DESCRIPTION
The interface was not consistent. This would result in a:

```
  File "/Users/andre/work/penv/discosite/lib/python2.7/site-packages/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py", line 384, in validate_token_request
    request.code, request.redirect_uri, request.client):
TypeError: confirm_redirect_uri() takes at least 6 arguments (5 given)
```
