### PR TITLE
Fix test method name conflict.

### DIFF
--- a/tests/oauth2/rfc6749/grant_types/test_refresh_token.py
+++ b/tests/oauth2/rfc6749/grant_types/test_refresh_token.py
@@ -108,7 +108,7 @@ class RefreshTokenGrantTest(TestCase):
         self.assertRaises(errors.InvalidRequestError,
                           self.auth.validate_token_request, self.request)
 
-    def test_invalid_scope(self):
+    def test_invalid_scope_original_scopes_empty(self):
         self.mock_validator.validate_refresh_token.return_value = True
         self.assertRaises(errors.InvalidScopeError,
                           self.auth.validate_token_request, self.request)


### PR DESCRIPTION
Without the fix only a single test_invalid_scope method is run.
