### PR TITLE
Fix docstrings to reflect the actual returned value of validate_* methods

### DIFF
--- a/oauthlib/oauth1/rfc5849/endpoints/access_token.py
+++ b/oauthlib/oauth1/rfc5849/endpoints/access_token.py
@@ -118,7 +118,9 @@ class AccessTokenEndpoint(BaseEndpoint):
 
         :param request: An oauthlib.common.Request object.
         :raises: OAuth1Error if the request is invalid.
-        :returns: True or False
+        :returns: A tuple of 2 elements.
+                  1. The validation result (True or False).
+                  2. The request object.
         """
         self._check_transport_security(request)
         self._check_mandatory_parameters(request)

--- a/oauthlib/oauth1/rfc5849/endpoints/request_token.py
+++ b/oauthlib/oauth1/rfc5849/endpoints/request_token.py
@@ -108,7 +108,9 @@ class RequestTokenEndpoint(BaseEndpoint):
 
         :param request: An oauthlib.common.Request object.
         :raises: OAuth1Error if the request is invalid.
-        :returns: True or False
+        :returns: A tuple of 2 elements.
+                  1. The validation result (True or False).
+                  2. The request object.
         """
         self._check_transport_security(request)
         self._check_mandatory_parameters(request)


### PR DESCRIPTION
The docstrings for `validate_access_token_request` and `validate_request_token_request` say those methods return just a boolean when in fact it returns a tuple. This simply fixes those 2 docstrings.
