### PR TITLE
Move docstrings above `from __future__` imports.

### DIFF
--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.common
 ~~~~~~~~~~~~~~
@@ -8,6 +6,7 @@ oauthlib.common
 This module provides data structures and utilities common
 to all implementations of OAuth.
 """
+from __future__ import absolute_import, unicode_literals
 
 import collections
 import datetime

--- a/oauthlib/oauth1/__init__.py
+++ b/oauthlib/oauth1/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.oauth1
 ~~~~~~~~~~~~~~
@@ -8,6 +6,7 @@ oauthlib.oauth1
 This module is a wrapper for the most recent implementation of OAuth 1.0 Client
 and Server classes.
 """
+from __future__ import absolute_import, unicode_literals
 
 from .rfc5849 import Client
 from .rfc5849 import SIGNATURE_HMAC, SIGNATURE_RSA, SIGNATURE_PLAINTEXT

--- a/oauthlib/oauth1/rfc5849/__init__.py
+++ b/oauthlib/oauth1/rfc5849/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.oauth1.rfc5849
 ~~~~~~~~~~~~~~
@@ -8,6 +6,7 @@ oauthlib.oauth1.rfc5849
 This module is an implementation of various logic needed
 for signing and checking OAuth 1.0 RFC 5849 requests.
 """
+from __future__ import absolute_import, unicode_literals
 
 import logging
 log = logging.getLogger("oauthlib")
@@ -40,6 +39,7 @@ CONTENT_TYPE_FORM_URLENCODED = 'application/x-www-form-urlencoded'
 
 
 class Client(object):
+    """A client used to sign OAuth 1.0 RFC 5849 requests."""
     SIGNATURE_METHODS = {
         SIGNATURE_HMAC: signature.sign_hmac_sha1_with_client,
         SIGNATURE_RSA: signature.sign_rsa_sha1_with_client,
@@ -50,7 +50,6 @@ class Client(object):
     def register_signature_method(cls, method_name, method_callback):
         cls.SIGNATURE_METHODS[method_name] = method_callback
 
-    """A client used to sign OAuth 1.0 RFC 5849 requests"""
     def __init__(self, client_key,
             client_secret=None,
             resource_owner_key=None,

--- a/oauthlib/oauth1/rfc5849/endpoints/access_token.py
+++ b/oauthlib/oauth1/rfc5849/endpoints/access_token.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.oauth1.rfc5849.endpoints.access_token
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -10,6 +8,8 @@ OAuth 1.0 RFC 5849. It validates the correctness of access token requests,
 creates and persists tokens as well as create the proper response to be
 returned to the client.
 """
+from __future__ import absolute_import, unicode_literals
+
 from oauthlib.common import log, urlencode
 
 from .base import BaseEndpoint

--- a/oauthlib/oauth1/rfc5849/endpoints/authorization.py
+++ b/oauthlib/oauth1/rfc5849/endpoints/authorization.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.oauth1.rfc5849.endpoints.authorization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -8,6 +6,7 @@ oauthlib.oauth1.rfc5849.endpoints.authorization
 This module is an implementation of various logic needed
 for signing and checking OAuth 1.0 RFC 5849 requests.
 """
+from __future__ import absolute_import, unicode_literals
 
 from oauthlib.common import Request, add_params_to_uri
 

--- a/oauthlib/oauth1/rfc5849/endpoints/base.py
+++ b/oauthlib/oauth1/rfc5849/endpoints/base.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.oauth1.rfc5849.endpoints.base
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -8,6 +6,7 @@ oauthlib.oauth1.rfc5849.endpoints.base
 This module is an implementation of various logic needed
 for signing and checking OAuth 1.0 RFC 5849 requests.
 """
+from __future__ import absolute_import, unicode_literals
 
 import time
 

--- a/oauthlib/oauth1/rfc5849/endpoints/request_token.py
+++ b/oauthlib/oauth1/rfc5849/endpoints/request_token.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.oauth1.rfc5849.endpoints.request_token
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -10,6 +8,8 @@ OAuth 1.0 RFC 5849. It validates the correctness of request token requests,
 creates and persists tokens as well as create the proper response to be
 returned to the client.
 """
+from __future__ import absolute_import, unicode_literals
+
 from oauthlib.common import log, urlencode
 
 from .base import BaseEndpoint

--- a/oauthlib/oauth1/rfc5849/endpoints/resource.py
+++ b/oauthlib/oauth1/rfc5849/endpoints/resource.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.oauth1.rfc5849.endpoints.resource
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -8,6 +6,8 @@ oauthlib.oauth1.rfc5849.endpoints.resource
 This module is an implementation of the resource protection provider logic of
 OAuth 1.0 RFC 5849.
 """
+from __future__ import absolute_import, unicode_literals
+
 from oauthlib.common import log
 
 from .base import BaseEndpoint

--- a/oauthlib/oauth1/rfc5849/parameters.py
+++ b/oauthlib/oauth1/rfc5849/parameters.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.parameters
 ~~~~~~~~~~~~~~~~~~~
@@ -9,6 +7,7 @@ This module contains methods related to `section 3.5`_ of the OAuth 1.0a spec.
 
 .. _`section 3.5`: http://tools.ietf.org/html/rfc5849#section-3.5
 """
+from __future__ import absolute_import, unicode_literals
 
 try:
     from urlparse import urlparse, urlunparse

--- a/oauthlib/oauth1/rfc5849/request_validator.py
+++ b/oauthlib/oauth1/rfc5849/request_validator.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.oauth1.rfc5849
 ~~~~~~~~~~~~~~
@@ -8,6 +6,7 @@ oauthlib.oauth1.rfc5849
 This module is an implementation of various logic needed
 for signing and checking OAuth 1.0 RFC 5849 requests.
 """
+from __future__ import absolute_import, unicode_literals
 
 from . import SIGNATURE_METHODS, utils
 

--- a/oauthlib/oauth1/rfc5849/signature.py
+++ b/oauthlib/oauth1/rfc5849/signature.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
 """
 oauthlib.oauth1.rfc5849.signature
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -22,6 +21,8 @@ Steps for signing a request:
 
 .. _`section 3.4`: http://tools.ietf.org/html/rfc5849#section-3.4
 """
+from __future__ import absolute_import, unicode_literals
+
 import binascii
 import hashlib
 import hmac

--- a/oauthlib/oauth1/rfc5849/utils.py
+++ b/oauthlib/oauth1/rfc5849/utils.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.utils
 ~~~~~~~~~~~~~~
@@ -8,6 +6,7 @@ oauthlib.utils
 This module contains utility methods used by various parts of the OAuth
 spec.
 """
+from __future__ import absolute_import, unicode_literals
 
 try:
     import urllib2

--- a/oauthlib/oauth2/__init__.py
+++ b/oauthlib/oauth2/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.oauth2
 ~~~~~~~~~~~~~~
@@ -8,6 +6,7 @@ oauthlib.oauth2
 This module is a wrapper for the most recent implementation of OAuth 2.0 Client
 and Server classes.
 """
+from __future__ import absolute_import, unicode_literals
 
 from .rfc6749.clients import Client
 from .rfc6749.clients import WebApplicationClient

--- a/oauthlib/oauth2/rfc6749/__init__.py
+++ b/oauthlib/oauth2/rfc6749/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.oauth2.rfc6749
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -8,6 +6,8 @@ oauthlib.oauth2.rfc6749
 This module is an implementation of various logic needed
 for consuming and providing OAuth 2.0 RFC6749.
 """
+from __future__ import absolute_import, unicode_literals
+
 import functools
 
 from oauthlib.common import log

--- a/oauthlib/oauth2/rfc6749/clients/__init__.py
+++ b/oauthlib/oauth2/rfc6749/clients/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.oauth2.rfc6749
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -8,6 +6,7 @@ oauthlib.oauth2.rfc6749
 This module is an implementation of various logic needed
 for consuming OAuth 2.0 RFC6749.
 """
+from __future__ import absolute_import, unicode_literals
 
 from .base import *
 from .web_application import WebApplicationClient

--- a/oauthlib/oauth2/rfc6749/clients/backend_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/backend_application.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.oauth2.rfc6749
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -8,6 +6,8 @@ oauthlib.oauth2.rfc6749
 This module is an implementation of various logic needed
 for consuming and providing OAuth 2.0 RFC6749.
 """
+from __future__ import absolute_import, unicode_literals
+
 from .base import Client
 from ..parameters import prepare_token_request
 from ..parameters import parse_token_response

--- a/oauthlib/oauth2/rfc6749/clients/base.py
+++ b/oauthlib/oauth2/rfc6749/clients/base.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.oauth2.rfc6749
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -8,6 +6,8 @@ oauthlib.oauth2.rfc6749
 This module is an implementation of various logic needed
 for consuming OAuth 2.0 RFC6749.
 """
+from __future__ import absolute_import, unicode_literals
+
 import time
 
 from oauthlib.oauth2.rfc6749 import tokens

--- a/oauthlib/oauth2/rfc6749/clients/legacy_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/legacy_application.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.oauth2.rfc6749
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -8,6 +6,8 @@ oauthlib.oauth2.rfc6749
 This module is an implementation of various logic needed
 for consuming and providing OAuth 2.0 RFC6749.
 """
+from __future__ import absolute_import, unicode_literals
+
 from .base import Client
 from ..parameters import prepare_token_request
 from ..parameters import parse_token_response

--- a/oauthlib/oauth2/rfc6749/clients/mobile_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/mobile_application.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.oauth2.rfc6749
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -8,6 +6,8 @@ oauthlib.oauth2.rfc6749
 This module is an implementation of various logic needed
 for consuming and providing OAuth 2.0 RFC6749.
 """
+from __future__ import absolute_import, unicode_literals
+
 from .base import Client
 from ..parameters import prepare_grant_uri
 from ..parameters import parse_implicit_response

--- a/oauthlib/oauth2/rfc6749/clients/web_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/web_application.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.oauth2.rfc6749
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -8,6 +6,8 @@ oauthlib.oauth2.rfc6749
 This module is an implementation of various logic needed
 for consuming and providing OAuth 2.0 RFC6749.
 """
+from __future__ import absolute_import, unicode_literals
+
 from .base import Client
 from ..parameters import prepare_grant_uri, prepare_token_request
 from ..parameters import parse_authorization_code_response

--- a/oauthlib/oauth2/rfc6749/endpoints/__init__.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.oauth2.rfc6749
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -8,6 +6,7 @@ oauthlib.oauth2.rfc6749
 This module is an implementation of various logic needed
 for consuming and providing OAuth 2.0 RFC6749.
 """
+from __future__ import absolute_import, unicode_literals
 
 from .authorization import AuthorizationEndpoint
 from .token import TokenEndpoint

--- a/oauthlib/oauth2/rfc6749/endpoints/authorization.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/authorization.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.oauth2.rfc6749
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -8,6 +6,7 @@ oauthlib.oauth2.rfc6749
 This module is an implementation of various logic needed
 for consuming and providing OAuth 2.0 RFC6749.
 """
+from __future__ import absolute_import, unicode_literals
 
 from oauthlib.common import Request, log
 

--- a/oauthlib/oauth2/rfc6749/endpoints/base.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/base.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.oauth2.rfc6749
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -8,6 +6,8 @@ oauthlib.oauth2.rfc6749
 This module is an implementation of various logic needed
 for consuming and providing OAuth 2.0 RFC6749.
 """
+from __future__ import absolute_import, unicode_literals
+
 import functools
 
 from oauthlib.common import log

--- a/oauthlib/oauth2/rfc6749/endpoints/pre_configured.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/pre_configured.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.oauth2.rfc6749
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -8,6 +6,8 @@ oauthlib.oauth2.rfc6749
 This module is an implementation of various logic needed
 for consuming and providing OAuth 2.0 RFC6749.
 """
+from __future__ import absolute_import, unicode_literals
+
 from ..tokens import BearerToken
 from ..grant_types import AuthorizationCodeGrant
 from ..grant_types import ImplicitGrant

--- a/oauthlib/oauth2/rfc6749/endpoints/resource.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/resource.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.oauth2.rfc6749
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -8,6 +6,8 @@ oauthlib.oauth2.rfc6749
 This module is an implementation of various logic needed
 for consuming and providing OAuth 2.0 RFC6749.
 """
+from __future__ import absolute_import, unicode_literals
+
 from oauthlib.common import Request, log
 
 from .base import BaseEndpoint, catch_errors_and_unavailability

--- a/oauthlib/oauth2/rfc6749/endpoints/revocation.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/revocation.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.oauth2.rfc6749.endpoint.revocation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -9,6 +7,7 @@ An implementation of the OAuth 2 `Token Revocation`_ spec (draft 11).
 
 .. _`Token Revocation`: http://tools.ietf.org/html/draft-ietf-oauth-revocation-11
 """
+from __future__ import absolute_import, unicode_literals
 
 from oauthlib.common import Request, log
 

--- a/oauthlib/oauth2/rfc6749/endpoints/token.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/token.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.oauth2.rfc6749
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -8,6 +6,8 @@ oauthlib.oauth2.rfc6749
 This module is an implementation of various logic needed
 for consuming and providing OAuth 2.0 RFC6749.
 """
+from __future__ import absolute_import, unicode_literals
+
 from oauthlib.common import Request, log
 
 from .base import BaseEndpoint, catch_errors_and_unavailability

--- a/oauthlib/oauth2/rfc6749/parameters.py
+++ b/oauthlib/oauth2/rfc6749/parameters.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.oauth2.rfc6749.parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -9,6 +7,7 @@ This module contains methods related to `Section 4`_ of the OAuth 2 RFC.
 
 .. _`Section 4`: http://tools.ietf.org/html/rfc6749#section-4
 """
+from __future__ import absolute_import, unicode_literals
 
 import json
 import time

--- a/oauthlib/oauth2/rfc6749/tokens.py
+++ b/oauthlib/oauth2/rfc6749/tokens.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, unicode_literals
 """
 oauthlib.oauth2.rfc6749.tokens
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -9,6 +8,8 @@ This module contains methods for adding two types of access tokens to requests.
 - MAC http://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-01
 
 """
+from __future__ import absolute_import, unicode_literals
+
 from binascii import b2a_base64
 import hashlib
 import hmac

--- a/oauthlib/oauth2/rfc6749/utils.py
+++ b/oauthlib/oauth2/rfc6749/utils.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-
 """
 oauthlib.utils
 ~~~~~~~~~~~~~~
 
 This module contains utility methods used by various parts of the OAuth 2 spec.
 """
+from __future__ import absolute_import, unicode_literals
 
 import os
 import datetime

--- a/oauthlib/uri_validate.py
+++ b/oauthlib/uri_validate.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-import re
 """
 Regex for URIs
 
@@ -10,6 +8,8 @@ They should be processed with re.VERBOSE.
 
 Thanks Mark Nottingham for this code - https://gist.github.com/138549
 """
+from __future__ import unicode_literals
+import re
 
 ### basics
 


### PR DESCRIPTION
Docstrings are considered as such by python only if they are the first
statement in the file/block.  Even if they are preceded by a
`from __future__` import they are interpreted as just a string.
