### PR TITLE
Use 401 status code for some OAuth 2 errors

### DIFF
--- a/oauthlib/oauth2/rfc6749/errors.py
+++ b/oauthlib/oauth2/rfc6749/errors.py
@@ -13,8 +13,9 @@ from oauthlib.common import urlencode, add_params_to_uri
 
 class OAuth2Error(Exception):
     error = None
+    status_code = 400
 
-    def __init__(self, description=None, uri=None, state=None, status_code=400,
+    def __init__(self, description=None, uri=None, state=None, status_code=None,
                  request=None):
         """
         description:    A human-readable ASCII [USASCII] text providing
@@ -38,7 +39,9 @@ class OAuth2Error(Exception):
         self.description = description
         self.uri = uri
         self.state = state
-        self.status_code = status_code
+
+        if status_code:
+            self.status_code = status_code
 
         if request:
             self.redirect_uri = request.redirect_uri
@@ -141,6 +144,7 @@ class InvalidRequestError(OAuth2Error):
 class AccessDeniedError(OAuth2Error):
     """The resource owner or authorization server denied the request."""
     error = 'access_denied'
+    status_code = 401
 
 
 class UnsupportedResponseTypeError(OAuth2Error):
@@ -153,6 +157,7 @@ class UnsupportedResponseTypeError(OAuth2Error):
 class InvalidScopeError(OAuth2Error):
     """The requested scope is invalid, unknown, or malformed."""
     error = 'invalid_scope'
+    status_code = 401
 
 
 class ServerError(OAuth2Error):
@@ -185,6 +190,7 @@ class InvalidClientError(OAuth2Error):
     client.
     """
     error = 'invalid_client'
+    status_code = 401
 
 
 class InvalidGrantError(OAuth2Error):
@@ -194,6 +200,7 @@ class InvalidGrantError(OAuth2Error):
     issued to another client.
     """
     error = 'invalid_grant'
+    status_code = 401
 
 
 class UnauthorizedClientError(OAuth2Error):
@@ -201,6 +208,7 @@ class UnauthorizedClientError(OAuth2Error):
     grant type.
     """
     error = 'unauthorized_client'
+    status_code = 401
 
 
 class UnsupportedGrantTypeError(OAuth2Error):

--- a/oauthlib/oauth2/rfc6749/grant_types/refresh_token.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/refresh_token.py
@@ -83,7 +83,7 @@ class RefreshTokenGrant(GrantTypeBase):
             log.debug('Authenticating client, %r.', request)
             if not self.request_validator.authenticate_client(request):
                 log.debug('Invalid client (%r), denying access.', request)
-                raise errors.InvalidClientError(request=request, status_code=401)
+                raise errors.InvalidClientError(request=request)
         elif not self.request_validator.authenticate_client_id(request.client_id, request):
             log.debug('Client authentication failed, %r.', request)
             raise errors.InvalidClientError(request=request)
@@ -112,6 +112,6 @@ class RefreshTokenGrant(GrantTypeBase):
                 log.debug('Refresh token %s lack requested scopes, %r.',
                         request.refresh_token, request.scopes)
                 raise errors.InvalidScopeError(
-                        state=request.state, request=request, status_code=401)
+                        state=request.state, request=request)
         else:
             request.scopes = original_scopes

--- a/tests/oauth2/rfc6749/grant_types/test_refresh_token.py
+++ b/tests/oauth2/rfc6749/grant_types/test_refresh_token.py
@@ -76,7 +76,7 @@ class RefreshTokenGrantTest(TestCase):
                 self.request, bearer)
         token = json.loads(body)
         self.assertEqual(token['error'], 'invalid_grant')
-        self.assertEqual(status_code, 400)
+        self.assertEqual(status_code, 401)
 
     def test_invalid_client(self):
         self.mock_validator.authenticate_client.return_value = False

--- a/tests/oauth2/rfc6749/grant_types/test_resource_owner_password.py
+++ b/tests/oauth2/rfc6749/grant_types/test_resource_owner_password.py
@@ -45,12 +45,12 @@ class ResourceOwnerPasswordCredentialsGrantTest(TestCase):
         self.mock_validator.validate_user.return_value = True
         self.mock_validator.authenticate_client.return_value = False
         status_code = self.auth.create_token_response(self.request, bearer)[2]
-        self.assertEqual(status_code, 400)
+        self.assertEqual(status_code, 401)
         # mock client_authentication_required() returning False then fail
         self.mock_validator.client_authentication_required.return_value = False
         self.mock_validator.authenticate_client_id.return_value = False
         status_code = self.auth.create_token_response(self.request, bearer)[2]
-        self.assertEqual(status_code, 400)
+        self.assertEqual(status_code, 401)
 
     def test_error_response(self):
         pass


### PR DESCRIPTION
Errors related to failed authentication or related denied access should IMO default to 401 status code. The OAuth 2 spec (see §5.2) only explicitly specifies that the invalid_client error may (and actually MUST when using the "Authorization" header) return a 401 status code, while it currently returns 400 in oauthlib. This changes that default.

Depending on how strict interpretation of the spec you want to follow, I also suggest using the 401 status code for some other errors, which I find is much more relevant for clients (in fact, some clients seem to expect 401 for API calls related to authorization). You already did use the 401 status code for the invalid_scope error, which is technically supposed to use a 400 status code according to the spec, so.... :)
