### PR TITLE
Allow unescaped @ in urlencoded parameters

### DIFF
--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -119,7 +119,7 @@ def decode_params_utf8(params):
     return decoded
 
 
-urlencoded = set(always_safe) | set('=&;%+~,*')
+urlencoded = set(always_safe) | set('=&;%+~,*@')
 
 
 def urldecode(query):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -41,6 +41,7 @@ class EncodingTest(TestCase):
                               [('foo_ ~', '.bar-')])
         self.assertItemsEqual(urldecode('foo=1,2,3'), [('foo', '1,2,3')])
         self.assertItemsEqual(urldecode('foo=bar.*'), [('foo', 'bar.*')])
+        self.assertItemsEqual(urldecode('foo=bar@spam'), [('foo', 'bar@spam')])
         self.assertRaises(ValueError, urldecode, 'foo bar')
         self.assertRaises(ValueError, urldecode, '?')
         self.assertRaises(ValueError, urldecode, '%R')


### PR DESCRIPTION
At least Internet Explorer does not url encode the `@` symbol, such as
when in an email address, in it's form uploading from HTML. Since the `@`
symbol doesn't have any special meaning in the querystring of a URL, not
encoding it shouldn't present any problems. Thus, we should add `@` to the
list of allowed characters in form urlencoded data.
