### PR TITLE
Use warnings.warn() to warn for scope change

### DIFF
--- a/oauthlib/oauth2/rfc6749/parameters.py
+++ b/oauthlib/oauth2/rfc6749/parameters.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import, unicode_literals
 
 import json
 import time
+import warnings
 try:
     import urlparse
 except ImportError:
@@ -322,9 +323,7 @@ def validate_token_parameters(params, scope=None):
     new_scope = params.get('scope', None)
     scope = scope_to_list(scope)
     if scope and new_scope and set(scope) != set(new_scope):
-        w = Warning("Scope has changed from {old} to {new}.".format(
+        msg = "Scope has changed from {old} to {new}.".format(
             old=scope, new=new_scope,
-        ))
-        w.old_scope = scope
-        w.new_scope = new_scope
-        raise w
+        )
+        warnings.warn(msg)


### PR DESCRIPTION
Similar to #269, but drops the envvar
