### PR TITLE
Dispatch a blinker signal on scope change, instead of raising a warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors unittest2; fi
-  - pip install nose pycrypto mock pyjwt
+  - pip install nose pycrypto mock pyjwt blinker
 
 script:
   - nosetests -w tests

--- a/AUTHORS
+++ b/AUTHORS
@@ -21,3 +21,4 @@ Kyle Valade
 Tyler Jones (squirly)
 Massimiliano Pippi
 Josh Turmel
+David Baumgold

--- a/oauthlib/oauth2/rfc6749/clients/backend_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/backend_application.py
@@ -72,7 +72,7 @@ class BackendApplicationClient(Client):
         :param body: The response body from the token request.
         :param scope: Scopes originally requested.
         :return: Dictionary of token parameters.
-        :raises: Warning if scope has changed. OAuth2Error if response is invalid.
+        :raises: OAuth2Error if response is invalid.
 
         These response are json encoded and could easily be parsed without
         the assistance of OAuthLib. However, there are a few subtle issues
@@ -123,18 +123,19 @@ class BackendApplicationClient(Client):
                     'scope': ['hello', 'world'],    # note the list
             }
 
-        If there was a scope change you will be notified with a warning::
+        If there was a scope change, a "scope changed" signal will be dispatched
+        using the `blinker`_ library, if installed. (If blinker is not installed,
+        there will be no notification on scope change.) To be automatically
+        notified when the returned scope is different from the requested scope,
+        simply connect a function to the ``oauthlib.signals.scope_changed``
+        dispatcher::
 
+            >>> def alert_scope_changed(message, old, new):
+            ...     print(message, old, new)
+            ...
+            >>> oauthlib.signals.scope_changed.connect(alert_scope_changed)
             >>> client.parse_request_body_response(response_body, scope=['images'])
-            Traceback (most recent call last):
-                File "<stdin>", line 1, in <module>
-                File "oauthlib/oauth2/rfc6749/__init__.py", line 421, in parse_request_body_response
-                    .. _`Section 5.2`: http://tools.ietf.org/html/rfc6749#section-5.2
-                File "oauthlib/oauth2/rfc6749/parameters.py", line 263, in parse_token_response
-                    validate_token_parameters(params, scope)
-                File "oauthlib/oauth2/rfc6749/parameters.py", line 285, in validate_token_parameters
-                    raise Warning("Scope has changed to %s." % new_scope)
-            Warning: Scope has changed to [u'hello', u'world'].
+            ('Scope has changed from "images" to "hello world".', ['images'], ['hello', 'world'])
 
         If there was an error on the providers side you will be notified with
         an error. For example, if there was no ``token_type`` provided::
@@ -153,6 +154,7 @@ class BackendApplicationClient(Client):
         .. _`Section 5.1`: http://tools.ietf.org/html/rfc6749#section-5.1
         .. _`Section 5.2`: http://tools.ietf.org/html/rfc6749#section-5.2
         .. _`Section 7.1`: http://tools.ietf.org/html/rfc6749#section-7.1
+        .. _`blinker`: http://pythonhosted.org/blinker/
         """
         self.token = parse_token_response(body, scope=scope)
         self._populate_attributes(self.token)

--- a/oauthlib/oauth2/rfc6749/clients/legacy_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/legacy_application.py
@@ -84,7 +84,7 @@ class LegacyApplicationClient(Client):
         :param body: The response body from the token request.
         :param scope: Scopes originally requested.
         :return: Dictionary of token parameters.
-        :raises: Warning if scope has changed. OAuth2Error if response is invalid.
+        :raises: OAuth2Error if response is invalid.
 
         These response are json encoded and could easily be parsed without
         the assistance of OAuthLib. However, there are a few subtle issues
@@ -135,18 +135,19 @@ class LegacyApplicationClient(Client):
                     'scope': ['hello', 'world'],    # note the list
             }
 
-        If there was a scope change you will be notified with a warning::
+        If there was a scope change, a "scope changed" signal will be dispatched
+        using the `blinker`_ library, if installed. (If blinker is not installed,
+        there will be no notification on scope change.) To be automatically
+        notified when the returned scope is different from the requested scope,
+        simply connect a function to the ``oauthlib.signals.scope_changed``
+        dispatcher::
 
+            >>> def alert_scope_changed(message, old, new):
+            ...     print(message, old, new)
+            ...
+            >>> oauthlib.signals.scope_changed.connect(alert_scope_changed)
             >>> client.parse_request_body_response(response_body, scope=['images'])
-            Traceback (most recent call last):
-                File "<stdin>", line 1, in <module>
-                File "oauthlib/oauth2/rfc6749/__init__.py", line 421, in parse_request_body_response
-                    .. _`Section 5.2`: http://tools.ietf.org/html/rfc6749#section-5.2
-                File "oauthlib/oauth2/rfc6749/parameters.py", line 263, in parse_token_response
-                    validate_token_parameters(params, scope)
-                File "oauthlib/oauth2/rfc6749/parameters.py", line 285, in validate_token_parameters
-                    raise Warning("Scope has changed to %s." % new_scope)
-            Warning: Scope has changed to [u'hello', u'world'].
+            ('Scope has changed from "images" to "hello world".', ['images'], ['hello', 'world'])
 
         If there was an error on the providers side you will be notified with
         an error. For example, if there was no ``token_type`` provided::
@@ -165,6 +166,7 @@ class LegacyApplicationClient(Client):
         .. _`Section 5.1`: http://tools.ietf.org/html/rfc6749#section-5.1
         .. _`Section 5.2`: http://tools.ietf.org/html/rfc6749#section-5.2
         .. _`Section 7.1`: http://tools.ietf.org/html/rfc6749#section-7.1
+        .. _`blinker`: http://pythonhosted.org/blinker/
         """
         self.token = parse_token_response(body, scope=scope)
         self._populate_attributes(self.token)

--- a/oauthlib/oauth2/rfc6749/clients/mobile_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/mobile_application.py
@@ -108,7 +108,7 @@ class MobileApplicationClient(Client):
         :param state: The state provided in the authorization request.
         :param scope: The scopes provided in the authorization request.
         :return: Dictionary of token parameters.
-        :raises: Warning if scope has changed. OAuth2Error if response is invalid.
+        :raises: OAuth2Error if response is invalid.
 
         A successful response should always contain
 
@@ -158,16 +158,12 @@ class MobileApplicationClient(Client):
                 File "oauthlib/oauth2/rfc6749/parameters.py", line 197, in parse_implicit_response
                     raise ValueError("Mismatching or missing state in params.")
             ValueError: Mismatching or missing state in params.
-            >>> client.parse_request_uri_response(response_uri, scope=['other'])
-            Traceback (most recent call last):
-                File "<stdin>", line 1, in <module>
-                File "oauthlib/oauth2/rfc6749/__init__.py", line 598, in parse_request_uri_response
-                    **scope**
-                File "oauthlib/oauth2/rfc6749/parameters.py", line 199, in parse_implicit_response
-                    validate_token_parameters(params, scope)
-                File "oauthlib/oauth2/rfc6749/parameters.py", line 285, in validate_token_parameters
-                    raise Warning("Scope has changed to %s." % new_scope)
-            Warning: Scope has changed to [u'hello', u'world'].
+            >>> def alert_scope_changed(message, old, new):
+            ...     print(message, old, new)
+            ...
+            >>> oauthlib.signals.scope_changed.connect(alert_scope_changed)
+            >>> client.parse_request_body_response(response_body, scope=['other'])
+            ('Scope has changed from "other" to "hello world".', ['other'], ['hello', 'world'])
 
         .. _`Section 7.1`: http://tools.ietf.org/html/rfc6749#section-7.1
         .. _`Section 3.3`: http://tools.ietf.org/html/rfc6749#section-3.3

--- a/oauthlib/signals.py
+++ b/oauthlib/signals.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""
+    Implements signals based on blinker if available, otherwise
+    falls silently back to a noop. Shamelessly stolen from flask.signals:
+    https://github.com/mitsuhiko/flask/blob/master/flask/signals.py
+"""
+signals_available = False
+try:
+    from blinker import Namespace
+    signals_available = True
+except ImportError:
+    class Namespace(object):
+        def signal(self, name, doc=None):
+            return _FakeSignal(name, doc)
+
+    class _FakeSignal(object):
+        """If blinker is unavailable, create a fake class with the same
+        interface that allows sending of signals but will fail with an
+        error on anything else.  Instead of doing anything on send, it
+        will just ignore the arguments and do nothing instead.
+        """
+
+        def __init__(self, name, doc=None):
+            self.name = name
+            self.__doc__ = doc
+        def _fail(self, *args, **kwargs):
+            raise RuntimeError('signalling support is unavailable '
+                               'because the blinker library is '
+                               'not installed.')
+        send = lambda *a, **kw: None
+        connect = disconnect = has_receivers_for = receivers_for = \
+            temporarily_connected_to = connected_to = _fail
+        del _fail
+
+# The namespace for code signals.  If you are not oauthlib code, do
+# not put signals in here.  Create your own namespace instead.
+_signals = Namespace()
+
+
+# Core signals.
+scope_changed = _signals.signal('scope-changed')

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,12 @@ def fread(fn):
         return f.read()
 
 if sys.version_info[0] == 3:
-    tests_require = ['nose', 'pycrypto', 'pyjwt']
+    tests_require = ['nose', 'pycrypto', 'pyjwt', 'blinker']
 else:
-    tests_require = ['nose', 'unittest2', 'pycrypto', 'mock', 'pyjwt']
+    tests_require = ['nose', 'unittest2', 'pycrypto', 'mock', 'pyjwt', 'blinker']
 rsa_require = ['pycrypto']
 signedtoken_require = ['pycrypto', 'pyjwt']
+signals_require = ['blinker']
 
 requires = []
 
@@ -41,7 +42,12 @@ setup(
     packages=find_packages(exclude=('docs', 'tests', 'tests.*')),
     test_suite='nose.collector',
     tests_require=tests_require,
-    extras_require={'test': tests_require, 'rsa': rsa_require, 'signedtoken': signedtoken_require},
+    extras_require={
+        'test': tests_require,
+        'rsa': rsa_require,
+        'signedtoken': signedtoken_require,
+        'signals': signals_require,
+    },
     install_requires=requires,
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/tests/oauth2/rfc6749/clients/test_backend_application.py
+++ b/tests/oauth2/rfc6749/clients/test_backend_application.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, unicode_literals
 from mock import patch
 
 from oauthlib.oauth2 import BackendApplicationClient
+from oauthlib import signals
 
 from ....unittest import TestCase
 
@@ -63,4 +64,17 @@ class BackendApplicationClientTest(TestCase):
         self.assertEqual(client.token_type, response.get("token_type"))
 
         # Mismatching state
-        self.assertRaises(Warning, client.parse_request_body_response, self.token_json, scope="invalid")
+        scope_changes_recorded = []
+        def record_scope_change(sender, message, old, new):
+            scope_changes_recorded.append((message, old, new))
+
+        signals.scope_changed.connect(record_scope_change)
+        try:
+            client.parse_request_body_response(self.token_json, scope="invalid")
+            self.assertEqual(len(scope_changes_recorded), 1)
+            message, old, new = scope_changes_recorded[0]
+            self.assertEqual(message, 'Scope has changed from "invalid" to "/profile".')
+            self.assertEqual(old, ['invalid'])
+            self.assertEqual(new, ['/profile'])
+        finally:
+            signals.scope_changed.disconnect(record_scope_change)

--- a/tests/oauth2/rfc6749/clients/test_legacy_application.py
+++ b/tests/oauth2/rfc6749/clients/test_legacy_application.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 
 from mock import patch
 
+from oauthlib import signals
 from oauthlib.oauth2 import LegacyApplicationClient
 
 from ....unittest import TestCase
@@ -65,4 +66,17 @@ class LegacyApplicationClientTest(TestCase):
         self.assertEqual(client.token_type, response.get("token_type"))
 
         # Mismatching state
-        self.assertRaises(Warning, client.parse_request_body_response, self.token_json, scope="invalid")
+        scope_changes_recorded = []
+        def record_scope_change(sender, message, old, new):
+            scope_changes_recorded.append((message, old, new))
+
+        signals.scope_changed.connect(record_scope_change)
+        try:
+            client.parse_request_body_response(self.token_json, scope="invalid")
+            self.assertEqual(len(scope_changes_recorded), 1)
+            message, old, new = scope_changes_recorded[0]
+            self.assertEqual(message, 'Scope has changed from "invalid" to "/profile".')
+            self.assertEqual(old, ['invalid'])
+            self.assertEqual(new, ['/profile'])
+        finally:
+            signals.scope_changed.disconnect(record_scope_change)


### PR DESCRIPTION
Followup to #265. Note that this does break backwards compatibility, so we should think carefully about making this change -- and if we decide to move forward with it, we should increment at least the minor version, and possibly the major version (1.0!).
