### PR TITLE
fix add_params_to_uri() fragment bug

### DIFF
--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -281,7 +281,7 @@ def add_params_to_uri(uri, params, fragment=False):
     """Add a list of two-tuples to the uri query components."""
     sch, net, path, par, query, fra = urlparse.urlparse(uri)
     if fragment:
-        fra = add_params_to_qs(query, params)
+        fra = add_params_to_qs(fra, params)
     else:
         query = add_params_to_qs(query, params)
     return urlparse.urlunparse((sch, net, path, par, query, fra))


### PR DESCRIPTION
add_params_to_uri() ovewrites existing fragment when fragment parameter = true
