### PR TITLE
updated token endpoint documentation to reflect current behavior

### DIFF
--- a/docs/oauth2/endpoints/token.rst
+++ b/docs/oauth2/endpoints/token.rst
@@ -63,10 +63,7 @@ tokens which unless you are certain you need them, are a bad idea.
             'access_token': 'sldafh309sdf',
             'refresh_token': 'alsounguessablerandomstring',
             'expires_in': 3600,
-            'scopes': [
-                'https://example.com/userProfile',
-                'https://example.com/pictures'
-            ],
+            'scope': 'https://example.com/userProfile https://example.com/pictures',
             'token_type': 'Bearer'
         }
         # body will contain an error code and possibly an error description if


### PR DESCRIPTION
fixes #284
The token contains a string with the scopes separated by spaces with key 'scope' instead of a list of string with key 'scopes'
I think is the only place where the documentation is wrong, let me know if further changes are needed.
