### PR TITLE
Openid connect jwt

### DIFF
--- a/oauthlib/oauth2/rfc6749/endpoints/pre_configured.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/pre_configured.py
@@ -16,7 +16,7 @@ from ..grant_types import (AuthCodeGrantDispatcher, AuthorizationCodeGrant,
                            OpenIDConnectHybrid,
                            RefreshTokenGrant,
                            ResourceOwnerPasswordCredentialsGrant)
-from ..tokens import BearerToken
+from ..tokens import BearerToken, JWTToken
 from .authorization import AuthorizationEndpoint
 from .resource import ResourceEndpoint
 from .revocation import RevocationEndpoint
@@ -57,6 +57,9 @@ class Server(AuthorizationEndpoint, TokenEndpoint, ResourceEndpoint,
         bearer = BearerToken(request_validator, token_generator,
                              token_expires_in, refresh_token_generator)
 
+        jwt = JWTToken(request_validator, token_generator,
+                       token_expires_in, refresh_token_generator)
+
         auth_grant_choice = AuthCodeGrantDispatcher(default_auth_grant=auth_grant, oidc_auth_grant=openid_connect_auth)
         implicit_grant_choice = ImplicitTokenGrantDispatcher(default_implicit_grant=implicit_grant, oidc_implicit_grant=openid_connect_implicit)
 
@@ -86,7 +89,7 @@ class Server(AuthorizationEndpoint, TokenEndpoint, ResourceEndpoint,
                                },
                                default_token_type=bearer)
         ResourceEndpoint.__init__(self, default_token='Bearer',
-                                  token_types={'Bearer': bearer})
+                                  token_types={'Bearer': bearer, 'JWT': jwt})
         RevocationEndpoint.__init__(self, request_validator)
 
 

--- a/oauthlib/oauth2/rfc6749/endpoints/resource.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/resource.py
@@ -83,5 +83,5 @@ class ResourceEndpoint(BaseEndpoint):
         to give an estimation based on the request.
         """
         estimates = sorted(((t.estimate_type(request), n)
-                            for n, t in self.tokens.items()))
+                            for n, t in self.tokens.items()), reverse=True)
         return estimates[0][1] if len(estimates) else None

--- a/oauthlib/oauth2/rfc6749/request_validator.py
+++ b/oauthlib/oauth2/rfc6749/request_validator.py
@@ -312,8 +312,24 @@ class RequestValidator(object):
         """
         raise NotImplementedError('Subclasses must implement this method.')
 
-    def get_id_token(self, token, token_handler, request):
+    def get_jwt_bearer_token(self, token, token_handler, request):
+        """Get JWT Bearer token or OpenID Connect ID token
+
+        If using OpenID Connect this SHOULD call `oauthlib.oauth2.RequestValidator.get_id_token`
+
+        :param token: A Bearer token dict
+        :param token_handler: the token handler (BearerToken class)
+        :param request: the HTTP Request (oauthlib.common.Request)
+        :return: The JWT Bearer token or OpenID Connect ID token (a JWS signed JWT)
+
+        Method is used by JWT Bearer and OpenID Connect tokens:
+            - JWTToken.create_token
         """
+        raise NotImplementedError('Subclasses must implement this method.')
+
+    def get_id_token(self, token, token_handler, request):
+        """Get OpenID Connect ID token
+
         In the OpenID Connect workflows when an ID Token is requested this method is called.
         Subclasses should implement the construction, signing and optional encryption of the
         ID Token as described in the OpenID Connect spec.
@@ -344,12 +360,31 @@ class RequestValidator(object):
         # the request.scope should be used by the get_id_token() method to determine which claims to include in the resulting id_token
         raise NotImplementedError('Subclasses must implement this method.')
 
+    def validate_jwt_bearer_token(self, token, scopes, request):
+        """Ensure the JWT Bearer token or OpenID Connect ID token are valids and authorized access to scopes.
+
+        If using OpenID Connect this SHOULD call `oauthlib.oauth2.RequestValidator.get_id_token`
+
+        OpenID connect core 1.0 describe how to validate an id_token:
+            - http://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation
+            - http://openid.net/specs/openid-connect-core-1_0.html#ImplicitIDTValidation
+            - http://openid.net/specs/openid-connect-core-1_0.html#HybridIDTValidation
+            - http://openid.net/specs/openid-connect-core-1_0.html#HybridIDTValidation2
+
+        :param token: Unicode Bearer token
+        :param scopes: List of scopes (defined by you)
+        :param request: The HTTP Request (oauthlib.common.Request)
+        :rtype: True or False
+
+        Method is indirectly used by all core OpenID connect JWT token issuing grant types:
+            - Authorization Code Grant
+            - Implicit Grant
+            - Hybrid Grant
+        """
+        raise NotImplementedError('Subclasses must implement this method.')
+
     def validate_id_token(self, token, scopes, request):
         """Ensure the id token is valid and authorized access to scopes.
-
-        :param token: A string of JWT serialized.
-        :param scopes: A list of scopes associated with the protected resource.
-        :param request: The HTTP Request (oauthlib.common.Request)
 
         OpenID connect core 1.0 describe how to validate an id_token:
             - http://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation

--- a/oauthlib/oauth2/rfc6749/request_validator.py
+++ b/oauthlib/oauth2/rfc6749/request_validator.py
@@ -365,6 +365,8 @@ class RequestValidator(object):
 
         If using OpenID Connect this SHOULD call `oauthlib.oauth2.RequestValidator.get_id_token`
 
+        If not using OpenID Connect this can `return None` to avoid 5xx rather 401/3 response.
+
         OpenID connect core 1.0 describe how to validate an id_token:
             - http://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation
             - http://openid.net/specs/openid-connect-core-1_0.html#ImplicitIDTValidation

--- a/oauthlib/oauth2/rfc6749/request_validator.py
+++ b/oauthlib/oauth2/rfc6749/request_validator.py
@@ -344,6 +344,31 @@ class RequestValidator(object):
         # the request.scope should be used by the get_id_token() method to determine which claims to include in the resulting id_token
         raise NotImplementedError('Subclasses must implement this method.')
 
+    def validate_id_token(self, token, scopes, request):
+        """Ensure the id token is valid and authorized access to scopes.
+
+        :param token: A string of JWT serialized.
+        :param scopes: A list of scopes associated with the protected resource.
+        :param request: The HTTP Request (oauthlib.common.Request)
+
+        OpenID connect core 1.0 describe how to validate an id_token:
+            - http://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation
+            - http://openid.net/specs/openid-connect-core-1_0.html#ImplicitIDTValidation
+            - http://openid.net/specs/openid-connect-core-1_0.html#HybridIDTValidation
+            - http://openid.net/specs/openid-connect-core-1_0.html#HybridIDTValidation2
+
+        :param token: Unicode Bearer token
+        :param scopes: List of scopes (defined by you)
+        :param request: The HTTP Request (oauthlib.common.Request)
+        :rtype: True or False
+
+        Method is indirectly used by all core OpenID connect JWT token issuing grant types:
+            - Authorization Code Grant
+            - Implicit Grant
+            - Hybrid Grant
+        """
+        raise NotImplementedError('Subclasses must implement this method.')
+
     def validate_bearer_token(self, token, scopes, request):
         """Ensure the Bearer token is valid and authorized access to scopes.
 

--- a/oauthlib/oauth2/rfc6749/tokens.py
+++ b/oauthlib/oauth2/rfc6749/tokens.py
@@ -328,7 +328,7 @@ class JWTToken(TokenBase):
 
         request.expires_in = expires_in
 
-        return self.request_validator.get_id_token(None, None, request)
+        return self.request_validator.get_jwt_bearer_token(None, None, request)
 
     def validate_request(self, request):
         token = None
@@ -336,7 +336,7 @@ class JWTToken(TokenBase):
             token = request.headers.get('Authorization')[7:]
         else:
             token = request.access_token
-        return self.request_validator.validate_id_token(
+        return self.request_validator.validate_jwt_bearer_token(
             token, request.scopes, request)
 
     def estimate_type(self, request):

--- a/oauthlib/oauth2/rfc6749/tokens.py
+++ b/oauthlib/oauth2/rfc6749/tokens.py
@@ -341,7 +341,7 @@ class JWTToken(TokenBase):
 
     def estimate_type(self, request):
         token = request.headers.get('Authorization', '')[7:]
-        if token.count('.') in (2, 4):
+        if token.startswith('ey') and token.count('.') in (2, 4):
             return 10
         else:
             return 0

--- a/oauthlib/oauth2/rfc6749/tokens.py
+++ b/oauthlib/oauth2/rfc6749/tokens.py
@@ -24,8 +24,6 @@ except ImportError:
     from urllib.parse import urlparse
 
 
-
-
 class OAuth2Token(dict):
 
     def __init__(self, params, old_scope=None):
@@ -301,5 +299,49 @@ class BearerToken(TokenBase):
             return 9
         elif request.access_token is not None:
             return 5
+        else:
+            return 0
+
+
+class JWTToken(TokenBase):
+    __slots__ = (
+        'request_validator', 'token_generator',
+        'refresh_token_generator', 'expires_in'
+    )
+
+    def __init__(self, request_validator=None, token_generator=None,
+                 expires_in=None, refresh_token_generator=None):
+        self.request_validator = request_validator
+        self.token_generator = token_generator or random_token_generator
+        self.refresh_token_generator = (
+            refresh_token_generator or self.token_generator
+        )
+        self.expires_in = expires_in or 3600
+
+    def create_token(self, request, refresh_token=False, save_token=False):
+        """Create a JWT Token, using requestvalidator method."""
+
+        if callable(self.expires_in):
+            expires_in = self.expires_in(request)
+        else:
+            expires_in = self.expires_in
+
+        request.expires_in = expires_in
+
+        return self.request_validator.get_id_token(None, None, request)
+
+    def validate_request(self, request):
+        token = None
+        if 'Authorization' in request.headers:
+            token = request.headers.get('Authorization')[7:]
+        else:
+            token = request.access_token
+        return self.request_validator.validate_id_token(
+            token, request.scopes, request)
+
+    def estimate_type(self, request):
+        token = request.headers.get('Authorization', '')[7:]
+        if token.count('.') in (2, 4):
+            return 10
         else:
             return 0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 coverage>=3.7.1
 nose==1.3.7
-mock==1.0.1
+mock>=2.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def fread(fn):
 if sys.version_info[0] == 3:
     tests_require = ['nose', 'cryptography', 'pyjwt>=1.0.0', 'blinker']
 else:
-    tests_require = ['nose', 'unittest2', 'cryptography', 'mock', 'pyjwt>=1.0.0', 'blinker']
+    tests_require = ['nose', 'unittest2', 'cryptography', 'mock>=2.0', 'pyjwt>=1.0.0', 'blinker']
 rsa_require = ['cryptography']
 signedtoken_require = ['cryptography', 'pyjwt>=1.0.0']
 signals_require = ['blinker']

--- a/tests/oauth2/rfc6749/test_tokens.py
+++ b/tests/oauth2/rfc6749/test_tokens.py
@@ -127,7 +127,7 @@ class JWTTokenTestCase(TestCase):
             token = JWTToken(expires_in=mock.MagicMock(), request_validator=request_validator)
             token.create_token(request=request_mock)
 
-            request_validator.get_id_token.assert_called_once_with(None, None, request_mock)
+            request_validator.get_jwt_bearer_token.assert_called_once_with(None, None, request_mock)
 
     def test_validate_request_token_from_headers(self):
         """
@@ -151,7 +151,7 @@ class JWTTokenTestCase(TestCase):
 
             token.validate_request(request=request)
 
-            request_validator_mock.validate_id_token.assert_called_once_with('some-token-from-header',
+            request_validator_mock.validate_jwt_bearer_token.assert_called_once_with('some-token-from-header',
                                                                              request.scopes,
                                                                              request)
 
@@ -176,7 +176,7 @@ class JWTTokenTestCase(TestCase):
 
             token.validate_request(request=request)
 
-            request_validator_mock.validate_id_token.assert_called_once_with('some-token-from-request-object',
+            request_validator_mock.validate_jwt_bearer_token.assert_called_once_with('some-token-from-request-object',
                                                                              request.scopes,
                                                                              request)
 

--- a/tests/oauth2/rfc6749/test_tokens.py
+++ b/tests/oauth2/rfc6749/test_tokens.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
+import mock
+
 from oauthlib.oauth2.rfc6749.tokens import *
 
 from ...unittest import TestCase
@@ -80,3 +82,129 @@ class TokenTest(TestCase):
         self.assertEqual(prepare_bearer_headers(self.token), self.bearer_headers)
         self.assertEqual(prepare_bearer_body(self.token), self.bearer_body)
         self.assertEqual(prepare_bearer_uri(self.token, uri=self.uri), self.bearer_uri)
+
+
+class JWTTokenTestCase(TestCase):
+
+    def test_create_token_callable_expires_in(self):
+        """
+        Test retrieval of the expires in value by calling the callable expires_in property
+        """
+
+        expires_in_mock = mock.MagicMock()
+        request_mock = mock.MagicMock()
+
+        token = JWTToken(expires_in=expires_in_mock, request_validator=mock.MagicMock())
+        token.create_token(request=request_mock)
+
+        expires_in_mock.assert_called_once_with(request_mock)
+
+    def test_create_token_non_callable_expires_in(self):
+        """
+        When a non callable expires in is set this should just be set to the request
+        """
+
+        expires_in_mock = mock.NonCallableMagicMock()
+        request_mock = mock.MagicMock()
+
+        token = JWTToken(expires_in=expires_in_mock, request_validator=mock.MagicMock())
+        token.create_token(request=request_mock)
+
+        self.assertFalse(expires_in_mock.called)
+        self.assertEqual(request_mock.expires_in, expires_in_mock)
+
+    def test_create_token_calls_get_id_token(self):
+        """
+        When create_token is called the call should be forwarded to the get_id_token on the token validator
+        """
+        request_mock = mock.MagicMock()
+
+        with mock.patch('oauthlib.oauth2.rfc6749.request_validator.RequestValidator',
+                        autospec=True) as RequestValidatorMock:
+
+            request_validator = RequestValidatorMock()
+
+            token = JWTToken(expires_in=mock.MagicMock(), request_validator=request_validator)
+            token.create_token(request=request_mock)
+
+            request_validator.get_id_token.assert_called_once_with(None, None, request_mock)
+
+    def test_validate_request_token_from_headers(self):
+        """
+        Bearer token get retrieved from headers.
+        """
+
+        with mock.patch('oauthlib.common.Request', autospec=True) as RequestMock, \
+                mock.patch('oauthlib.oauth2.rfc6749.request_validator.RequestValidator',
+                           autospec=True) as RequestValidatorMock:
+            request_validator_mock = RequestValidatorMock()
+
+            token = JWTToken(request_validator=request_validator_mock)
+
+            request = RequestMock('/uri')
+            # Scopes is retrieved using the __call__ method which is not picked up correctly by mock.patch
+            # with autospec=True
+            request.scopes = mock.MagicMock()
+            request.headers = {
+                'Authorization': 'Bearer some-token-from-header'
+            }
+
+            token.validate_request(request=request)
+
+            request_validator_mock.validate_id_token.assert_called_once_with('some-token-from-header',
+                                                                             request.scopes,
+                                                                             request)
+
+    def test_validate_token_from_request(self):
+        """
+        Token get retrieved from request object.
+        """
+
+        with mock.patch('oauthlib.common.Request', autospec=True) as RequestMock, \
+                mock.patch('oauthlib.oauth2.rfc6749.request_validator.RequestValidator',
+                           autospec=True) as RequestValidatorMock:
+            request_validator_mock = RequestValidatorMock()
+
+            token = JWTToken(request_validator=request_validator_mock)
+
+            request = RequestMock('/uri')
+            # Scopes is retrieved using the __call__ method which is not picked up correctly by mock.patch
+            # with autospec=True
+            request.scopes = mock.MagicMock()
+            request.access_token = 'some-token-from-request-object'
+            request.headers = {}
+
+            token.validate_request(request=request)
+
+            request_validator_mock.validate_id_token.assert_called_once_with('some-token-from-request-object',
+                                                                             request.scopes,
+                                                                             request)
+
+    def test_estimate_type(self):
+        """
+        Estimate type results for a jwt token
+        """
+
+        def test_token(token, expected_result):
+            with mock.patch('oauthlib.common.Request', autospec=True) as RequestMock:
+                jwt_token = JWTToken()
+
+                request = RequestMock('/uri')
+                # Scopes is retrieved using the __call__ method which is not picked up correctly by mock.patch
+                # with autospec=True
+                request.headers = {
+                    'Authorization': 'Bearer {}'.format(token)
+                }
+
+                result = jwt_token.estimate_type(request=request)
+
+                self.assertEqual(result, expected_result)
+
+        test_items = (
+            ('foo.foo.foo', 10),
+            ('foo.foo.foo.foo.foo', 10),
+            ('foobar', 0)
+        )
+
+        for token, expected_result in test_items:
+            test_token(token, expected_result)

--- a/tests/oauth2/rfc6749/test_tokens.py
+++ b/tests/oauth2/rfc6749/test_tokens.py
@@ -201,9 +201,9 @@ class JWTTokenTestCase(TestCase):
                 self.assertEqual(result, expected_result)
 
         test_items = (
-            ('foo.foo.foo', 10),
-            ('foo.foo.foo.foo.foo', 10),
-            ('foobar', 0)
+            ('eyfoo.foo.foo', 10),
+            ('eyfoo.foo.foo.foo.foo', 10),
+            ('eyfoobar', 0)
         )
 
         for token, expected_result in test_items:


### PR DESCRIPTION
This pull request adds support to receive JWT token in request in the following form:

```
curl -vv --header "Content-Type: application/json" \
         --header "Accept: application/json; indent=4" \
         --header "Authorization: Bearer eyJhbGciOiAiUlMyNTYifQ..." \
         http://127.0.0.1:8000/v1/users/
...
> GET /v1/users/ HTTP/1.1
> Host: 127.0.0.1:8000
> User-Agent: curl/7.53.1
> Content-Type: application/json
> Accept: application/json; indent=4
> Authorization: Bearer eyJhbGciOiAiUlMyNTYifQ....
> 
* HTTP 1.0, assume close after body
< HTTP/1.0 200 OK
< Date: Sun, 01 Oct 2017 19:53:52 GMT
< Server: WSGIServer/0.2 CPython/3.6.2
< Content-Type: application/json
< Vary: Accept
< Allow: GET, POST, HEAD, OPTIONS
< X-Frame-Options: SAMEORIGIN
< Content-Length: 159
< 
[
    {
        "url": "http://127.0.0.1:8000/v1/users/1/",
        "username": "wiliam",
        "email": "wiliam@olist.com",
        "is_staff": true
    }
* Closing connection 0
]
```
Don't find tests for `tokens.py` model. Any clue?