### PR TITLE
Request object not given to confirm_redirect_uri

### DIFF
--- a/examples/skeleton_oauth2_web_application_server.py
+++ b/examples/skeleton_oauth2_web_application_server.py
@@ -67,7 +67,7 @@ class SkeletonValidator(RequestValidator):
         # state and user to request.scopes and request.user.
         pass
 
-    def confirm_redirect_uri(self, client_id, code, redirect_uri, client, *args, **kwargs):
+    def confirm_redirect_uri(self, client_id, code, redirect_uri, client, request, *args, **kwargs):
         # You did save the redirect uri with the authorization code right?
         pass
 

--- a/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
@@ -421,7 +421,8 @@ class AuthorizationCodeGrant(GrantTypeBase):
         # authorization request as described in Section 4.1.1, and their
         # values MUST be identical.
         if not self.request_validator.confirm_redirect_uri(request.client_id, request.code,
-                                                           request.redirect_uri, request.client):
+                                                           request.redirect_uri, request.client,
+                                                           request):
             log.debug('Redirect_uri (%r) invalid for client %r (%r).',
                       request.redirect_uri, request.client_id, request.client)
             raise errors.MismatchingRedirectURIError(request=request)

--- a/oauthlib/oauth2/rfc6749/request_validator.py
+++ b/oauthlib/oauth2/rfc6749/request_validator.py
@@ -82,7 +82,7 @@ class RequestValidator(object):
         """
         raise NotImplementedError('Subclasses must implement this method.')
 
-    def confirm_redirect_uri(self, client_id, code, redirect_uri, client,
+    def confirm_redirect_uri(self, client_id, code, redirect_uri, client, request,
                              *args, **kwargs):
         """Ensure that the authorization process represented by this authorization
         code began with this 'redirect_uri'.


### PR DESCRIPTION
It seems that the request object is never given to the `confirm_redirect_uri`.

```console
$ git grep -l confirm_redirect_uri oauthlib
oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
oauthlib/oauth2/rfc6749/request_validator.py
```

```console
$ grep -A 1 confirm_redirect_uri oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
        if not self.request_validator.confirm_redirect_uri(request.client_id, request.code,
                                                           request.redirect_uri, request.client):
```

This is an issue since I enclose the database session within the request object. That means that I cannot proceed with the query to fulfill the request.