### PR TITLE
Replace G+ with Gitter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,13 +2,14 @@ OAuthLib
 ========
 
 *A generic, spec-compliant, thorough implementation of the OAuth request-signing
-logic for python*
+logic for Python 2.7 and 3.4+.*
 
 .. image:: https://travis-ci.org/oauthlib/oauthlib.svg?branch=master
   :target: https://travis-ci.org/oauthlib/oauthlib
 .. image:: https://coveralls.io/repos/oauthlib/oauthlib/badge.svg?branch=master
   :target: https://coveralls.io/r/oauthlib/oauthlib
-
+.. image:: https://badges.gitter.im/oauthlib/oauthlib.svg
+  :target: https://gitter.im/oauthlib/Lobby?utm_source=share-link&utm_medium=link&utm_campaign=share-link
 
 OAuth often seems complicated and difficult-to-implement. There are several
 prominent libraries for handling OAuth requests, but they all suffer from one or
@@ -33,10 +34,10 @@ Documentation
 
 Full documentation is available on `Read the Docs`_. All contributions are very
 welcome! The documentation is still quite sparse, please open an issue for what
-you'd like to know, or discuss it in our `G+ community`_, or even better, send a
+you'd like to know, or discuss it in our `Gitter community`_, or even better, send a
 pull request!
 
-.. _`G+ community`: https://plus.google.com/communities/101889017375384052571
+.. _`Gitter community`: https://gitter.im/oauthlib/Lobby?utm_source=share-link&utm_medium=link&utm_campaign=share-link
 .. _`Read the Docs`: https://oauthlib.readthedocs.io/en/latest/index.html
 
 Interested in making OAuth requests?
@@ -74,7 +75,7 @@ Patching OAuth support onto an http request framework? Creating an OAuth
 provider extension for a web framework? Simply using OAuthLib to Get Things Done
 or to learn?
 
-No matter which we'd love to hear from you in our `G+ community`_ or if you have
+No matter which we'd love to hear from you in our `Gitter community`_ or if you have
 anything in particular you would like to have, change or comment on don't
 hesitate for a second to send a pull request or open an issue. We might be quite
 busy and therefore slow to reply but we love feedback!
@@ -83,7 +84,7 @@ Chances are you have run into something annoying that you wish there was
 documentation for, if you wish to gain eternal fame and glory, and a drink if we
 have the pleasure to run into eachother, please send a docs pull request =)
 
-.. _`G+ community`: https://plus.google.com/communities/101889017375384052571
+.. _`Gitter community`: https://gitter.im/oauthlib/Lobby?utm_source=share-link&utm_medium=link&utm_campaign=share-link
 
 License
 -------


### PR DESCRIPTION
This replaces the links to the G+ community with Gitter. Also adds a Gitter badge.