### PR TITLE
Release 2.0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,12 @@ script: tox
 
 after_success: coveralls
 notifications:
-  irc: irc.freenode.org#oauthlib
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/6008c872bf0ecee344f4
+    on_success: change
+    on_failure: always
+    on_start: never
 deploy:
   provider: pypi
   user: ib.lundgren

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,17 @@ notifications:
     on_failure: always
     on_start: never
 deploy:
-  provider: pypi
-  user: ib.lundgren
-  password:
-    secure: PGZF9pRiTGCSwQjk1ddTKF3x4rQ0iAiPbg2uSixyO68uMXRgJjwHhSrNM0OEqtK5YWU5FE5L0DwR1nkrpEJKO4a5q2EOgos+gVoKpJfinoUNOOkjc1VHpqKM0uRf/OKrw1alvWUwqvW8B+DOb9TY5c5VZxQuRL+iwdrtwzFlKls=
-  distributions: sdist bdist_wheel
-  on:
-    tags: true
-    repo: oauthlib/oauthlib
+  - provider: pypi
+    user: ib.lundgren
+    password:
+      secure: PGZF9pRiTGCSwQjk1ddTKF3x4rQ0iAiPbg2uSixyO68uMXRgJjwHhSrNM0OEqtK5YWU5FE5L0DwR1nkrpEJKO4a5q2EOgos+gVoKpJfinoUNOOkjc1VHpqKM0uRf/OKrw1alvWUwqvW8B+DOb9TY5c5VZxQuRL+iwdrtwzFlKls=
+      distributions: sdist bdist_wheel
+      on:
+        tags: true
+        repo: oauthlib/oauthlib
+  - provider: releases
+    api_key: "$GITHUB_OAUTH_TOKEN"
+    skip_cleanup: true
+    on:
+      tags: true
+      repo: oauthlib/oauthlib

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ notifications:
     on_start: never
 deploy:
   - provider: pypi
-    user: ib.lundgren
+    user: JonathanHuot
     password:
-      secure: PGZF9pRiTGCSwQjk1ddTKF3x4rQ0iAiPbg2uSixyO68uMXRgJjwHhSrNM0OEqtK5YWU5FE5L0DwR1nkrpEJKO4a5q2EOgos+gVoKpJfinoUNOOkjc1VHpqKM0uRf/OKrw1alvWUwqvW8B+DOb9TY5c5VZxQuRL+iwdrtwzFlKls=
+      secure: "OozNM16flVLvqDoNzmoTENchhS1w0/dEJZvXBQK2KWmh8fyGj2UZus1vkl6bA5V3Yu9MZLYFpDcltl/qraY3Up6iXQpwKz4q+ICygAudYM2kJ5l8ZEe+wy2FikWbD6LkXf5uKIJJnPNSC8AI86ZyxM/XZxbYjj/+jXyJ1YFZwwQ="
       distributions: sdist bdist_wheel
       on:
         tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     tags: true
-    repo: idan/oauthlib
+    repo: oauthlib/oauthlib

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ deploy:
   user: ib.lundgren
   password:
     secure: PGZF9pRiTGCSwQjk1ddTKF3x4rQ0iAiPbg2uSixyO68uMXRgJjwHhSrNM0OEqtK5YWU5FE5L0DwR1nkrpEJKO4a5q2EOgos+gVoKpJfinoUNOOkjc1VHpqKM0uRf/OKrw1alvWUwqvW8B+DOb9TY5c5VZxQuRL+iwdrtwzFlKls=
+  distributions: sdist bdist_wheel
   on:
     tags: true
     repo: idan/oauthlib

--- a/AUTHORS
+++ b/AUTHORS
@@ -26,3 +26,5 @@ Juan Fabio García Solero
 Omer Katz
 Joel Stevenson
 Brendan McCollam
+Jonathan Huot
+Pieter Ennes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,11 +1,22 @@
 Changelog
 =========
 
+2.0.7 (2018-03-09)
+------------------
+
+* Moved oauthlib into new organization on GitHub.
+* Include license file in the generated wheel package. (#494)
+* When deploying a release to PyPI, include the wheel distribution. (#496)
+* Check access token in self.token dict. (#500)
+* Added bottle-oauthlib to docs. (#509)
+* Updated docs for organization change. (#515)
+* Update repository location in Travis. (#514)
+* Replace G+ with Gitter. (#517)
+
 2.0.6 (2017-10-20)
 ------------------
 
 * 2.0.5 contains breaking changes.
-
 
 2.0.5 (2017-10-19)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-2.0.7 (2018-03-09)
+2.0.7 (2018-03-19)
 ------------------
 
 * Moved oauthlib into new organization on GitHub.
@@ -9,9 +9,15 @@ Changelog
 * When deploying a release to PyPI, include the wheel distribution. (#496)
 * Check access token in self.token dict. (#500)
 * Added bottle-oauthlib to docs. (#509)
-* Updated docs for organization change. (#515)
 * Update repository location in Travis. (#514)
+* Updated docs for organization change. (#515)
 * Replace G+ with Gitter. (#517)
+* Update requirements. (#518)
+* Add shields for Python versions, license and RTD. (#520)
+* Fix ReadTheDocs build (#521).
+* Fixed "make" command to test upstream with local oauthlib. (#522)
+* Replace IRC notification with Gitter Hook. (#523)
+* Added Github Releases deploy provider. (#523)
 
 2.0.6 (2017-10-20)
 ------------------

--- a/Makefile
+++ b/Makefile
@@ -1,47 +1,57 @@
-PYS = py27,py34,pypy
+# Downstream tests (Don't be evil)
+#
+# Try and not break the libraries below by running their tests too.
+#
+# Unfortunately there is no neat way to run downstream tests AFAIK
+# Until we have a proper downstream testing system we will
+# stick to this Makefile.
+#---------------------------
+# HOW TO ADD NEW DOWNSTREAM LIBRARIES
+#
+# Please specify your library as well as primary contacts.
+# Since these contacts will be addressed with Github mentions they
+# need to be Github users (for now)(sorry Bitbucket).
+#
+clean:
+	rm -rf .tox
+	rm -rf bottle-oauthlib
+	rm -rf django-oauth-toolkit
+	rm -rf flask-oauthlib
+	rm -rf requests-oauthlib
 
 test:
-	# Test OAuthLib
-	tox -e "$(PYS)"
-	#
-	# Downstream tests (Don't be evil)
-	#
-	# Try and not break the libraries below by running their tests too.
-	#
-	# Unfortunately there is no neat way to run downstream tests AFAIK
-	# Until we have a proper downstream testing system we will
-	# stick to this Makefile.
+	tox
+
+bottle:
 	#---------------------------
-	# HOW TO ADD NEW DOWNSTREAM LIBRARIES
-	#
-	# Please specify your library as well as primary contacts.
-	# Since these contacts will be addressed with Github mentions they
-	# need to be Github users (for now)(sorry Bitbucket).
-	#
+	# Library thomsonreuters/bottle-oauthlib
+	# Contacts: Jonathan.Huot
+	cd bottle-oauthlib 2>/dev/null || git clone https://github.com/thomsonreuters/bottle-oauthlib.git
+	cd bottle-oauthlib && sed -i.old 's,deps =,deps= --editable=file://{toxinidir}/../,' tox.ini && sed -i.old '/oauthlib/d' requirements.txt && tox
+
+flask:
 	#---------------------------
 	# Library: lepture/flask-oauthLib
 	# Contacts: lepture,widnyana
-	git clone https://github.com/lepture/flask-oauthlib.git
-	cd flask-oauthlib && cp ../tox.ini . && sed -i 's/py32,py33,py34,//' tox.ini && sed -i '/mock/a \     Flask-SQLAlchemy' tox.ini &&  tox -e "$(PYS)"
-	rm -rf flask-oauthlib
+	cd flask-oauthlib 2>/dev/null || git clone https://github.com/lepture/flask-oauthlib.git
+	cd flask-oauthlib && sed -i.old 's,deps =,deps= --editable=file://{toxinidir}/../,' tox.ini && sed -i.old '/oauthlib/d' requirements.txt && tox
+
+django:
 	#---------------------------
 	# Library: evonove/django-oauth-toolkit
 	# Contacts: evonove,masci
 	# (note: has tox.ini already)
-	git clone https://github.com/evonove/django-oauth-toolkit.git
-	cd django-oauth-toolkit && tox -e "$(PYS)"
-	rm -rf django-oauth-toolkit
+	cd django-oauth-toolkit 2>/dev/null || git clone https://github.com/evonove/django-oauth-toolkit.git
+	cd django-oauth-toolkit && sed -i.old 's,deps =,deps= --editable=file://{toxinidir}/../,' tox.ini && tox -e py27,py35,py36
+
+requests:
 	#---------------------------
 	# Library requests/requests-oauthlib
 	# Contacts: ib-lundgren,lukasa
-	git clone https://github.com/requests/requests-oauthlib.git
-	cd requests-oauthlib && cp ../tox.ini . && sed -i '/mock/a \     requests' tox.ini && tox -e "$(PYS)"
-	rm -rf requests-oauthlib
-	#---------------------------
-	#
+	cd requests-oauthlib 2>/dev/null || git clone https://github.com/requests/requests-oauthlib.git
+	cd requests-oauthlib && sed -i.old 's,deps=,deps = --editable=file://{toxinidir}/../[signedtoken],' tox.ini && sed -i.old '/oauthlib/d' requirements.txt && tox
 
-pycco:
-	find oauthlib -name "*.py" -exec pycco -p -s reST {} \;
 
-pycco-clean:
-	rm -rf docs/oauthlib docs/pycco.css
+.DEFAULT_GOAL := all
+.PHONY: clean test bottle django flask requests
+all: clean test bottle django flask requests

--- a/README.rst
+++ b/README.rst
@@ -6,10 +6,22 @@ logic for Python 2.7 and 3.4+.*
 
 .. image:: https://travis-ci.org/oauthlib/oauthlib.svg?branch=master
   :target: https://travis-ci.org/oauthlib/oauthlib
+  :alt: Travis
 .. image:: https://coveralls.io/repos/oauthlib/oauthlib/badge.svg?branch=master
   :target: https://coveralls.io/r/oauthlib/oauthlib
+  :alt: Coveralls
+.. image:: https://img.shields.io/pypi/pyversions/oauthlib.svg
+  :target: https://pypi.python.org/pypi/oauthlib
+  :alt: Download from PyPi
+.. image:: https://img.shields.io/pypi/l/oauthlib.svg
+  :target: https://pypi.python.org/pypi/oauthlib
+  :alt: License
+.. image:: https://img.shields.io/readthedocs/oauthlib.svg
+  :target: https://oauthlib.readthedocs.io/en/latest/index.html
+  :alt: Read the Docs
 .. image:: https://badges.gitter.im/oauthlib/oauthlib.svg
-  :target: https://gitter.im/oauthlib/Lobby?utm_source=share-link&utm_medium=link&utm_campaign=share-link
+  :target: https://gitter.im/oauthlib/Lobby
+  :alt: Chat on Gitter
 
 OAuth often seems complicated and difficult-to-implement. There are several
 prominent libraries for handling OAuth requests, but they all suffer from one or
@@ -37,7 +49,7 @@ welcome! The documentation is still quite sparse, please open an issue for what
 you'd like to know, or discuss it in our `Gitter community`_, or even better, send a
 pull request!
 
-.. _`Gitter community`: https://gitter.im/oauthlib/Lobby?utm_source=share-link&utm_medium=link&utm_campaign=share-link
+.. _`Gitter community`: https://gitter.im/oauthlib/Lobby
 .. _`Read the Docs`: https://oauthlib.readthedocs.io/en/latest/index.html
 
 Interested in making OAuth requests?
@@ -84,7 +96,7 @@ Chances are you have run into something annoying that you wish there was
 documentation for, if you wish to gain eternal fame and glory, and a drink if we
 have the pleasure to run into eachother, please send a docs pull request =)
 
-.. _`Gitter community`: https://gitter.im/oauthlib/Lobby?utm_source=share-link&utm_medium=link&utm_campaign=share-link
+.. _`Gitter community`: https://gitter.im/oauthlib/Lobby
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -2,13 +2,14 @@ OAuthLib
 ========
 
 *A generic, spec-compliant, thorough implementation of the OAuth request-signing
-logic for python*
+logic for Python 2.7 and 3.4+.*
 
 .. image:: https://travis-ci.org/oauthlib/oauthlib.svg?branch=master
   :target: https://travis-ci.org/oauthlib/oauthlib
 .. image:: https://coveralls.io/repos/oauthlib/oauthlib/badge.svg?branch=master
   :target: https://coveralls.io/r/oauthlib/oauthlib
-
+.. image:: https://badges.gitter.im/oauthlib/oauthlib.svg
+  :target: https://gitter.im/oauthlib/Lobby?utm_source=share-link&utm_medium=link&utm_campaign=share-link
 
 OAuth often seems complicated and difficult-to-implement. There are several
 prominent libraries for handling OAuth requests, but they all suffer from one or
@@ -33,10 +34,10 @@ Documentation
 
 Full documentation is available on `Read the Docs`_. All contributions are very
 welcome! The documentation is still quite sparse, please open an issue for what
-you'd like to know, or discuss it in our `G+ community`_, or even better, send a
+you'd like to know, or discuss it in our `Gitter community`_, or even better, send a
 pull request!
 
-.. _`G+ community`: https://plus.google.com/communities/101889017375384052571
+.. _`Gitter community`: https://gitter.im/oauthlib/Lobby?utm_source=share-link&utm_medium=link&utm_campaign=share-link
 .. _`Read the Docs`: https://oauthlib.readthedocs.io/en/latest/index.html
 
 Interested in making OAuth requests?
@@ -74,7 +75,7 @@ Patching OAuth support onto an http request framework? Creating an OAuth
 provider extension for a web framework? Simply using OAuthLib to Get Things Done
 or to learn?
 
-No matter which we'd love to hear from you in our `G+ community`_ or if you have
+No matter which we'd love to hear from you in our `Gitter community`_ or if you have
 anything in particular you would like to have, change or comment on don't
 hesitate for a second to send a pull request or open an issue. We might be quite
 busy and therefore slow to reply but we love feedback!
@@ -83,7 +84,7 @@ Chances are you have run into something annoying that you wish there was
 documentation for, if you wish to gain eternal fame and glory, and a drink if we
 have the pleasure to run into eachother, please send a docs pull request =)
 
-.. _`G+ community`: https://plus.google.com/communities/101889017375384052571
+.. _`Gitter community`: https://gitter.im/oauthlib/Lobby?utm_source=share-link&utm_medium=link&utm_campaign=share-link
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,7 @@ The following packages provide OAuth support using OAuthLib.
 - For Django there is `django-oauth-toolkit`_, which includes `Django REST framework`_ support.
 - For Flask there is `flask-oauthlib`_ and `Flask-Dance`_.
 - For Pyramid there is `pyramid-oauthlib`_.
+- For Bottle there is `bottle-oauthlib`_.
 
 If you have written an OAuthLib package that supports your favorite framework,
 please open a Pull Request, updating the documentation.
@@ -65,6 +66,7 @@ please open a Pull Request, updating the documentation.
 .. _`Django REST framework`: http://django-rest-framework.org
 .. _`Flask-Dance`: https://github.com/singingwolfboy/flask-dance
 .. _`pyramid-oauthlib`: https://github.com/tilgovi/pyramid-oauthlib
+.. _`bottle-oauthlib`: https://github.com/thomsonreuters/bottle-oauthlib
 
 Using OAuthLib? Please get in touch!
 ------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -4,10 +4,10 @@ OAuthLib
 *A generic, spec-compliant, thorough implementation of the OAuth request-signing
 logic for python*
 
-.. image:: https://travis-ci.org/idan/oauthlib.svg?branch=master
-  :target: https://travis-ci.org/idan/oauthlib
-.. image:: https://coveralls.io/repos/idan/oauthlib/badge.svg?branch=master
-  :target: https://coveralls.io/r/idan/oauthlib
+.. image:: https://travis-ci.org/oauthlib/oauthlib.svg?branch=master
+  :target: https://travis-ci.org/oauthlib/oauthlib
+.. image:: https://coveralls.io/repos/oauthlib/oauthlib/badge.svg?branch=master
+  :target: https://coveralls.io/r/oauthlib/oauthlib
 
 
 OAuth often seems complicated and difficult-to-implement. There are several
@@ -18,8 +18,8 @@ both of the following:
 2. They predate the `OAuth 2.0 spec`_, AKA RFC 6749.
 3. They assume the usage of a specific HTTP request library.
 
-.. _`OAuth 1.0 spec`: http://tools.ietf.org/html/rfc5849
-.. _`OAuth 2.0 spec`: http://tools.ietf.org/html/rfc6749
+.. _`OAuth 1.0 spec`: https://tools.ietf.org/html/rfc5849
+.. _`OAuth 2.0 spec`: https://tools.ietf.org/html/rfc6749
 
 OAuthLib is a generic utility which implements the logic of OAuth without
 assuming a specific HTTP request object or web framework. Use it to graft OAuth
@@ -45,7 +45,7 @@ Interested in making OAuth requests?
 Then you might be more interested in using `requests`_ which has OAuthLib
 powered OAuth support provided by the `requests-oauthlib`_ library.
 
-.. _`requests`: https://github.com/kennethreitz/requests
+.. _`requests`: https://github.com/requests/requests
 .. _`requests-oauthlib`: https://github.com/requests/requests-oauthlib
 
 Which web frameworks are supported?

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,8 +14,6 @@
 import os
 import sys
 
-from oauthlib import __version__ as v
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -51,6 +49,7 @@ copyright = u'2012, Idan Gazit and the Python Community'
 #
 # The short X.Y version.
 
+from oauthlib import __version__ as v
 version = v[:3]
 # The full version, including alpha/beta/rc tags.
 release = v

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -243,3 +243,5 @@ texinfo_documents = [
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
+
+linkcheck_ignore = ["https://github.com/oauthlib/oauthlib/issues/new"]

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -91,7 +91,7 @@ request only to have it rejected because it has diverged too far from master.
 
 To pull in upstream changes::
 
-    git remote add upstream https://github.com/idan/oauthlib.git
+    git remote add upstream https://github.com/oauthlib/oauthlib.git
     git fetch upstream
 
 Check the log to be sure that you actually want the changes, before merging::
@@ -102,7 +102,7 @@ Then merge the changes that you fetched::
 
     git merge upstream/master
 
-For more info, see http://help.github.com/fork-a-repo/
+For more info, see https://help.github.com/fork-a-repo/
 
 How to get your pull request accepted
 =====================================
@@ -148,7 +148,7 @@ version. For Ubuntu you can easily install all after adding one ppa.
    $ sudo apt-get install pypy pypy-dev
 
 .. _`Tox`: https://tox.readthedocs.io/en/latest/install.html
-.. _`virtualenv`: http://www.virtualenv.org/en/latest/#installation
+.. _`virtualenv`: https://virtualenv.pypa.io/en/latest/installation/
 
 If you add code you need to add tests!
 --------------------------------------
@@ -223,5 +223,5 @@ to GitHub::
     git push upstream master
 
 .. _installation: install.html
-.. _GitHub project: https://github.com/idan/oauthlib
-.. _issue tracker: https://github.com/idan/oauthlib/issues
+.. _GitHub project: https://github.com/oauthlib/oauthlib
+.. _issue tracker: https://github.com/oauthlib/oauthlib/issues

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -100,6 +100,6 @@ Some argue OAuth 2 is worse than 1, is that true?
 .. _`flask-oauthlib`: https://github.com/lepture/flask-oauthlib
 .. _`pyramid-oauthlib`: https://github.com/tilgovi/pyramid-oauthlib
 .. _`bottle-oauthlib`: https://github.com/thomsonreuters/bottle-oauthlib
-.. _`GitHub issue`: https://github.com/idan/oauthlib/issues/new
+.. _`GitHub issue`: https://github.com/oauthlib/oauthlib/issues/new
 .. _`G+`: https://plus.google.com/communities/101889017375384052571
-.. _`difference`: http://www.cyberciti.biz/faq/authentication-vs-authorization/
+.. _`difference`: https://www.cyberciti.biz/faq/authentication-vs-authorization/

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -65,10 +65,17 @@ How do I use OAuthLib with Google, Twitter and other providers?
 How do I use OAuthlib as a provider with Django, Flask and other web frameworks?
 --------------------------------------------------------------------------------
 
-    Providers using Django should seek out `django-oauth-toolkit`_
-    and those using Flask `flask-oauthlib`_. For other frameworks,
-    please get in touch by opening a `GitHub issue`_, on `G+`_ or
-    on IRC #oauthlib irc.freenode.net.
+    Providers can be implemented in any web frameworks. However, some of
+    them have ready-to-use libraries to help integration:
+    - Django `django-oauth-toolkit`_
+    - Flask `flask-oauthlib`_
+    - Pyramid `pyramid-oauthlib`_
+    - Bottle `bottle-oauthlib`_
+
+    For other frameworks, please get in touch by opening a `GitHub issue`_, on `G+`_ or
+    on IRC #oauthlib irc.freenode.net. If you have written an OAuthLib package that
+    supports your favorite framework, please open a Pull Request to update the docs.
+
 
 What is the difference between authentication and authorization?
 ----------------------------------------------------------------
@@ -91,6 +98,8 @@ Some argue OAuth 2 is worse than 1, is that true?
 .. _`requests-oauthlib`: https://github.com/requests/requests-oauthlib
 .. _`django-oauth-toolkit`: https://github.com/evonove/django-oauth-toolkit
 .. _`flask-oauthlib`: https://github.com/lepture/flask-oauthlib
+.. _`pyramid-oauthlib`: https://github.com/tilgovi/pyramid-oauthlib
+.. _`bottle-oauthlib`: https://github.com/thomsonreuters/bottle-oauthlib
 .. _`GitHub issue`: https://github.com/idan/oauthlib/issues/new
 .. _`G+`: https://plus.google.com/communities/101889017375384052571
 .. _`difference`: http://www.cyberciti.biz/faq/authentication-vs-authorization/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ Check out :doc:`error_reporting` for details on how to be an awesome bug reporte
 
 For news and discussions please head over to our `G+ OAuthLib community`_.
 
-.. _`new issue on GitHub`: https://github.com/idan/oauthlib/issues/new
+.. _`new issue on GitHub`: https://github.com/oauthlib/oauthlib/issues/new
 .. _`G+ OAuthLib community`: https://plus.google.com/communities/101889017375384052571
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,14 +7,14 @@ Welcome to OAuthLib's documentation!
 ====================================
 
 If you can't find what you need or have suggestions for improvement, don't
-hesitate to open a `new issue on GitHub`_!  
+hesitate to open a `new issue on GitHub`_!
 
 Check out :doc:`error_reporting` for details on how to be an awesome bug reporter.
 
-For news and discussions please head over to our `G+ OAuthLib community`_.
+For news and discussions please head over to our `Gitter OAuthLib community`_.
 
 .. _`new issue on GitHub`: https://github.com/oauthlib/oauthlib/issues/new
-.. _`G+ OAuthLib community`: https://plus.google.com/communities/101889017375384052571
+.. _`Gitter OAuthLib community`: https://gitter.im/oauthlib/Lobby
 
 .. toctree::
    :maxdepth: 1

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,7 +22,7 @@ Bleeding edge from GitHub master
 
 .. code-block:: bash
 
-    pip install -e git+https://github.com/idan/oauthlib.git#egg=oauthlib
+    pip install -e git+https://github.com/oauthlib/oauthlib.git#egg=oauthlib
 
 Debian and derivatives like Ubuntu, Mint, etc.
 ---------------------------------------------

--- a/docs/oauth1/preconfigured_servers.rst
+++ b/docs/oauth1/preconfigured_servers.rst
@@ -12,7 +12,7 @@ Construction is simple, only import your validator and you are good to go::
 
     server = WebApplicationServer(your_validator)
 
-All endpoints are documented in :doc:`endpoints`.
+All endpoints are documented in :doc:`Provider endpoints <endpoints/endpoints>`.
 
 .. autoclass:: oauthlib.oauth1.WebApplicationServer
     :members:

--- a/docs/oauth1/server.rst
+++ b/docs/oauth1/server.rst
@@ -436,7 +436,7 @@ shown below as well as run your flask server locally on port `5000`.
 Drop a line in our `G+ community`_ or open a `GitHub issue`_ =)
 
 .. _`G+ community`: https://plus.google.com/communities/101889017375384052571
-.. _`GitHub issue`: https://github.com/idan/oauthlib/issues/new
+.. _`GitHub issue`: https://github.com/oauthlib/oauthlib/issues/new
 
 If you run into issues it can be helpful to enable debug logging::
 

--- a/docs/oauth2/clients/client.rst
+++ b/docs/oauth2/clients/client.rst
@@ -24,5 +24,5 @@ to use them please browse the documentation for each client type below.
     If you are interested in integrating OAuth 2 support into your favourite
     HTTP library you might find the requests-oauthlib implementation interesting.
 
-    .. _`requests`: https://github.com/kennethreitz/requests
+    .. _`requests`: https://github.com/requests/requests
     .. _`requests-oauthlib`: https://github.com/requests/requests-oauthlib

--- a/docs/oauth2/endpoints/endpoints.rst
+++ b/docs/oauth2/endpoints/endpoints.rst
@@ -23,7 +23,7 @@ handles user authorization, the token endpoint which provides tokens and the
 resource endpoint which provides access to protected resources. It is to the
 endpoints you will feed requests and get back an almost complete response. This
 process is simplified for you using a decorator such as the django one described
-later.
+later (but it's applicable to all other web frameworks librairies).
 
 The main purpose of the endpoint in OAuthLib is to figure out which grant type
 or token to dispatch the request to.

--- a/docs/oauth2/endpoints/endpoints.rst
+++ b/docs/oauth2/endpoints/endpoints.rst
@@ -23,7 +23,7 @@ handles user authorization, the token endpoint which provides tokens and the
 resource endpoint which provides access to protected resources. It is to the
 endpoints you will feed requests and get back an almost complete response. This
 process is simplified for you using a decorator such as the django one described
-later (but it's applicable to all other web frameworks librairies).
+later (but it's applicable to all other web frameworks libraries).
 
 The main purpose of the endpoint in OAuthLib is to figure out which grant type
 or token to dispatch the request to.

--- a/docs/oauth2/grants/jwt.rst
+++ b/docs/oauth2/grants/jwt.rst
@@ -4,4 +4,4 @@ JWT Tokens
 
 Not yet implemented. Track progress in `GitHub issue 50`_.
 
-.. _`GitHub issue 50`: https://github.com/idan/oauthlib/issues/50
+.. _`GitHub issue 50`: https://github.com/oauthlib/oauthlib/issues/50

--- a/docs/oauth2/server.rst
+++ b/docs/oauth2/server.rst
@@ -6,8 +6,10 @@ OAuthLib is a dependency free library that may be used with any web
 framework. That said, there are framework specific helper libraries
 to make your life easier.
 
-- For Django there is `django-oauth-toolkit`_.
-- For Flask there is `flask-oauthlib`_.
+- Django `django-oauth-toolkit`_
+- Flask `flask-oauthlib`_
+- Pyramid `pyramid-oauthlib`_
+- Bottle `bottle-oauthlib`_
 
 If there is no support for your favourite framework and you are interested
 in providing it then you have come to the right place. OAuthLib can handle
@@ -17,6 +19,8 @@ as well as provide an interface for a backend to store tokens, clients, etc.
 
 .. _`django-oauth-toolkit`: https://github.com/evonove/django-oauth-toolkit
 .. _`flask-oauthlib`: https://github.com/lepture/flask-oauthlib
+.. _`pyramid-oauthlib`: https://github.com/tilgovi/pyramid-oauthlib
+.. _`bottle-oauthlib`: https://github.com/thomsonreuters/bottle-oauthlib
 
 .. contents:: Tutorial Contents
     :depth: 3

--- a/docs/oauth2/server.rst
+++ b/docs/oauth2/server.rst
@@ -279,7 +279,7 @@ all methods depending on which grant types you wish to support. A skeleton
 validator listing the methods required for the WebApplicationServer is
 available in the `examples`_ folder on GitHub.
 
-..  _`examples`: https://github.com/idan/oauthlib/blob/master/examples/skeleton_oauth2_web_application_server.py
+..  _`examples`: https://github.com/oauthlib/oauthlib/blob/master/examples/skeleton_oauth2_web_application_server.py
 
 Relevant sections include:
 
@@ -496,7 +496,7 @@ at runtime by a function, rather then by a list.
 Drop a line in our `G+ community`_ or open a `GitHub issue`_ =)
 
 .. _`G+ community`: https://plus.google.com/communities/101889017375384052571
-.. _`GitHub issue`: https://github.com/idan/oauthlib/issues/new
+.. _`GitHub issue`: https://github.com/oauthlib/oauthlib/issues/new
 
 If you run into issues it can be helpful to enable debug logging.
 

--- a/docs/oauth2/tokens/mac.rst
+++ b/docs/oauth2/tokens/mac.rst
@@ -5,4 +5,4 @@ MAC tokens
 Not yet implemented. Track progress in `GitHub issue 29`_. Might never be
 supported depending on whether the work on the specification is resumed or not.
 
-.. _`GitHub issue 29`: https://github.com/idan/oauthlib/issues/29
+.. _`GitHub issue 29`: https://github.com/oauthlib/oauthlib/issues/29

--- a/docs/oauth2/tokens/saml.rst
+++ b/docs/oauth2/tokens/saml.rst
@@ -4,4 +4,4 @@ SAML Tokens
 
 Not yet implemented. Track progress in `GitHub issue 49`_.
 
-.. _`GitHub issue 49`: https://github.com/idan/oauthlib/issues/49
+.. _`GitHub issue 49`: https://github.com/oauthlib/oauthlib/issues/49

--- a/docs/oauth2/tokens/tokens.rst
+++ b/docs/oauth2/tokens/tokens.rst
@@ -15,8 +15,8 @@ providers, notably Facebook, do not provide this information. Per the
 is missing. You can force a ``MissingTokenTypeError`` exception instead, by
 setting ``OAUTHLIB_STRICT_TOKEN_TYPE`` in the environment.
 
-.. _requires: http://tools.ietf.org/html/rfc6749#section-5.1
-.. _robustness principle: http://en.wikipedia.org/wiki/Robustness_principle
+.. _requires: https://tools.ietf.org/html/rfc6749#section-5.1
+.. _robustness principle: https://en.wikipedia.org/wiki/Robustness_principle
 
 .. toctree::
     :maxdepth: 2

--- a/oauthlib/__init__.py
+++ b/oauthlib/__init__.py
@@ -9,8 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
-__author__ = 'Idan Gazit <idan@gazit.me>'
-__version__ = '2.0.6'
+__author__ = 'The OAuthlib Community'
+__version__ = '2.0.7'
 
 
 import logging

--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -199,8 +199,8 @@ def generate_nonce():
     A random 64-bit number is appended to the epoch timestamp for both
     randomness and to decrease the likelihood of collisions.
 
-    .. _`section 3.2.1`: http://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-01#section-3.2.1
-    .. _`section 3.3`: http://tools.ietf.org/html/rfc5849#section-3.3
+    .. _`section 3.2.1`: https://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-01#section-3.2.1
+    .. _`section 3.3`: https://tools.ietf.org/html/rfc5849#section-3.3
     """
     return unicode_type(unicode_type(random.getrandbits(64)) + generate_timestamp())
 
@@ -211,8 +211,8 @@ def generate_timestamp():
     Per `section 3.3`_ of the OAuth 1 RFC 5849 spec.
     Per `section 3.2.1`_ of the MAC Access Authentication spec.
 
-    .. _`section 3.2.1`: http://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-01#section-3.2.1
-    .. _`section 3.3`: http://tools.ietf.org/html/rfc5849#section-3.3
+    .. _`section 3.2.1`: https://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-01#section-3.2.1
+    .. _`section 3.3`: https://tools.ietf.org/html/rfc5849#section-3.3
     """
     return unicode_type(int(time.time()))
 
@@ -257,7 +257,7 @@ def generate_client_id(length=30, chars=CLIENT_ID_CHARACTER_SET):
     """Generates an OAuth client_id
 
     OAuth 2 specify the format of client_id in
-    http://tools.ietf.org/html/rfc6749#appendix-A.
+    https://tools.ietf.org/html/rfc6749#appendix-A.
     """
     return generate_token(length, chars)
 

--- a/oauthlib/oauth1/rfc5849/__init__.py
+++ b/oauthlib/oauth1/rfc5849/__init__.py
@@ -119,7 +119,7 @@ class Client(object):
         replace any netloc part of the request argument's uri attribute
         value.
 
-        .. _`section 3.4.1.2`: http://tools.ietf.org/html/rfc5849#section-3.4.1.2
+        .. _`section 3.4.1.2`: https://tools.ietf.org/html/rfc5849#section-3.4.1.2
         """
         if self.signature_method == SIGNATURE_PLAINTEXT:
             # fast-path
@@ -297,7 +297,7 @@ class Client(object):
             raise ValueError(
                 'Body signatures may only be used with form-urlencoded content')
 
-        # We amend http://tools.ietf.org/html/rfc5849#section-3.4.1.3.1
+        # We amend https://tools.ietf.org/html/rfc5849#section-3.4.1.3.1
         # with the clause that parameters from body should only be included
         # in non GET or HEAD requests. Extracting the request body parameters
         # and including them in the signature base string would give semantic

--- a/oauthlib/oauth1/rfc5849/endpoints/access_token.py
+++ b/oauthlib/oauth1/rfc5849/endpoints/access_token.py
@@ -180,7 +180,7 @@ class AccessTokenEndpoint(BaseEndpoint):
         # token credentials to the client, and ensure that the temporary
         # credentials have not expired or been used before.  The server MUST
         # also verify the verification code received from the client.
-        # .. _`Section 3.2`: http://tools.ietf.org/html/rfc5849#section-3.2
+        # .. _`Section 3.2`: https://tools.ietf.org/html/rfc5849#section-3.2
         #
         # Note that early exit would enable resource owner authorization
         # verifier enumertion.

--- a/oauthlib/oauth1/rfc5849/endpoints/base.py
+++ b/oauthlib/oauth1/rfc5849/endpoints/base.py
@@ -127,7 +127,7 @@ class BaseEndpoint(object):
         # specification.  Implementers should review the Security
         # Considerations section (`Section 4`_) before deciding on which
         # method to support.
-        # .. _`Section 4`: http://tools.ietf.org/html/rfc5849#section-4
+        # .. _`Section 4`: https://tools.ietf.org/html/rfc5849#section-4
         if (not request.signature_method in
                 self.request_validator.allowed_signature_methods):
             raise errors.InvalidSignatureMethodError(
@@ -181,7 +181,7 @@ class BaseEndpoint(object):
         # ---- RSA Signature verification ----
         if request.signature_method == SIGNATURE_RSA:
             # The server verifies the signature per `[RFC3447] section 8.2.2`_
-            # .. _`[RFC3447] section 8.2.2`: http://tools.ietf.org/html/rfc3447#section-8.2.1
+            # .. _`[RFC3447] section 8.2.2`: https://tools.ietf.org/html/rfc3447#section-8.2.1
             rsa_key = self.request_validator.get_rsa_key(
                 request.client_key, request)
             valid_signature = signature.verify_rsa_sha1(request, rsa_key)
@@ -192,7 +192,7 @@ class BaseEndpoint(object):
             #   Recalculating the request signature independently as described in
             #   `Section 3.4`_ and comparing it to the value received from the
             #   client via the "oauth_signature" parameter.
-            # .. _`Section 3.4`: http://tools.ietf.org/html/rfc5849#section-3.4
+            # .. _`Section 3.4`: https://tools.ietf.org/html/rfc5849#section-3.4
             client_secret = self.request_validator.get_client_secret(
                 request.client_key, request)
             resource_owner_secret = None

--- a/oauthlib/oauth1/rfc5849/endpoints/request_token.py
+++ b/oauthlib/oauth1/rfc5849/endpoints/request_token.py
@@ -156,7 +156,7 @@ class RequestTokenEndpoint(BaseEndpoint):
         # However they could be seen as a scope or realm to which the
         # client has access and as such every client should be checked
         # to ensure it is authorized access to that scope or realm.
-        # .. _`realm`: http://tools.ietf.org/html/rfc2617#section-1.2
+        # .. _`realm`: https://tools.ietf.org/html/rfc2617#section-1.2
         #
         # Note that early exit would enable client realm access enumeration.
         #
@@ -178,7 +178,7 @@ class RequestTokenEndpoint(BaseEndpoint):
 
         # Callback is normally never required, except for requests for
         # a Temporary Credential as described in `Section 2.1`_
-        # .._`Section 2.1`: http://tools.ietf.org/html/rfc5849#section-2.1
+        # .._`Section 2.1`: https://tools.ietf.org/html/rfc5849#section-2.1
         valid_redirect = self.request_validator.validate_redirect_uri(
             request.client_key, request.redirect_uri, request)
         if not request.redirect_uri:

--- a/oauthlib/oauth1/rfc5849/endpoints/resource.py
+++ b/oauthlib/oauth1/rfc5849/endpoints/resource.py
@@ -119,7 +119,7 @@ class ResourceEndpoint(BaseEndpoint):
         # However they could be seen as a scope or realm to which the
         # client has access and as such every client should be checked
         # to ensure it is authorized access to that scope or realm.
-        # .. _`realm`: http://tools.ietf.org/html/rfc2617#section-1.2
+        # .. _`realm`: https://tools.ietf.org/html/rfc2617#section-1.2
         #
         # Note that early exit would enable client realm access enumeration.
         #

--- a/oauthlib/oauth1/rfc5849/parameters.py
+++ b/oauthlib/oauth1/rfc5849/parameters.py
@@ -5,7 +5,7 @@ oauthlib.parameters
 
 This module contains methods related to `section 3.5`_ of the OAuth 1.0a spec.
 
-.. _`section 3.5`: http://tools.ietf.org/html/rfc5849#section-3.5
+.. _`section 3.5`: https://tools.ietf.org/html/rfc5849#section-3.5
 """
 from __future__ import absolute_import, unicode_literals
 
@@ -42,8 +42,8 @@ def prepare_headers(oauth_params, headers=None, realm=None):
             oauth_version="1.0"
 
 
-    .. _`section 3.5.1`: http://tools.ietf.org/html/rfc5849#section-3.5.1
-    .. _`RFC2617`: http://tools.ietf.org/html/rfc2617
+    .. _`section 3.5.1`: https://tools.ietf.org/html/rfc5849#section-3.5.1
+    .. _`RFC2617`: https://tools.ietf.org/html/rfc2617
     """
     headers = headers or {}
 
@@ -54,7 +54,7 @@ def prepare_headers(oauth_params, headers=None, realm=None):
         # 1.  Parameter names and values are encoded per Parameter Encoding
         #     (`Section 3.6`_)
         #
-        # .. _`Section 3.6`: http://tools.ietf.org/html/rfc5849#section-3.6
+        # .. _`Section 3.6`: https://tools.ietf.org/html/rfc5849#section-3.6
         escaped_name = utils.escape(oauth_parameter_name)
         escaped_value = utils.escape(value)
 
@@ -68,14 +68,14 @@ def prepare_headers(oauth_params, headers=None, realm=None):
     # 3.  Parameters are separated by a "," character (ASCII code 44) and
     #     OPTIONAL linear whitespace per `RFC2617`_.
     #
-    # .. _`RFC2617`: http://tools.ietf.org/html/rfc2617
+    # .. _`RFC2617`: https://tools.ietf.org/html/rfc2617
     authorization_header_parameters = ', '.join(
         authorization_header_parameters_parts)
 
     # 4.  The OPTIONAL "realm" parameter MAY be added and interpreted per
     #     `RFC2617 section 1.2`_.
     #
-    # .. _`RFC2617 section 1.2`: http://tools.ietf.org/html/rfc2617#section-1.2
+    # .. _`RFC2617 section 1.2`: https://tools.ietf.org/html/rfc2617#section-1.2
     if realm:
         # NOTE: realm should *not* be escaped
         authorization_header_parameters = ('realm="%s", ' % realm +
@@ -98,8 +98,8 @@ def _append_params(oauth_params, params):
 
     Per `section 3.5.2`_ and `3.5.3`_ of the spec.
 
-    .. _`section 3.5.2`: http://tools.ietf.org/html/rfc5849#section-3.5.2
-    .. _`3.5.3`: http://tools.ietf.org/html/rfc5849#section-3.5.3
+    .. _`section 3.5.2`: https://tools.ietf.org/html/rfc5849#section-3.5.2
+    .. _`3.5.3`: https://tools.ietf.org/html/rfc5849#section-3.5.3
 
     """
     merged = list(params)
@@ -117,7 +117,7 @@ def prepare_form_encoded_body(oauth_params, body):
 
     Per `section 3.5.2`_ of the spec.
 
-    .. _`section 3.5.2`: http://tools.ietf.org/html/rfc5849#section-3.5.2
+    .. _`section 3.5.2`: https://tools.ietf.org/html/rfc5849#section-3.5.2
 
     """
     # append OAuth params to the existing body
@@ -129,7 +129,7 @@ def prepare_request_uri_query(oauth_params, uri):
 
     Per `section 3.5.3`_ of the spec.
 
-    .. _`section 3.5.3`: http://tools.ietf.org/html/rfc5849#section-3.5.3
+    .. _`section 3.5.3`: https://tools.ietf.org/html/rfc5849#section-3.5.3
 
     """
     # append OAuth params to the existing set of query components

--- a/oauthlib/oauth1/rfc5849/request_validator.py
+++ b/oauthlib/oauth1/rfc5849/request_validator.py
@@ -109,7 +109,7 @@ class RequestValidator(object):
     their use more straightforward and as such it could be worth reading what
     follows in chronological order.
 
-    .. _`whitelisting or blacklisting`: http://www.schneier.com/blog/archives/2011/01/whitelisting_vs.html
+    .. _`whitelisting or blacklisting`: https://www.schneier.com/blog/archives/2011/01/whitelisting_vs.html
     """
 
     def __init__(self):
@@ -445,7 +445,7 @@ class RequestValidator(object):
         "The server MUST (...) ensure that the temporary
         credentials have not expired or been used before."
 
-        .. _`Section 2.3`: http://tools.ietf.org/html/rfc5849#section-2.3
+        .. _`Section 2.3`: https://tools.ietf.org/html/rfc5849#section-2.3
 
         This method should ensure that provided token won't validate anymore.
         It can be simply removing RequestToken from storage or setting
@@ -582,7 +582,7 @@ class RequestValidator(object):
         channel.  The nonce value MUST be unique across all requests with the
         same timestamp, client credentials, and token combinations."
 
-        .. _`Section 3.3`: http://tools.ietf.org/html/rfc5849#section-3.3
+        .. _`Section 3.3`: https://tools.ietf.org/html/rfc5849#section-3.3
 
         One of the first validation checks that will be made is for the validity
         of the nonce and timestamp, which are associated with a client key and

--- a/oauthlib/oauth1/rfc5849/signature.py
+++ b/oauthlib/oauth1/rfc5849/signature.py
@@ -19,7 +19,7 @@ Steps for signing a request:
    construct the base string
 5. Pass the base string and any keys needed to a signing function
 
-.. _`section 3.4`: http://tools.ietf.org/html/rfc5849#section-3.4
+.. _`section 3.4`: https://tools.ietf.org/html/rfc5849#section-3.4
 """
 from __future__ import absolute_import, unicode_literals
 
@@ -69,7 +69,7 @@ def construct_base_string(http_method, base_string_uri,
         ethod%3DHMAC-SHA1%26oauth_timestamp%3D137131201%26oauth_token%3Dkkk
         9d7dh3k39sjv7
 
-    .. _`section 3.4.1.1`: http://tools.ietf.org/html/rfc5849#section-3.4.1.1
+    .. _`section 3.4.1.1`: https://tools.ietf.org/html/rfc5849#section-3.4.1.1
     """
 
     # The signature base string is constructed by concatenating together,
@@ -79,7 +79,7 @@ def construct_base_string(http_method, base_string_uri,
     #     "GET", "POST", etc.  If the request uses a custom HTTP method, it
     #     MUST be encoded (`Section 3.6`_).
     #
-    # .. _`Section 3.6`: http://tools.ietf.org/html/rfc5849#section-3.6
+    # .. _`Section 3.6`: https://tools.ietf.org/html/rfc5849#section-3.6
     base_string = utils.escape(http_method.upper())
 
     # 2.  An "&" character (ASCII code 38).
@@ -88,8 +88,8 @@ def construct_base_string(http_method, base_string_uri,
     # 3.  The base string URI from `Section 3.4.1.2`_, after being encoded
     #     (`Section 3.6`_).
     #
-    # .. _`Section 3.4.1.2`: http://tools.ietf.org/html/rfc5849#section-3.4.1.2
-    # .. _`Section 3.4.6`: http://tools.ietf.org/html/rfc5849#section-3.4.6
+    # .. _`Section 3.4.1.2`: https://tools.ietf.org/html/rfc5849#section-3.4.1.2
+    # .. _`Section 3.4.6`: https://tools.ietf.org/html/rfc5849#section-3.4.6
     base_string += utils.escape(base_string_uri)
 
     # 4.  An "&" character (ASCII code 38).
@@ -98,8 +98,8 @@ def construct_base_string(http_method, base_string_uri,
     # 5.  The request parameters as normalized in `Section 3.4.1.3.2`_, after
     #     being encoded (`Section 3.6`).
     #
-    # .. _`Section 3.4.1.3.2`: http://tools.ietf.org/html/rfc5849#section-3.4.1.3.2
-    # .. _`Section 3.4.6`: http://tools.ietf.org/html/rfc5849#section-3.4.6
+    # .. _`Section 3.4.1.3.2`: https://tools.ietf.org/html/rfc5849#section-3.4.1.3.2
+    # .. _`Section 3.4.6`: https://tools.ietf.org/html/rfc5849#section-3.4.6
     base_string += utils.escape(normalized_encoded_request_parameters)
 
     return base_string
@@ -123,7 +123,7 @@ def normalize_base_string_uri(uri, host=None):
 
     is represented by the base string URI: "https://www.example.net:8080/".
 
-    .. _`section 3.4.1.2`: http://tools.ietf.org/html/rfc5849#section-3.4.1.2
+    .. _`section 3.4.1.2`: https://tools.ietf.org/html/rfc5849#section-3.4.1.2
 
     The host argument overrides the netloc part of the uri argument.
     """
@@ -137,7 +137,7 @@ def normalize_base_string_uri(uri, host=None):
     # are included by constructing an "http" or "https" URI representing
     # the request resource (without the query or fragment) as follows:
     #
-    # .. _`RFC3986`: http://tools.ietf.org/html/rfc3986
+    # .. _`RFC3986`: https://tools.ietf.org/html/rfc3986
 
     if not scheme or not netloc:
         raise ValueError('uri must include a scheme and netloc')
@@ -147,7 +147,7 @@ def normalize_base_string_uri(uri, host=None):
     # Note that the absolute path cannot be empty; if none is present in
     # the original URI, it MUST be given as "/" (the server root).
     #
-    # .. _`RFC 2616 section 5.1.2`: http://tools.ietf.org/html/rfc2616#section-5.1.2
+    # .. _`RFC 2616 section 5.1.2`: https://tools.ietf.org/html/rfc2616#section-5.1.2
     if not path:
         path = '/'
 
@@ -166,8 +166,8 @@ def normalize_base_string_uri(uri, host=None):
     #     to port 80 or when making an HTTPS request `RFC2818`_ to port 443.
     #     All other non-default port numbers MUST be included.
     #
-    # .. _`RFC2616`: http://tools.ietf.org/html/rfc2616
-    # .. _`RFC2818`: http://tools.ietf.org/html/rfc2818
+    # .. _`RFC2616`: https://tools.ietf.org/html/rfc2616
+    # .. _`RFC2818`: https://tools.ietf.org/html/rfc2818
     default_ports = (
         ('http', '80'),
         ('https', '443'),
@@ -190,7 +190,7 @@ def normalize_base_string_uri(uri, host=None):
 #    particular manner that is often different from their original
 #    encoding scheme, and concatenated into a single string.
 #
-# .. _`section 3.4.1.3`: http://tools.ietf.org/html/rfc5849#section-3.4.1.3
+# .. _`section 3.4.1.3`: https://tools.ietf.org/html/rfc5849#section-3.4.1.3
 
 def collect_parameters(uri_query='', body=[], headers=None,
                        exclude_oauth_signature=True, with_realm=False):
@@ -249,7 +249,7 @@ def collect_parameters(uri_query='', body=[], headers=None,
     parameter instances (the "a3" parameter is used twice in this
     request).
 
-    .. _`section 3.4.1.3.1`: http://tools.ietf.org/html/rfc5849#section-3.4.1.3.1
+    .. _`section 3.4.1.3.1`: https://tools.ietf.org/html/rfc5849#section-3.4.1.3.1
     """
     headers = headers or {}
     params = []
@@ -264,8 +264,8 @@ def collect_parameters(uri_query='', body=[], headers=None,
     #    and values and decoding them as defined by
     #    `W3C.REC-html40-19980424`_, Section 17.13.4.
     #
-    # .. _`RFC3986, Section 3.4`: http://tools.ietf.org/html/rfc3986#section-3.4
-    # .. _`W3C.REC-html40-19980424`: http://tools.ietf.org/html/rfc5849#ref-W3C.REC-html40-19980424
+    # .. _`RFC3986, Section 3.4`: https://tools.ietf.org/html/rfc3986#section-3.4
+    # .. _`W3C.REC-html40-19980424`: https://tools.ietf.org/html/rfc5849#ref-W3C.REC-html40-19980424
     if uri_query:
         params.extend(urldecode(uri_query))
 
@@ -274,7 +274,7 @@ def collect_parameters(uri_query='', body=[], headers=None,
     #    pairs excluding the "realm" parameter if present.  The parameter
     #    values are decoded as defined by `Section 3.5.1`_.
     #
-    # .. _`Section 3.5.1`: http://tools.ietf.org/html/rfc5849#section-3.5.1
+    # .. _`Section 3.5.1`: https://tools.ietf.org/html/rfc5849#section-3.5.1
     if headers:
         headers_lower = dict((k.lower(), v) for k, v in headers.items())
         authorization_header = headers_lower.get('authorization')
@@ -293,7 +293,7 @@ def collect_parameters(uri_query='', body=[], headers=None,
     #     *  The HTTP request entity-header includes the "Content-Type"
     #        header field set to "application/x-www-form-urlencoded".
     #
-    # .._`W3C.REC-html40-19980424`: http://tools.ietf.org/html/rfc5849#ref-W3C.REC-html40-19980424
+    # .._`W3C.REC-html40-19980424`: https://tools.ietf.org/html/rfc5849#ref-W3C.REC-html40-19980424
 
     # TODO: enforce header param inclusion conditions
     bodyparams = extract_params(body) or []
@@ -383,18 +383,18 @@ def normalize_parameters(params):
         dj82h48djs9d2&oauth_nonce=7d8f3e4a&oauth_signature_method=HMAC-SHA1
         &oauth_timestamp=137131201&oauth_token=kkk9d7dh3k39sjv7
 
-    .. _`section 3.4.1.3.2`: http://tools.ietf.org/html/rfc5849#section-3.4.1.3.2
+    .. _`section 3.4.1.3.2`: https://tools.ietf.org/html/rfc5849#section-3.4.1.3.2
     """
 
     # The parameters collected in `Section 3.4.1.3`_ are normalized into a
     # single string as follows:
     #
-    # .. _`Section 3.4.1.3`: http://tools.ietf.org/html/rfc5849#section-3.4.1.3
+    # .. _`Section 3.4.1.3`: https://tools.ietf.org/html/rfc5849#section-3.4.1.3
 
     # 1.  First, the name and value of each parameter are encoded
     #     (`Section 3.6`_).
     #
-    # .. _`Section 3.6`: http://tools.ietf.org/html/rfc5849#section-3.6
+    # .. _`Section 3.6`: https://tools.ietf.org/html/rfc5849#section-3.6
     key_values = [(utils.escape(k), utils.escape(v)) for k, v in params]
 
     # 2.  The parameters are sorted by name, using ascending byte value
@@ -430,8 +430,8 @@ def sign_hmac_sha1(base_string, client_secret, resource_owner_secret):
 
     Per `section 3.4.2`_ of the spec.
 
-    .. _`RFC2104`: http://tools.ietf.org/html/rfc2104
-    .. _`section 3.4.2`: http://tools.ietf.org/html/rfc5849#section-3.4.2
+    .. _`RFC2104`: https://tools.ietf.org/html/rfc2104
+    .. _`section 3.4.2`: https://tools.ietf.org/html/rfc5849#section-3.4.2
     """
 
     # The HMAC-SHA1 function variables are used in following way:
@@ -439,13 +439,13 @@ def sign_hmac_sha1(base_string, client_secret, resource_owner_secret):
     # text is set to the value of the signature base string from
     # `Section 3.4.1.1`_.
     #
-    # .. _`Section 3.4.1.1`: http://tools.ietf.org/html/rfc5849#section-3.4.1.1
+    # .. _`Section 3.4.1.1`: https://tools.ietf.org/html/rfc5849#section-3.4.1.1
     text = base_string
 
     # key is set to the concatenated values of:
     # 1.  The client shared-secret, after being encoded (`Section 3.6`_).
     #
-    # .. _`Section 3.6`: http://tools.ietf.org/html/rfc5849#section-3.6
+    # .. _`Section 3.6`: https://tools.ietf.org/html/rfc5849#section-3.6
     key = utils.escape(client_secret or '')
 
     # 2.  An "&" character (ASCII code 38), which MUST be included
@@ -454,7 +454,7 @@ def sign_hmac_sha1(base_string, client_secret, resource_owner_secret):
 
     # 3.  The token shared-secret, after being encoded (`Section 3.6`_).
     #
-    # .. _`Section 3.6`: http://tools.ietf.org/html/rfc5849#section-3.6
+    # .. _`Section 3.6`: https://tools.ietf.org/html/rfc5849#section-3.6
     key += utils.escape(resource_owner_secret or '')
 
     # FIXME: HMAC does not support unicode!
@@ -466,7 +466,7 @@ def sign_hmac_sha1(base_string, client_secret, resource_owner_secret):
     #         parameter, after the result octet string is base64-encoded
     #         per `RFC2045, Section 6.8`.
     #
-    # .. _`RFC2045, Section 6.8`: http://tools.ietf.org/html/rfc2045#section-6.8
+    # .. _`RFC2045, Section 6.8`: https://tools.ietf.org/html/rfc2045#section-6.8
     return binascii.b2a_base64(signature.digest())[:-1].decode('utf-8')
 
 _jwtrs1 = None
@@ -491,8 +491,8 @@ def sign_rsa_sha1(base_string, rsa_private_key):
     with the server that included its RSA public key (in a manner that is
     beyond the scope of this specification).
 
-    .. _`section 3.4.3`: http://tools.ietf.org/html/rfc5849#section-3.4.3
-    .. _`RFC3447, Section 8.2`: http://tools.ietf.org/html/rfc3447#section-8.2
+    .. _`section 3.4.3`: https://tools.ietf.org/html/rfc5849#section-3.4.3
+    .. _`RFC3447, Section 8.2`: https://tools.ietf.org/html/rfc3447#section-8.2
 
     """
     if isinstance(base_string, unicode_type):
@@ -521,7 +521,7 @@ def sign_plaintext(client_secret, resource_owner_secret):
     utilize the signature base string or the "oauth_timestamp" and
     "oauth_nonce" parameters.
 
-    .. _`section 3.4.4`: http://tools.ietf.org/html/rfc5849#section-3.4.4
+    .. _`section 3.4.4`: https://tools.ietf.org/html/rfc5849#section-3.4.4
 
     """
 
@@ -530,7 +530,7 @@ def sign_plaintext(client_secret, resource_owner_secret):
 
     # 1.  The client shared-secret, after being encoded (`Section 3.6`_).
     #
-    # .. _`Section 3.6`: http://tools.ietf.org/html/rfc5849#section-3.6
+    # .. _`Section 3.6`: https://tools.ietf.org/html/rfc5849#section-3.6
     signature = utils.escape(client_secret or '')
 
     # 2.  An "&" character (ASCII code 38), which MUST be included even
@@ -539,7 +539,7 @@ def sign_plaintext(client_secret, resource_owner_secret):
 
     # 3.  The token shared-secret, after being encoded (`Section 3.6`_).
     #
-    # .. _`Section 3.6`: http://tools.ietf.org/html/rfc5849#section-3.6
+    # .. _`Section 3.6`: https://tools.ietf.org/html/rfc5849#section-3.6
     signature += utils.escape(resource_owner_secret or '')
 
     return signature
@@ -555,7 +555,7 @@ def verify_hmac_sha1(request, client_secret=None,
 
     Per `section 3.4`_ of the spec.
 
-    .. _`section 3.4`: http://tools.ietf.org/html/rfc5849#section-3.4
+    .. _`section 3.4`: https://tools.ietf.org/html/rfc5849#section-3.4
 
     To satisfy `RFC2616 section 5.2`_ item 1, the request argument's uri
     attribute MUST be an absolute URI whose netloc part identifies the
@@ -563,7 +563,7 @@ def verify_hmac_sha1(request, client_secret=None,
     item of the request argument's headers dict attribute will be
     ignored.
 
-    .. _`RFC2616 section 5.2`: http://tools.ietf.org/html/rfc2616#section-5.2
+    .. _`RFC2616 section 5.2`: https://tools.ietf.org/html/rfc2616#section-5.2
 
     """
     norm_params = normalize_parameters(request.params)
@@ -589,7 +589,7 @@ def verify_rsa_sha1(request, rsa_public_key):
 
     Note this method requires the jwt and cryptography libraries.
 
-    .. _`section 3.4.3`: http://tools.ietf.org/html/rfc5849#section-3.4.3
+    .. _`section 3.4.3`: https://tools.ietf.org/html/rfc5849#section-3.4.3
 
     To satisfy `RFC2616 section 5.2`_ item 1, the request argument's uri
     attribute MUST be an absolute URI whose netloc part identifies the
@@ -597,7 +597,7 @@ def verify_rsa_sha1(request, rsa_public_key):
     item of the request argument's headers dict attribute will be
     ignored.
 
-    .. _`RFC2616 section 5.2`: http://tools.ietf.org/html/rfc2616#section-5.2
+    .. _`RFC2616 section 5.2`: https://tools.ietf.org/html/rfc2616#section-5.2
     """
     norm_params = normalize_parameters(request.params)
     uri = normalize_base_string_uri(request.uri)
@@ -618,7 +618,7 @@ def verify_plaintext(request, client_secret=None, resource_owner_secret=None):
 
     Per `section 3.4`_ of the spec.
 
-    .. _`section 3.4`: http://tools.ietf.org/html/rfc5849#section-3.4
+    .. _`section 3.4`: https://tools.ietf.org/html/rfc5849#section-3.4
     """
     signature = sign_plaintext(client_secret, resource_owner_secret)
     match = safe_string_equals(signature, request.signature)

--- a/oauthlib/oauth1/rfc5849/utils.py
+++ b/oauthlib/oauth1/rfc5849/utils.py
@@ -49,7 +49,7 @@ def escape(u):
 
     Per `section 3.6`_ of the spec.
 
-    .. _`section 3.6`: http://tools.ietf.org/html/rfc5849#section-3.6
+    .. _`section 3.6`: https://tools.ietf.org/html/rfc5849#section-3.6
 
     """
     if not isinstance(u, unicode_type):

--- a/oauthlib/oauth2/rfc6749/clients/backend_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/backend_application.py
@@ -52,9 +52,9 @@ class BackendApplicationClient(Client):
             >>> client.prepare_request_body(scope=['hello', 'world'])
             'grant_type=client_credentials&scope=hello+world'
 
-        .. _`Appendix B`: http://tools.ietf.org/html/rfc6749#appendix-B
-        .. _`Section 3.3`: http://tools.ietf.org/html/rfc6749#section-3.3
-        .. _`Section 3.2.1`: http://tools.ietf.org/html/rfc6749#section-3.2.1
+        .. _`Appendix B`: https://tools.ietf.org/html/rfc6749#appendix-B
+        .. _`Section 3.3`: https://tools.ietf.org/html/rfc6749#section-3.3
+        .. _`Section 3.2.1`: https://tools.ietf.org/html/rfc6749#section-3.2.1
         """
         return prepare_token_request('client_credentials', body=body,
                                      scope=scope, **kwargs)

--- a/oauthlib/oauth2/rfc6749/clients/base.py
+++ b/oauthlib/oauth2/rfc6749/clients/base.py
@@ -173,8 +173,8 @@ class Client(object):
                                 nonce="274312:dj83hs9s",
                                 mac="kDZvddkndxvhGRXZhvuDjEWhGeE="
 
-        .. _`I-D.ietf-oauth-v2-bearer`: http://tools.ietf.org/html/rfc6749#section-12.2
-        .. _`I-D.ietf-oauth-v2-http-mac`: http://tools.ietf.org/html/rfc6749#section-12.2
+        .. _`I-D.ietf-oauth-v2-bearer`: https://tools.ietf.org/html/rfc6749#section-12.2
+        .. _`I-D.ietf-oauth-v2-http-mac`: https://tools.ietf.org/html/rfc6749#section-12.2
         """
         if not is_secure_transport(uri):
             raise InsecureTransportError()
@@ -401,9 +401,9 @@ class Client(object):
             Providers may supply this in all responses but are required to only
             if it has changed since the authorization request.
 
-        .. _`Section 5.1`: http://tools.ietf.org/html/rfc6749#section-5.1
-        .. _`Section 5.2`: http://tools.ietf.org/html/rfc6749#section-5.2
-        .. _`Section 7.1`: http://tools.ietf.org/html/rfc6749#section-7.1
+        .. _`Section 5.1`: https://tools.ietf.org/html/rfc6749#section-5.1
+        .. _`Section 5.2`: https://tools.ietf.org/html/rfc6749#section-5.2
+        .. _`Section 7.1`: https://tools.ietf.org/html/rfc6749#section-7.1
         """
         self.token = parse_token_response(body, scope=scope)
         self._populate_attributes(self.token)

--- a/oauthlib/oauth2/rfc6749/clients/base.py
+++ b/oauthlib/oauth2/rfc6749/clients/base.py
@@ -186,7 +186,7 @@ class Client(object):
         if not self.token_type.lower() in case_insensitive_token_types:
             raise ValueError("Unsupported token type: %s" % self.token_type)
 
-        if not self.access_token:
+        if not (self.access_token or self.token.get('access_token')):
             raise ValueError("Missing access token.")
 
         if self._expires_at and self._expires_at < time.time():

--- a/oauthlib/oauth2/rfc6749/clients/legacy_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/legacy_application.py
@@ -64,9 +64,9 @@ class LegacyApplicationClient(Client):
             >>> client.prepare_request_body(username='foo', password='bar', scope=['hello', 'world'])
             'grant_type=password&username=foo&scope=hello+world&password=bar'
 
-        .. _`Appendix B`: http://tools.ietf.org/html/rfc6749#appendix-B
-        .. _`Section 3.3`: http://tools.ietf.org/html/rfc6749#section-3.3
-        .. _`Section 3.2.1`: http://tools.ietf.org/html/rfc6749#section-3.2.1
+        .. _`Appendix B`: https://tools.ietf.org/html/rfc6749#appendix-B
+        .. _`Section 3.3`: https://tools.ietf.org/html/rfc6749#section-3.3
+        .. _`Section 3.2.1`: https://tools.ietf.org/html/rfc6749#section-3.2.1
         """
         return prepare_token_request('password', body=body, username=username,
                                      password=password, scope=scope, **kwargs)

--- a/oauthlib/oauth2/rfc6749/clients/mobile_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/mobile_application.py
@@ -85,11 +85,11 @@ class MobileApplicationClient(Client):
             >>> client.prepare_request_uri('https://example.com', foo='bar')
             'https://example.com?client_id=your_id&response_type=token&foo=bar'
 
-        .. _`Appendix B`: http://tools.ietf.org/html/rfc6749#appendix-B
-        .. _`Section 2.2`: http://tools.ietf.org/html/rfc6749#section-2.2
-        .. _`Section 3.1.2`: http://tools.ietf.org/html/rfc6749#section-3.1.2
-        .. _`Section 3.3`: http://tools.ietf.org/html/rfc6749#section-3.3
-        .. _`Section 10.12`: http://tools.ietf.org/html/rfc6749#section-10.12
+        .. _`Appendix B`: https://tools.ietf.org/html/rfc6749#appendix-B
+        .. _`Section 2.2`: https://tools.ietf.org/html/rfc6749#section-2.2
+        .. _`Section 3.1.2`: https://tools.ietf.org/html/rfc6749#section-3.1.2
+        .. _`Section 3.3`: https://tools.ietf.org/html/rfc6749#section-3.3
+        .. _`Section 10.12`: https://tools.ietf.org/html/rfc6749#section-10.12
         """
         return prepare_grant_uri(uri, self.client_id, 'token',
                                  redirect_uri=redirect_uri, state=state, scope=scope, **kwargs)
@@ -164,8 +164,8 @@ class MobileApplicationClient(Client):
             >>> client.parse_request_body_response(response_body, scope=['other'])
             ('Scope has changed from "other" to "hello world".', ['other'], ['hello', 'world'])
 
-        .. _`Section 7.1`: http://tools.ietf.org/html/rfc6749#section-7.1
-        .. _`Section 3.3`: http://tools.ietf.org/html/rfc6749#section-3.3
+        .. _`Section 7.1`: https://tools.ietf.org/html/rfc6749#section-7.1
+        .. _`Section 3.3`: https://tools.ietf.org/html/rfc6749#section-3.3
         """
         self.token = parse_implicit_response(uri, state=state, scope=scope)
         self._populate_attributes(self.token)

--- a/oauthlib/oauth2/rfc6749/clients/service_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/service_application.py
@@ -136,7 +136,7 @@ class ServiceApplicationClient(Client):
             eyJpc3Mi[...omitted for brevity...].
             J9l-ZhwP[...omitted for brevity...]
 
-        .. _`Section 3.2.1`: http://tools.ietf.org/html/rfc6749#section-3.2.1
+        .. _`Section 3.2.1`: https://tools.ietf.org/html/rfc6749#section-3.2.1
         """
         import jwt
 

--- a/oauthlib/oauth2/rfc6749/clients/web_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/web_application.py
@@ -76,11 +76,11 @@ class WebApplicationClient(Client):
             >>> client.prepare_request_uri('https://example.com', foo='bar')
             'https://example.com?client_id=your_id&response_type=code&foo=bar'
 
-        .. _`Appendix B`: http://tools.ietf.org/html/rfc6749#appendix-B
-        .. _`Section 2.2`: http://tools.ietf.org/html/rfc6749#section-2.2
-        .. _`Section 3.1.2`: http://tools.ietf.org/html/rfc6749#section-3.1.2
-        .. _`Section 3.3`: http://tools.ietf.org/html/rfc6749#section-3.3
-        .. _`Section 10.12`: http://tools.ietf.org/html/rfc6749#section-10.12
+        .. _`Appendix B`: https://tools.ietf.org/html/rfc6749#appendix-B
+        .. _`Section 2.2`: https://tools.ietf.org/html/rfc6749#section-2.2
+        .. _`Section 3.1.2`: https://tools.ietf.org/html/rfc6749#section-3.1.2
+        .. _`Section 3.3`: https://tools.ietf.org/html/rfc6749#section-3.3
+        .. _`Section 10.12`: https://tools.ietf.org/html/rfc6749#section-10.12
         """
         return prepare_grant_uri(uri, self.client_id, 'code',
                                  redirect_uri=redirect_uri, scope=scope, state=state, **kwargs)
@@ -120,8 +120,8 @@ class WebApplicationClient(Client):
             >>> client.prepare_request_body(code='sh35ksdf09sf', foo='bar')
             'grant_type=authorization_code&code=sh35ksdf09sf&foo=bar'
 
-        .. _`Section 4.1.1`: http://tools.ietf.org/html/rfc6749#section-4.1.1
-        .. _`Section 3.2.1`: http://tools.ietf.org/html/rfc6749#section-3.2.1
+        .. _`Section 4.1.1`: https://tools.ietf.org/html/rfc6749#section-4.1.1
+        .. _`Section 3.2.1`: https://tools.ietf.org/html/rfc6749#section-3.2.1
         """
         code = code or self.code
         return prepare_token_request('authorization_code', code=code, body=body,

--- a/oauthlib/oauth2/rfc6749/endpoints/authorization.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/authorization.py
@@ -59,7 +59,7 @@ class AuthorizationEndpoint(BaseEndpoint):
 
         # Enforced through the design of oauthlib.common.Request
 
-    .. _`Appendix B`: http://tools.ietf.org/html/rfc6749#appendix-B
+    .. _`Appendix B`: https://tools.ietf.org/html/rfc6749#appendix-B
     """
 
     def __init__(self, default_response_type, default_token_type,

--- a/oauthlib/oauth2/rfc6749/endpoints/revocation.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/revocation.py
@@ -5,7 +5,7 @@ oauthlib.oauth2.rfc6749.endpoint.revocation
 
 An implementation of the OAuth 2 `Token Revocation`_ spec (draft 11).
 
-.. _`Token Revocation`: http://tools.ietf.org/html/draft-ietf-oauth-revocation-11
+.. _`Token Revocation`: https://tools.ietf.org/html/draft-ietf-oauth-revocation-11
 """
 from __future__ import absolute_import, unicode_literals
 
@@ -110,11 +110,11 @@ class RevocationEndpoint(BaseEndpoint):
         The client also includes its authentication credentials as described in
         `Section 2.3`_. of [`RFC6749`_].
 
-        .. _`section 1.4`: http://tools.ietf.org/html/rfc6749#section-1.4
-        .. _`section 1.5`: http://tools.ietf.org/html/rfc6749#section-1.5
-        .. _`section 2.3`: http://tools.ietf.org/html/rfc6749#section-2.3
-        .. _`Section 4.1.2`: http://tools.ietf.org/html/draft-ietf-oauth-revocation-11#section-4.1.2
-        .. _`RFC6749`: http://tools.ietf.org/html/rfc6749
+        .. _`section 1.4`: https://tools.ietf.org/html/rfc6749#section-1.4
+        .. _`section 1.5`: https://tools.ietf.org/html/rfc6749#section-1.5
+        .. _`section 2.3`: https://tools.ietf.org/html/rfc6749#section-2.3
+        .. _`Section 4.1.2`: https://tools.ietf.org/html/draft-ietf-oauth-revocation-11#section-4.1.2
+        .. _`RFC6749`: https://tools.ietf.org/html/rfc6749
         """
         if not request.token:
             raise InvalidRequestError(request=request,

--- a/oauthlib/oauth2/rfc6749/endpoints/token.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/token.py
@@ -59,7 +59,7 @@ class TokenEndpoint(BaseEndpoint):
 
         # Delegated to each grant type.
 
-    .. _`Appendix B`: http://tools.ietf.org/html/rfc6749#appendix-B
+    .. _`Appendix B`: https://tools.ietf.org/html/rfc6749#appendix-B
     """
 
     def __init__(self, default_grant_type, default_token_type, grant_types):

--- a/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
@@ -91,7 +91,7 @@ class AuthorizationCodeGrant(GrantTypeBase):
          step (C).  If valid, the authorization server responds back with
          an access token and, optionally, a refresh token.
 
-    .. _`Authorization Code Grant`: http://tools.ietf.org/html/rfc6749#section-4.1
+    .. _`Authorization Code Grant`: https://tools.ietf.org/html/rfc6749#section-4.1
     """
 
     default_response_mode = 'query'
@@ -175,11 +175,11 @@ class AuthorizationCodeGrant(GrantTypeBase):
                 File "oauthlib/oauth2/rfc6749/grant_types.py", line 591, in validate_authorization_request
             oauthlib.oauth2.rfc6749.errors.InvalidClientIdError
 
-        .. _`Appendix B`: http://tools.ietf.org/html/rfc6749#appendix-B
-        .. _`Section 2.2`: http://tools.ietf.org/html/rfc6749#section-2.2
-        .. _`Section 3.1.2`: http://tools.ietf.org/html/rfc6749#section-3.1.2
-        .. _`Section 3.3`: http://tools.ietf.org/html/rfc6749#section-3.3
-        .. _`Section 10.12`: http://tools.ietf.org/html/rfc6749#section-10.12
+        .. _`Appendix B`: https://tools.ietf.org/html/rfc6749#appendix-B
+        .. _`Section 2.2`: https://tools.ietf.org/html/rfc6749#section-2.2
+        .. _`Section 3.1.2`: https://tools.ietf.org/html/rfc6749#section-3.1.2
+        .. _`Section 3.3`: https://tools.ietf.org/html/rfc6749#section-3.3
+        .. _`Section 10.12`: https://tools.ietf.org/html/rfc6749#section-10.12
         """
         try:
             # request.scopes is only mandated in post auth and both pre and
@@ -206,7 +206,7 @@ class AuthorizationCodeGrant(GrantTypeBase):
         # the authorization server informs the client by adding the following
         # parameters to the query component of the redirection URI using the
         # "application/x-www-form-urlencoded" format, per Appendix B:
-        # http://tools.ietf.org/html/rfc6749#appendix-B
+        # https://tools.ietf.org/html/rfc6749#appendix-B
         except errors.OAuth2Error as e:
             log.debug('Client error during validation of %r. %r.', request, e)
             request.redirect_uri = request.redirect_uri or self.error_uri
@@ -285,7 +285,7 @@ class AuthorizationCodeGrant(GrantTypeBase):
                 raise errors.InvalidRequestFatalError(description='Duplicate %s parameter.' % param, request=request)
 
         # REQUIRED. The client identifier as described in Section 2.2.
-        # http://tools.ietf.org/html/rfc6749#section-2.2
+        # https://tools.ietf.org/html/rfc6749#section-2.2
         if not request.client_id:
             raise errors.MissingClientIdError(request=request)
 
@@ -293,7 +293,7 @@ class AuthorizationCodeGrant(GrantTypeBase):
             raise errors.InvalidClientIdError(request=request)
 
         # OPTIONAL. As described in Section 3.1.2.
-        # http://tools.ietf.org/html/rfc6749#section-3.1.2
+        # https://tools.ietf.org/html/rfc6749#section-3.1.2
         log.debug('Validating redirection uri %s for client %s.',
                   request.redirect_uri, request.client_id)
         if request.redirect_uri is not None:
@@ -320,7 +320,7 @@ class AuthorizationCodeGrant(GrantTypeBase):
         # the authorization server informs the client by adding the following
         # parameters to the query component of the redirection URI using the
         # "application/x-www-form-urlencoded" format, per Appendix B.
-        # http://tools.ietf.org/html/rfc6749#appendix-B
+        # https://tools.ietf.org/html/rfc6749#appendix-B
 
         # Note that the correct parameters to be added are automatically
         # populated through the use of specific exceptions.
@@ -346,7 +346,7 @@ class AuthorizationCodeGrant(GrantTypeBase):
             raise errors.UnauthorizedClientError(request=request)
 
         # OPTIONAL. The scope of the access request as described by Section 3.3
-        # http://tools.ietf.org/html/rfc6749#section-3.3
+        # https://tools.ietf.org/html/rfc6749#section-3.3
         self.validate_scopes(request)
 
         request_info.update({
@@ -384,14 +384,14 @@ class AuthorizationCodeGrant(GrantTypeBase):
             # credentials (or assigned other authentication requirements), the
             # client MUST authenticate with the authorization server as described
             # in Section 3.2.1.
-            # http://tools.ietf.org/html/rfc6749#section-3.2.1
+            # https://tools.ietf.org/html/rfc6749#section-3.2.1
             if not self.request_validator.authenticate_client(request):
                 log.debug('Client authentication failed, %r.', request)
                 raise errors.InvalidClientError(request=request)
         elif not self.request_validator.authenticate_client_id(request.client_id, request):
             # REQUIRED, if the client is not authenticating with the
             # authorization server as described in Section 3.2.1.
-            # http://tools.ietf.org/html/rfc6749#section-3.2.1
+            # https://tools.ietf.org/html/rfc6749#section-3.2.1
             log.debug('Client authentication failed, %r.', request)
             raise errors.InvalidClientError(request=request)
 

--- a/oauthlib/oauth2/rfc6749/grant_types/client_credentials.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/client_credentials.py
@@ -47,7 +47,7 @@ class ClientCredentialsGrant(GrantTypeBase):
     (B)  The authorization server authenticates the client, and if valid,
             issues an access token.
 
-    .. _`Client Credentials Grant`: http://tools.ietf.org/html/rfc6749#section-4.4
+    .. _`Client Credentials Grant`: https://tools.ietf.org/html/rfc6749#section-4.4
     """
 
     def create_token_response(self, request, token_handler):
@@ -59,8 +59,8 @@ class ClientCredentialsGrant(GrantTypeBase):
         failed client authentication or is invalid, the authorization server
         returns an error response as described in `Section 5.2`_.
 
-        .. _`Section 5.1`: http://tools.ietf.org/html/rfc6749#section-5.1
-        .. _`Section 5.2`: http://tools.ietf.org/html/rfc6749#section-5.2
+        .. _`Section 5.1`: https://tools.ietf.org/html/rfc6749#section-5.1
+        .. _`Section 5.2`: https://tools.ietf.org/html/rfc6749#section-5.2
         """
         headers = {
             'Content-Type': 'application/json',

--- a/oauthlib/oauth2/rfc6749/grant_types/implicit.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/implicit.py
@@ -112,9 +112,9 @@ class ImplicitGrant(GrantTypeBase):
     See `Section 10.3`_ and `Section 10.16`_ for important security considerations
     when using the implicit grant.
 
-    .. _`Implicit Grant`: http://tools.ietf.org/html/rfc6749#section-4.2
-    .. _`Section 10.3`: http://tools.ietf.org/html/rfc6749#section-10.3
-    .. _`Section 10.16`: http://tools.ietf.org/html/rfc6749#section-10.16
+    .. _`Implicit Grant`: https://tools.ietf.org/html/rfc6749#section-4.2
+    .. _`Section 10.3`: https://tools.ietf.org/html/rfc6749#section-10.3
+    .. _`Section 10.16`: https://tools.ietf.org/html/rfc6749#section-10.16
     """
 
     response_types = ['token']
@@ -153,11 +153,11 @@ class ImplicitGrant(GrantTypeBase):
         access token matches a redirection URI registered by the client as
         described in `Section 3.1.2`_.
 
-        .. _`Section 2.2`: http://tools.ietf.org/html/rfc6749#section-2.2
-        .. _`Section 3.1.2`: http://tools.ietf.org/html/rfc6749#section-3.1.2
-        .. _`Section 3.3`: http://tools.ietf.org/html/rfc6749#section-3.3
-        .. _`Section 10.12`: http://tools.ietf.org/html/rfc6749#section-10.12
-        .. _`Appendix B`: http://tools.ietf.org/html/rfc6749#appendix-B
+        .. _`Section 2.2`: https://tools.ietf.org/html/rfc6749#section-2.2
+        .. _`Section 3.1.2`: https://tools.ietf.org/html/rfc6749#section-3.1.2
+        .. _`Section 3.3`: https://tools.ietf.org/html/rfc6749#section-3.3
+        .. _`Section 10.12`: https://tools.ietf.org/html/rfc6749#section-10.12
+        .. _`Appendix B`: https://tools.ietf.org/html/rfc6749#appendix-B
         """
         return self.create_token_response(request, token_handler)
 
@@ -196,9 +196,9 @@ class ImplicitGrant(GrantTypeBase):
 
         The authorization server MUST NOT issue a refresh token.
 
-        .. _`Appendix B`: http://tools.ietf.org/html/rfc6749#appendix-B
-        .. _`Section 3.3`: http://tools.ietf.org/html/rfc6749#section-3.3
-        .. _`Section 7.1`: http://tools.ietf.org/html/rfc6749#section-7.1
+        .. _`Appendix B`: https://tools.ietf.org/html/rfc6749#appendix-B
+        .. _`Section 3.3`: https://tools.ietf.org/html/rfc6749#section-3.3
+        .. _`Section 7.1`: https://tools.ietf.org/html/rfc6749#section-7.1
         """
         try:
             # request.scopes is only mandated in post auth and both pre and
@@ -223,7 +223,7 @@ class ImplicitGrant(GrantTypeBase):
         # the authorization server informs the client by adding the following
         # parameters to the fragment component of the redirection URI using the
         # "application/x-www-form-urlencoded" format, per Appendix B:
-        # http://tools.ietf.org/html/rfc6749#appendix-B
+        # https://tools.ietf.org/html/rfc6749#appendix-B
         except errors.OAuth2Error as e:
             log.debug('Client error during validation of %r. %r.', request, e)
             return {'Location': common.add_params_to_uri(request.redirect_uri, e.twotuples,
@@ -281,7 +281,7 @@ class ImplicitGrant(GrantTypeBase):
                 raise errors.InvalidRequestFatalError(description='Duplicate %s parameter.' % param, request=request)
 
         # REQUIRED. The client identifier as described in Section 2.2.
-        # http://tools.ietf.org/html/rfc6749#section-2.2
+        # https://tools.ietf.org/html/rfc6749#section-2.2
         if not request.client_id:
             raise errors.MissingClientIdError(request=request)
 
@@ -289,7 +289,7 @@ class ImplicitGrant(GrantTypeBase):
             raise errors.InvalidClientIdError(request=request)
 
         # OPTIONAL. As described in Section 3.1.2.
-        # http://tools.ietf.org/html/rfc6749#section-3.1.2
+        # https://tools.ietf.org/html/rfc6749#section-3.1.2
         if request.redirect_uri is not None:
             request.using_default_redirect_uri = False
             log.debug('Using provided redirect_uri %s', request.redirect_uri)
@@ -300,7 +300,7 @@ class ImplicitGrant(GrantTypeBase):
             # to which it will redirect the access token matches a
             # redirection URI registered by the client as described in
             # Section 3.1.2.
-            # http://tools.ietf.org/html/rfc6749#section-3.1.2
+            # https://tools.ietf.org/html/rfc6749#section-3.1.2
             if not self.request_validator.validate_redirect_uri(
                     request.client_id, request.redirect_uri, request):
                 raise errors.MismatchingRedirectURIError(request=request)
@@ -325,7 +325,7 @@ class ImplicitGrant(GrantTypeBase):
         # the authorization server informs the client by adding the following
         # parameters to the fragment component of the redirection URI using the
         # "application/x-www-form-urlencoded" format, per Appendix B.
-        # http://tools.ietf.org/html/rfc6749#appendix-B
+        # https://tools.ietf.org/html/rfc6749#appendix-B
 
         # Note that the correct parameters to be added are automatically
         # populated through the use of specific exceptions
@@ -348,7 +348,7 @@ class ImplicitGrant(GrantTypeBase):
             raise errors.UnauthorizedClientError(request=request)
 
         # OPTIONAL. The scope of the access request as described by Section 3.3
-        # http://tools.ietf.org/html/rfc6749#section-3.3
+        # https://tools.ietf.org/html/rfc6749#section-3.3
         self.validate_scopes(request)
 
         request_info.update({

--- a/oauthlib/oauth2/rfc6749/grant_types/refresh_token.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/refresh_token.py
@@ -19,7 +19,7 @@ class RefreshTokenGrant(GrantTypeBase):
 
     """`Refresh token grant`_
 
-    .. _`Refresh token grant`: http://tools.ietf.org/html/rfc6749#section-6
+    .. _`Refresh token grant`: https://tools.ietf.org/html/rfc6749#section-6
     """
 
     def __init__(self, request_validator=None,
@@ -46,8 +46,8 @@ class RefreshTokenGrant(GrantTypeBase):
         identical to that of the refresh token included by the client in the
         request.
 
-        .. _`Section 5.1`: http://tools.ietf.org/html/rfc6749#section-5.1
-        .. _`Section 5.2`: http://tools.ietf.org/html/rfc6749#section-5.2
+        .. _`Section 5.1`: https://tools.ietf.org/html/rfc6749#section-5.1
+        .. _`Section 5.2`: https://tools.ietf.org/html/rfc6749#section-5.2
         """
         headers = {
             'Content-Type': 'application/json',
@@ -90,7 +90,7 @@ class RefreshTokenGrant(GrantTypeBase):
         # the client was issued client credentials (or assigned other
         # authentication requirements), the client MUST authenticate with the
         # authorization server as described in Section 3.2.1.
-        # http://tools.ietf.org/html/rfc6749#section-3.2.1
+        # https://tools.ietf.org/html/rfc6749#section-3.2.1
         if self.request_validator.client_authentication_required(request):
             log.debug('Authenticating client, %r.', request)
             if not self.request_validator.authenticate_client(request):

--- a/oauthlib/oauth2/rfc6749/grant_types/resource_owner_password_credentials.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/resource_owner_password_credentials.py
@@ -67,7 +67,7 @@ class ResourceOwnerPasswordCredentialsGrant(GrantTypeBase):
             the resource owner credentials, and if valid, issues an access
             token.
 
-    .. _`Resource Owner Password Credentials Grant`: http://tools.ietf.org/html/rfc6749#section-4.3
+    .. _`Resource Owner Password Credentials Grant`: https://tools.ietf.org/html/rfc6749#section-4.3
     """
 
     def create_token_response(self, request, token_handler):
@@ -79,8 +79,8 @@ class ResourceOwnerPasswordCredentialsGrant(GrantTypeBase):
         authentication or is invalid, the authorization server returns an
         error response as described in `Section 5.2`_.
 
-        .. _`Section 5.1`: http://tools.ietf.org/html/rfc6749#section-5.1
-        .. _`Section 5.2`: http://tools.ietf.org/html/rfc6749#section-5.2
+        .. _`Section 5.1`: https://tools.ietf.org/html/rfc6749#section-5.1
+        .. _`Section 5.2`: https://tools.ietf.org/html/rfc6749#section-5.2
         """
         headers = {
             'Content-Type': 'application/json',
@@ -153,8 +153,8 @@ class ResourceOwnerPasswordCredentialsGrant(GrantTypeBase):
         brute force attacks (e.g., using rate-limitation or generating
         alerts).
 
-        .. _`Section 3.3`: http://tools.ietf.org/html/rfc6749#section-3.3
-        .. _`Section 3.2.1`: http://tools.ietf.org/html/rfc6749#section-3.2.1
+        .. _`Section 3.3`: https://tools.ietf.org/html/rfc6749#section-3.3
+        .. _`Section 3.2.1`: https://tools.ietf.org/html/rfc6749#section-3.2.1
         """
         for validator in self.custom_validators.pre_token:
             validator(request)

--- a/oauthlib/oauth2/rfc6749/parameters.py
+++ b/oauthlib/oauth2/rfc6749/parameters.py
@@ -5,7 +5,7 @@ oauthlib.oauth2.rfc6749.parameters
 
 This module contains methods related to `Section 4`_ of the OAuth 2 RFC.
 
-.. _`Section 4`: http://tools.ietf.org/html/rfc6749#section-4
+.. _`Section 4`: https://tools.ietf.org/html/rfc6749#section-4
 """
 from __future__ import absolute_import, unicode_literals
 
@@ -61,11 +61,11 @@ def prepare_grant_uri(uri, client_id, response_type, redirect_uri=None,
             &redirect_uri=https%3A%2F%2Fclient%2Eexample%2Ecom%2Fcb HTTP/1.1
         Host: server.example.com
 
-    .. _`W3C.REC-html401-19991224`: http://tools.ietf.org/html/rfc6749#ref-W3C.REC-html401-19991224
-    .. _`Section 2.2`: http://tools.ietf.org/html/rfc6749#section-2.2
-    .. _`Section 3.1.2`: http://tools.ietf.org/html/rfc6749#section-3.1.2
-    .. _`Section 3.3`: http://tools.ietf.org/html/rfc6749#section-3.3
-    .. _`section 10.12`: http://tools.ietf.org/html/rfc6749#section-10.12
+    .. _`W3C.REC-html401-19991224`: https://tools.ietf.org/html/rfc6749#ref-W3C.REC-html401-19991224
+    .. _`Section 2.2`: https://tools.ietf.org/html/rfc6749#section-2.2
+    .. _`Section 3.1.2`: https://tools.ietf.org/html/rfc6749#section-3.1.2
+    .. _`Section 3.3`: https://tools.ietf.org/html/rfc6749#section-3.3
+    .. _`section 10.12`: https://tools.ietf.org/html/rfc6749#section-10.12
     """
     if not is_secure_transport(uri):
         raise InsecureTransportError()
@@ -111,7 +111,7 @@ def prepare_token_request(grant_type, body='', **kwargs):
         grant_type=authorization_code&code=SplxlOBeZQQYbYS6WxSbIA
         &redirect_uri=https%3A%2F%2Fclient%2Eexample%2Ecom%2Fcb
 
-    .. _`Section 4.1.1`: http://tools.ietf.org/html/rfc6749#section-4.1.1
+    .. _`Section 4.1.1`: https://tools.ietf.org/html/rfc6749#section-4.1.1
     """
     params = [('grant_type', grant_type)]
 
@@ -153,9 +153,9 @@ def prepare_token_revocation_request(url, token, token_type_hint="access_token",
         specification MAY define other values for this parameter using the
         registry defined in `Section 4.1.2`_.
 
-    .. _`Section 1.4`: http://tools.ietf.org/html/rfc6749#section-1.4
-    .. _`Section 1.5`: http://tools.ietf.org/html/rfc6749#section-1.5
-    .. _`Section 4.1.2`: http://tools.ietf.org/html/rfc7009#section-4.1.2
+    .. _`Section 1.4`: https://tools.ietf.org/html/rfc6749#section-1.4
+    .. _`Section 1.5`: https://tools.ietf.org/html/rfc6749#section-1.5
+    .. _`Section 4.1.2`: https://tools.ietf.org/html/rfc7009#section-4.1.2
 
     """
     if not is_secure_transport(url):
@@ -348,10 +348,10 @@ def parse_token_response(body, scope=None):
             "example_parameter":"example_value"
         }
 
-    .. _`Section 7.1`: http://tools.ietf.org/html/rfc6749#section-7.1
-    .. _`Section 6`: http://tools.ietf.org/html/rfc6749#section-6
-    .. _`Section 3.3`: http://tools.ietf.org/html/rfc6749#section-3.3
-    .. _`RFC4627`: http://tools.ietf.org/html/rfc4627
+    .. _`Section 7.1`: https://tools.ietf.org/html/rfc6749#section-7.1
+    .. _`Section 6`: https://tools.ietf.org/html/rfc6749#section-6
+    .. _`Section 3.3`: https://tools.ietf.org/html/rfc6749#section-3.3
+    .. _`RFC4627`: https://tools.ietf.org/html/rfc4627
     """
     try:
         params = json.loads(body)
@@ -359,7 +359,7 @@ def parse_token_response(body, scope=None):
 
         # Fall back to URL-encoded string, to support old implementations,
         # including (at time of writing) Facebook. See:
-        #   https://github.com/idan/oauthlib/issues/267
+        #   https://github.com/oauthlib/oauthlib/issues/267
 
         params = dict(urlparse.parse_qsl(body))
         for key in ('expires_in', 'expires'):
@@ -395,7 +395,7 @@ def validate_token_parameters(params):
     # If the issued access token scope is different from the one requested by
     # the client, the authorization server MUST include the "scope" response
     # parameter to inform the client of the actual scope granted.
-    # http://tools.ietf.org/html/rfc6749#section-3.3
+    # https://tools.ietf.org/html/rfc6749#section-3.3
     if params.scope_changed:
         message = 'Scope has changed from "{old}" to "{new}".'.format(
             old=params.old_scope, new=params.scope,

--- a/oauthlib/oauth2/rfc6749/request_validator.py
+++ b/oauthlib/oauth2/rfc6749/request_validator.py
@@ -34,9 +34,9 @@ class RequestValidator(object):
             - Resource Owner Password Credentials Grant
             - Refresh Token Grant
 
-        .. _`Section 4.3.2`: http://tools.ietf.org/html/rfc6749#section-4.3.2
-        .. _`Section 4.1.3`: http://tools.ietf.org/html/rfc6749#section-4.1.3
-        .. _`Section 6`: http://tools.ietf.org/html/rfc6749#section-6
+        .. _`Section 4.3.2`: https://tools.ietf.org/html/rfc6749#section-4.3.2
+        .. _`Section 4.1.3`: https://tools.ietf.org/html/rfc6749#section-4.1.3
+        .. _`Section 6`: https://tools.ietf.org/html/rfc6749#section-6
         """
         return True
 
@@ -60,7 +60,7 @@ class RequestValidator(object):
             - Client Credentials Grant
             - Refresh Token Grant
 
-        .. _`HTTP Basic Authentication Scheme`: http://tools.ietf.org/html/rfc1945#section-11.1
+        .. _`HTTP Basic Authentication Scheme`: https://tools.ietf.org/html/rfc1945#section-11.1
         """
         raise NotImplementedError('Subclasses must implement this method.')
 

--- a/oauthlib/oauth2/rfc6749/tokens.py
+++ b/oauthlib/oauth2/rfc6749/tokens.py
@@ -4,8 +4,8 @@ oauthlib.oauth2.rfc6749.tokens
 
 This module contains methods for adding two types of access tokens to requests.
 
-- Bearer http://tools.ietf.org/html/rfc6750
-- MAC http://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-01
+- Bearer https://tools.ietf.org/html/rfc6750
+- MAC https://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-01
 """
 from __future__ import absolute_import, unicode_literals
 
@@ -95,8 +95,8 @@ def prepare_mac_header(token, uri, key, http_method,
                        nonce="1336363200:dj83hs9s",
                        mac="bhCQXTVyfj5cmA9uKkPFx1zeOXM="
 
-    .. _`MAC Access Authentication`: http://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-01
-    .. _`extension algorithms`: http://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-01#section-7.1
+    .. _`MAC Access Authentication`: https://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-01
+    .. _`extension algorithms`: https://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-01#section-7.1
 
     :param uri: Request URI.
     :param headers: Request headers as a dictionary.
@@ -182,7 +182,7 @@ def prepare_bearer_uri(token, uri):
 
     http://www.example.com/path?access_token=h480djs93hd8
 
-    .. _`Bearer Token`: http://tools.ietf.org/html/rfc6750
+    .. _`Bearer Token`: https://tools.ietf.org/html/rfc6750
     """
     return add_params_to_uri(uri, [(('access_token', token))])
 
@@ -193,7 +193,7 @@ def prepare_bearer_headers(token, headers=None):
 
     Authorization: Bearer h480djs93hd8
 
-    .. _`Bearer Token`: http://tools.ietf.org/html/rfc6750
+    .. _`Bearer Token`: https://tools.ietf.org/html/rfc6750
     """
     headers = headers or {}
     headers['Authorization'] = 'Bearer %s' % token
@@ -205,7 +205,7 @@ def prepare_bearer_body(token, body=''):
 
     access_token=h480djs93hd8
 
-    .. _`Bearer Token`: http://tools.ietf.org/html/rfc6750
+    .. _`Bearer Token`: https://tools.ietf.org/html/rfc6750
     """
     return add_params_to_qs(body, [(('access_token', token))])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyjwt==1.0.0
-blinker==1.3
-cryptography>=0.8.1
+pyjwt==1.6.0
+blinker==1.4
+cryptography>=1.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal = 1
+
+[metadata]
+license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     author_email='idan@gazit.me',
     maintainer='Ib Lundgren',
     maintainer_email='ib.lundgren@gmail.com',
-    url='https://github.com/idan/oauthlib',
+    url='https://github.com/oauthlib/oauthlib',
     platforms='any',
     license='BSD',
     packages=find_packages(exclude=('docs', 'tests', 'tests.*')),

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,pypy
+envlist = py27,py34,py35,py36,pypy,docs
 
 [testenv]
 deps=
@@ -9,3 +9,9 @@ commands=nosetests --with-coverage --cover-erase --cover-package=oauthlib -w tes
 [testenv:py27]
 deps=unittest2
      {[testenv]deps}
+
+[testenv:docs]
+deps=sphinx
+changedir=docs
+whitelist_externals=make
+commands=make html

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,12 @@ commands=nosetests --with-coverage --cover-erase --cover-package=oauthlib -w tes
 deps=unittest2
      {[testenv]deps}
 
+# tox -e docs to mimick readthedocs build.
+# as of today, RTD is using python2.7 and doesn't run "setup.py install"
 [testenv:docs]
+basepython=python2.7
+skipsdist=True
 deps=sphinx
 changedir=docs
 whitelist_externals=make
-commands=make html
+commands=make clean html


### PR DESCRIPTION
This cherry picks the PRs mentioned in the changelog into the 2.x branch.

Following [semantic versioning](https://semver.org/), not included are:

* OpenID Connect jwt (#488) (not sure if backward compatible, for 3.0.0)
* Fix `client_id` in web request body (#505) (not sure if backward compatible, for 3.0.0)
* Add support for HMAC-SHA256 (builds on #388) (#498) (new feature, for 2.1.0)

