### PR TITLE
Fixed "make" command to test upstream with local oauthlib.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,47 +1,57 @@
-PYS = py27,py34,pypy
+# Downstream tests (Don't be evil)
+#
+# Try and not break the libraries below by running their tests too.
+#
+# Unfortunately there is no neat way to run downstream tests AFAIK
+# Until we have a proper downstream testing system we will
+# stick to this Makefile.
+#---------------------------
+# HOW TO ADD NEW DOWNSTREAM LIBRARIES
+#
+# Please specify your library as well as primary contacts.
+# Since these contacts will be addressed with Github mentions they
+# need to be Github users (for now)(sorry Bitbucket).
+#
+clean:
+	rm -rf .tox
+	rm -rf bottle-oauthlib
+	rm -rf django-oauth-toolkit
+	rm -rf flask-oauthlib
+	rm -rf requests-oauthlib
 
 test:
-	# Test OAuthLib
-	tox -e "$(PYS)"
-	#
-	# Downstream tests (Don't be evil)
-	#
-	# Try and not break the libraries below by running their tests too.
-	#
-	# Unfortunately there is no neat way to run downstream tests AFAIK
-	# Until we have a proper downstream testing system we will
-	# stick to this Makefile.
+	tox
+
+bottle:
 	#---------------------------
-	# HOW TO ADD NEW DOWNSTREAM LIBRARIES
-	#
-	# Please specify your library as well as primary contacts.
-	# Since these contacts will be addressed with Github mentions they
-	# need to be Github users (for now)(sorry Bitbucket).
-	#
+	# Library thomsonreuters/bottle-oauthlib
+	# Contacts: Jonathan.Huot
+	cd bottle-oauthlib 2>/dev/null || git clone https://github.com/thomsonreuters/bottle-oauthlib.git
+	cd bottle-oauthlib && sed -i.old 's,deps =,deps= --editable=file://{toxinidir}/../,' tox.ini && sed -i.old '/oauthlib/d' requirements.txt && tox
+
+flask:
 	#---------------------------
 	# Library: lepture/flask-oauthLib
 	# Contacts: lepture,widnyana
-	git clone https://github.com/lepture/flask-oauthlib.git
-	cd flask-oauthlib && cp ../tox.ini . && sed -i 's/py32,py33,py34,//' tox.ini && sed -i '/mock/a \     Flask-SQLAlchemy' tox.ini &&  tox -e "$(PYS)"
-	rm -rf flask-oauthlib
+	cd flask-oauthlib 2>/dev/null || git clone https://github.com/lepture/flask-oauthlib.git
+	cd flask-oauthlib && sed -i.old 's,deps =,deps= --editable=file://{toxinidir}/../,' tox.ini && sed -i.old '/oauthlib/d' requirements.txt && tox
+
+django:
 	#---------------------------
 	# Library: evonove/django-oauth-toolkit
 	# Contacts: evonove,masci
 	# (note: has tox.ini already)
-	git clone https://github.com/evonove/django-oauth-toolkit.git
-	cd django-oauth-toolkit && tox -e "$(PYS)"
-	rm -rf django-oauth-toolkit
+	cd django-oauth-toolkit 2>/dev/null || git clone https://github.com/evonove/django-oauth-toolkit.git
+	cd django-oauth-toolkit && sed -i.old 's,deps =,deps= --editable=file://{toxinidir}/../,' tox.ini && tox -e py27,py35,py36
+
+requests:
 	#---------------------------
 	# Library requests/requests-oauthlib
 	# Contacts: ib-lundgren,lukasa
-	git clone https://github.com/requests/requests-oauthlib.git
-	cd requests-oauthlib && cp ../tox.ini . && sed -i '/mock/a \     requests' tox.ini && tox -e "$(PYS)"
-	rm -rf requests-oauthlib
-	#---------------------------
-	#
+	cd requests-oauthlib 2>/dev/null || git clone https://github.com/requests/requests-oauthlib.git
+	cd requests-oauthlib && sed -i.old 's,deps=,deps = --editable=file://{toxinidir}/../[signedtoken],' tox.ini && sed -i.old '/oauthlib/d' requirements.txt && tox
 
-pycco:
-	find oauthlib -name "*.py" -exec pycco -p -s reST {} \;
 
-pycco-clean:
-	rm -rf docs/oauthlib docs/pycco.css
+.DEFAULT_GOAL := all
+.PHONY: clean test bottle django flask requests
+all: clean test bottle django flask requests


### PR DESCRIPTION
Doing `make` command to test upstream compatibility is great, however it has different flaws I fixed:
1) remove oauthlib references in upstream's project and replace it with local "dev" oauthlib: every dev should be able to run `make` to test their local changes before push.
2) clean rule: cleaning the working directories should not be done automatically, else it becomes a pain to debug them
3) python versions list should be based on the upstream's compatibility, and not on the oauthlib's compatibility (e.g. running plain `tox` everytime we can).  
4) added `bottle-oauthlib`

TBC: wait for https://github.com/requests/requests-oauthlib/pull/306 to be integrated to master & we will able to replace `Travis` build command from `tox` to `make`. However, if one of their builds failed for a different reason than us, it breaks our CI job.