### PR TITLE
Updated Travis releases part

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,12 @@ script: tox
 
 after_success: coveralls
 notifications:
-  irc: irc.freenode.org#oauthlib
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/6008c872bf0ecee344f4
+    on_success: change
+    on_failure: always
+    on_start: never
 deploy:
   provider: pypi
   user: ib.lundgren

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,17 @@ notifications:
     on_failure: always
     on_start: never
 deploy:
-  provider: pypi
-  user: ib.lundgren
-  password:
-    secure: PGZF9pRiTGCSwQjk1ddTKF3x4rQ0iAiPbg2uSixyO68uMXRgJjwHhSrNM0OEqtK5YWU5FE5L0DwR1nkrpEJKO4a5q2EOgos+gVoKpJfinoUNOOkjc1VHpqKM0uRf/OKrw1alvWUwqvW8B+DOb9TY5c5VZxQuRL+iwdrtwzFlKls=
-  distributions: sdist bdist_wheel
-  on:
-    tags: true
-    repo: oauthlib/oauthlib
+  - provider: pypi
+    user: ib.lundgren
+    password:
+      secure: PGZF9pRiTGCSwQjk1ddTKF3x4rQ0iAiPbg2uSixyO68uMXRgJjwHhSrNM0OEqtK5YWU5FE5L0DwR1nkrpEJKO4a5q2EOgos+gVoKpJfinoUNOOkjc1VHpqKM0uRf/OKrw1alvWUwqvW8B+DOb9TY5c5VZxQuRL+iwdrtwzFlKls=
+      distributions: sdist bdist_wheel
+      on:
+        tags: true
+        repo: oauthlib/oauthlib
+  - provider: releases
+    api_key: "$GITHUB_OAUTH_TOKEN"
+    skip_cleanup: true
+    on:
+      tags: true
+      repo: oauthlib/oauthlib


### PR DESCRIPTION
Since the migration to the community https://github.com/oauthlib/oauthlib/issues/511, we are deprecating IRC in favor of Gitter, and we need to provide a Github Releases tab in sync with pypi and our release schedule.

IIUC, the ChangeLog will not be done automatically by Travis, but at least we should have the correct assets (as opposite of https://github.com/oauthlib/oauthlib/issues/511 / Tagging issue). This step could always be done manually, after the release.