### PR TITLE
Merge 2.0.7 back to master

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,3 +26,5 @@ Juan Fabio García Solero
 Omer Katz
 Joel Stevenson
 Brendan McCollam
+Jonathan Huot
+Pieter Ennes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,23 @@
 Changelog
 =========
 
+2.0.7 (2018-03-09)
+------------------
+
+* Moved oauthlib into new organization on GitHub.
+* Include license file in the generated wheel package. (#494)
+* When deploying a release to PyPI, include the wheel distribution. (#496)
+* Check access token in self.token dict. (#500)
+* Added bottle-oauthlib to docs. (#509)
+* Updated docs for organization change. (#515)
+* Update repository location in Travis. (#514)
+* Replace G+ with Gitter. (#517)
+
+2.0.6 (2017-10-20)
+------------------
+
+* 2.0.5 contains breaking changes.
+
 2.0.5 (2017-10-19)
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-2.0.7 (2018-03-09)
+2.0.7 (2018-03-19)
 ------------------
 
 * Moved oauthlib into new organization on GitHub.
@@ -9,9 +9,15 @@ Changelog
 * When deploying a release to PyPI, include the wheel distribution. (#496)
 * Check access token in self.token dict. (#500)
 * Added bottle-oauthlib to docs. (#509)
-* Updated docs for organization change. (#515)
 * Update repository location in Travis. (#514)
+* Updated docs for organization change. (#515)
 * Replace G+ with Gitter. (#517)
+* Update requirements. (#518)
+* Add shields for Python versions, license and RTD. (#520)
+* Fix ReadTheDocs build (#521).
+* Fixed "make" command to test upstream with local oauthlib. (#522)
+* Replace IRC notification with Gitter Hook. (#523)
+* Added Github Releases deploy provider. (#523)
 
 2.0.6 (2017-10-20)
 ------------------

--- a/oauthlib/__init__.py
+++ b/oauthlib/__init__.py
@@ -9,8 +9,8 @@
     :license: BSD, see LICENSE for details.
 """
 
-__author__ = 'Idan Gazit <idan@gazit.me>'
-__version__ = '2.0.5'
+__author__ = 'The OAuthlib Community'
+__version__ = '2.0.7'
 
 
 import logging


### PR DESCRIPTION
I've cherry picked two commits from 2.x to update the changelog in master.

Alternatively, if we're planning to do further 2.x.y releases we could still revert the offending (breaking) commits from master so that we don't need the 2.x branch in the first place.

