### PR TITLE
Use secrets module in Python 3.6 and later

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,3 +28,4 @@ Joel Stevenson
 Brendan McCollam
 Jonathan Huot
 Pieter Ennes
+Olaf Conradi

--- a/docs/oauth1/security.rst
+++ b/docs/oauth1/security.rst
@@ -16,11 +16,13 @@ A few important facts regarding OAuth security
 
     * **Tokens must be random**, OAuthLib provides a method for generating
         secure tokens and it's packed into ``oauthlib.common.generate_token``,
-        use it. If you decide to roll your own, use ``random.SystemRandom``
-        which is based on ``os.urandom`` rather than the default ``random``
-        based on the effecient but not truly random Mersenne Twister.
-        Predictable tokens allow attackers to bypass virtually all defences
-        OAuth provides.
+        use it. If you decide to roll your own, use ``secrets.SystemRandom``
+        for Python 3.6 and later. The ``secrets`` module is designed for
+        generating cryptographically strong random numbers. For earlier versions
+        of Python, use ``random.SystemRandom`` which is based on ``os.urandom``
+        rather than the default ``random`` based on the effecient but not truly
+        random Mersenne Twister. Predictable tokens allow attackers to bypass
+        virtually all defences OAuth provides.
 
     * **Timing attacks are real** and more than possible if you host your
         application inside a shared datacenter. Ensure all ``validate_`` methods

--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -11,11 +11,16 @@ from __future__ import absolute_import, unicode_literals
 import collections
 import datetime
 import logging
-import random
 import re
 import sys
 import time
 
+try:
+    from secrets import randbits
+    from secrets import SystemRandom
+except ImportError:
+    from random import getrandbits as randbits
+    from random import SystemRandom
 try:
     from urllib import quote as _quote
     from urllib import unquote as _unquote
@@ -202,7 +207,7 @@ def generate_nonce():
     .. _`section 3.2.1`: https://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-01#section-3.2.1
     .. _`section 3.3`: https://tools.ietf.org/html/rfc5849#section-3.3
     """
-    return unicode_type(unicode_type(random.getrandbits(64)) + generate_timestamp())
+    return unicode_type(unicode_type(randbits(64)) + generate_timestamp())
 
 
 def generate_timestamp():
@@ -225,7 +230,7 @@ def generate_token(length=30, chars=UNICODE_ASCII_CHARACTER_SET):
     and entropy when generating the random characters is important. Which is
     why SystemRandom is used instead of the default random.choice method.
     """
-    rand = random.SystemRandom()
+    rand = SystemRandom()
     return ''.join(rand.choice(chars) for x in range(length))
 
 


### PR DESCRIPTION
The secrets module should be used for generating cryptographically
strong random numbers suitable for managing data such as passwords,
account authentication, security tokens, and related secrets.

In particularly, secrets should be used in preference to the default
pseudo-random number generator in the random module, which is
designed for modelling and simulation, not security or cryptography.