### PR TITLE
Avoid populating spurious token credentials

### DIFF
--- a/oauthlib/oauth2/rfc6749/clients/base.py
+++ b/oauthlib/oauth2/rfc6749/clients/base.py
@@ -111,6 +111,7 @@ class Client(object):
         self.state_generator = state_generator
         self.state = state
         self.redirect_url = redirect_url
+        self.code = None
         self.expires_in = None
         self._expires_at = None
         self._populate_token_attributes(self.token)

--- a/oauthlib/oauth2/rfc6749/clients/base.py
+++ b/oauthlib/oauth2/rfc6749/clients/base.py
@@ -111,8 +111,9 @@ class Client(object):
         self.state_generator = state_generator
         self.state = state
         self.redirect_url = redirect_url
+        self.expires_in = None
         self._expires_at = None
-        self._populate_attributes(self.token)
+        self._populate_token_attributes(self.token)
 
     @property
     def token_types(self):
@@ -406,7 +407,7 @@ class Client(object):
         .. _`Section 7.1`: https://tools.ietf.org/html/rfc6749#section-7.1
         """
         self.token = parse_token_response(body, scope=scope)
-        self._populate_attributes(self.token)
+        self._populate_token_attributes(self.token)
         return self.token
 
     def prepare_refresh_body(self, body='', refresh_token=None, scope=None, **kwargs):
@@ -459,8 +460,14 @@ class Client(object):
                                             hash_algorithm=self.mac_algorithm, **kwargs)
         return uri, headers, body
 
-    def _populate_attributes(self, response):
-        """Add commonly used values such as access_token to self."""
+    def _populate_code_attributes(self, response):
+        """Add attributes from an auth code response to self."""
+
+        if 'code' in response:
+            self.code = response.get('code')
+
+    def _populate_token_attributes(self, response):
+        """Add attributes from a token exchange response to self."""
 
         if 'access_token' in response:
             self.access_token = response.get('access_token')
@@ -477,9 +484,6 @@ class Client(object):
 
         if 'expires_at' in response:
             self._expires_at = int(response.get('expires_at'))
-
-        if 'code' in response:
-            self.code = response.get('code')
 
         if 'mac_key' in response:
             self.mac_key = response.get('mac_key')

--- a/oauthlib/oauth2/rfc6749/clients/mobile_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/mobile_application.py
@@ -168,5 +168,5 @@ class MobileApplicationClient(Client):
         .. _`Section 3.3`: https://tools.ietf.org/html/rfc6749#section-3.3
         """
         self.token = parse_implicit_response(uri, state=state, scope=scope)
-        self._populate_attributes(self.token)
+        self._populate_token_attributes(self.token)
         return self.token

--- a/oauthlib/oauth2/rfc6749/clients/web_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/web_application.py
@@ -172,5 +172,5 @@ class WebApplicationClient(Client):
             oauthlib.oauth2.rfc6749.errors.MismatchingStateError
         """
         response = parse_authorization_code_response(uri, state=state)
-        self._populate_attributes(response)
+        self._populate_code_attributes(response)
         return response

--- a/tests/oauth2/rfc6749/clients/test_mobile_application.py
+++ b/tests/oauth2/rfc6749/clients/test_mobile_application.py
@@ -69,6 +69,18 @@ class MobileApplicationClientTest(TestCase):
         uri = client.prepare_request_uri(self.uri, **self.kwargs)
         self.assertURLEqual(uri, self.uri_kwargs)
 
+    def test_populate_attributes(self):
+
+        client = MobileApplicationClient(self.client_id)
+
+        response_uri = (self.response_uri + "&code=EVIL-CODE")
+
+        client.parse_request_uri_response(response_uri, scope=self.scope)
+
+        # We must not accidentally pick up any further security
+        # credentials at this point.
+        self.assertIsNone(client.code)
+
     def test_parse_token_response(self):
         client = MobileApplicationClient(self.client_id)
 

--- a/tests/oauth2/rfc6749/clients/test_web_application.py
+++ b/tests/oauth2/rfc6749/clients/test_web_application.py
@@ -117,6 +117,25 @@ class WebApplicationClientTest(TestCase):
                 self.response_uri,
                 state="invalid")
 
+    def test_populate_attributes(self):
+
+        client = WebApplicationClient(self.client_id)
+
+        response_uri = (self.response_uri +
+                        "&access_token=EVIL-TOKEN"
+                        "&refresh_token=EVIL-TOKEN"
+                        "&mac_key=EVIL-KEY")
+
+        client.parse_request_uri_response(response_uri, self.state)
+
+        self.assertEqual(client.code, self.code)
+
+        # We must not accidentally pick up any further security
+        # credentials at this point.
+        self.assertIsNone(client.access_token)
+        self.assertIsNone(client.refresh_token)
+        self.assertIsNone(client.mac_key)
+
     def test_parse_token_response(self):
         client = WebApplicationClient(self.client_id)
 


### PR DESCRIPTION
This patch ensures we do not pick up client attributes too early.