### PR TITLE
Backward compatibility fix for requests-oauthlib

### DIFF
--- a/oauthlib/oauth2/rfc6749/clients/base.py
+++ b/oauthlib/oauth2/rfc6749/clients/base.py
@@ -9,6 +9,7 @@ for consuming OAuth 2.0 RFC6749.
 from __future__ import absolute_import, unicode_literals
 
 import time
+import warnings
 
 from oauthlib.common import generate_token
 from oauthlib.oauth2.rfc6749 import tokens
@@ -114,7 +115,7 @@ class Client(object):
         self.code = None
         self.expires_in = None
         self._expires_at = None
-        self._populate_token_attributes(self.token)
+        self.populate_token_attributes(self.token)
 
     @property
     def token_types(self):
@@ -408,7 +409,7 @@ class Client(object):
         .. _`Section 7.1`: https://tools.ietf.org/html/rfc6749#section-7.1
         """
         self.token = parse_token_response(body, scope=scope)
-        self._populate_token_attributes(self.token)
+        self.populate_token_attributes(self.token)
         return self.token
 
     def prepare_refresh_body(self, body='', refresh_token=None, scope=None, **kwargs):
@@ -461,13 +462,18 @@ class Client(object):
                                             hash_algorithm=self.mac_algorithm, **kwargs)
         return uri, headers, body
 
-    def _populate_code_attributes(self, response):
+    def _populate_attributes(self, response):
+        warnings.warn("Please switch to the public method "
+                      "populate_token_attributes.", DeprecationWarning)
+        return self.populate_token_attributes(response)
+
+    def populate_code_attributes(self, response):
         """Add attributes from an auth code response to self."""
 
         if 'code' in response:
             self.code = response.get('code')
 
-    def _populate_token_attributes(self, response):
+    def populate_token_attributes(self, response):
         """Add attributes from a token exchange response to self."""
 
         if 'access_token' in response:

--- a/oauthlib/oauth2/rfc6749/clients/mobile_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/mobile_application.py
@@ -168,5 +168,5 @@ class MobileApplicationClient(Client):
         .. _`Section 3.3`: https://tools.ietf.org/html/rfc6749#section-3.3
         """
         self.token = parse_implicit_response(uri, state=state, scope=scope)
-        self._populate_token_attributes(self.token)
+        self.populate_token_attributes(self.token)
         return self.token

--- a/oauthlib/oauth2/rfc6749/clients/web_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/web_application.py
@@ -172,5 +172,5 @@ class WebApplicationClient(Client):
             oauthlib.oauth2.rfc6749.errors.MismatchingStateError
         """
         response = parse_authorization_code_response(uri, state=state)
-        self._populate_code_attributes(response)
+        self.populate_code_attributes(response)
         return response


### PR DESCRIPTION
We recently renamed a private method which breaks requests-oauthlib. This PR reinstates the original name (with a deprecation warning attached) to unbreak it. And it marks the newly introduced methods as  public, since apparently they are useful to implementers.

After releasing this I think we should open a PR to requests-oauthlib to swap to the new version and pin oauthlib >= 2.0.8.
