### PR TITLE
Remove Python 2.6 compatibility code

### DIFF
--- a/oauthlib/__init__.py
+++ b/oauthlib/__init__.py
@@ -8,18 +8,10 @@
     :copyright: (c) 2011 by Idan Gazit.
     :license: BSD, see LICENSE for details.
 """
+import logging
+from logging import NullHandler
 
 __author__ = 'The OAuthlib Community'
 __version__ = '2.0.7'
-
-
-import logging
-try:  # Python 2.7+
-    from logging import NullHandler
-except ImportError:
-    class NullHandler(logging.Handler):
-
-        def emit(self, record):
-            pass
 
 logging.getLogger('oauthlib').addHandler(NullHandler())


### PR DESCRIPTION
Since we do not support 2.6 anymore this code is not required.