### PR TITLE
Update save_bearer_token docs to mention how the token is passed in a…

### DIFF
--- a/oauthlib/oauth2/rfc6749/request_validator.py
+++ b/oauthlib/oauth2/rfc6749/request_validator.py
@@ -332,7 +332,14 @@ class RequestValidator(object):
             }
 
         Note that while "scope" is a string-separated list of authorized scopes,
-        the original list is still available in request.scopes
+        the original list is still available in request.scopes.
+
+        The token dict is passed as a reference so any changes made to the dictionary
+        will go back to the user.  If additional information must return to the client
+        user, and it is only possible to get this information after writing the token
+        to storage, it should be added to the token dictionary.  If the token
+        dictionary must be modified but the changes should not go back to the user,
+        a copy of the dictionary must be made before making the changes.
 
         Also note that if an Authorization Code grant request included a valid claims
         parameter (for OpenID Connect) then the request.claims property will contain


### PR DESCRIPTION
…s a reference

I have some information that I want to return to clients when they create or refresh a token that is generated when the token is written to the database.  To get this data back to the user, I do what I consider a bit of a hack, by changing the token dictionary.  My plan was to update oauthlib to add a more explicit way to do this, but I didn't see a clear solution.

I hoped that the response from the function could get merged in, but this is not backwards compatible.  In fact, flask-oauthlib docs return a SQLAlchemy token: https://github.com/lepture/flask-oauthlib/blob/master/docs/oauth2.rst so that didn't seem like a good option.

Alternatively, I was thinking of adding a special extra credentials kwarg passed in as a reference that could get updated with changes that should get merged into the token before it's returned. 
 But I thought that might be confusing for users.

Instead I just updated the docs to specifically mention how this is passed in as a reference and can get updated to return data to the user.

If one of the options above seems better, please let me know and I can implement it and update the PR