### PR TITLE
$ and ' are allowed to be unencoded in query strings

### DIFF
--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -114,7 +114,7 @@ def decode_params_utf8(params):
     return decoded
 
 
-urlencoded = set(always_safe) | set('=&;:%+~,*@!()/?')
+urlencoded = set(always_safe) | set('=&;:%+~,*@!()/?\'$')
 
 
 def urldecode(query):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -39,6 +39,8 @@ class EncodingTest(TestCase):
         self.assertItemsEqual(urldecode('foo=bar@spam'), [('foo', 'bar@spam')])
         self.assertItemsEqual(urldecode('foo=bar/baz'), [('foo', 'bar/baz')])
         self.assertItemsEqual(urldecode('foo=bar?baz'), [('foo', 'bar?baz')])
+        self.assertItemsEqual(urldecode('foo=bar\'s'), [('foo', 'bar\'s')])
+        self.assertItemsEqual(urldecode('foo=$'), [('foo', '$')])
         self.assertRaises(ValueError, urldecode, 'foo bar')
         self.assertRaises(ValueError, urldecode, '%R')
         self.assertRaises(ValueError, urldecode, '%RA')


### PR DESCRIPTION
Adds missing characters that are allowed in query strings by [RFC3986](
https://tools.ietf.org/html/rfc3986#section-3.4). Fixes #563 