### PR TITLE
Add syntax check of get_default_redirect_uri

### DIFF
--- a/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
@@ -312,6 +312,8 @@ class AuthorizationCodeGrant(GrantTypeBase):
             log.debug('Using default redirect_uri %s.', request.redirect_uri)
             if not request.redirect_uri:
                 raise errors.MissingRedirectURIError(request=request)
+            if not is_absolute_uri(request.redirect_uri):
+                raise errors.InvalidRedirectURIError(request=request)
 
         # Then check for normal errors.
 

--- a/tests/oauth2/rfc6749/endpoints/test_error_responses.py
+++ b/tests/oauth2/rfc6749/endpoints/test_error_responses.py
@@ -44,6 +44,22 @@ class ErrorResponseTest(TestCase):
         self.assertRaises(errors.InvalidRedirectURIError,
                 self.mobile.create_authorization_response, uri.format('token'), scopes=['foo'])
 
+    def test_invalid_default_redirect_uri(self):
+        uri = 'https://example.com/authorize?response_type={0}&client_id=foo'
+        self.validator.get_default_redirect_uri.return_value = "wrong"
+
+        # Authorization code grant
+        self.assertRaises(errors.InvalidRedirectURIError,
+                self.web.validate_authorization_request, uri.format('code'))
+        self.assertRaises(errors.InvalidRedirectURIError,
+                self.web.create_authorization_response, uri.format('code'), scopes=['foo'])
+
+        # Implicit grant
+        self.assertRaises(errors.InvalidRedirectURIError,
+                self.mobile.validate_authorization_request, uri.format('token'))
+        self.assertRaises(errors.InvalidRedirectURIError,
+                self.mobile.create_authorization_response, uri.format('token'), scopes=['foo'])
+
     def test_missing_redirect_uri(self):
         uri = 'https://example.com/authorize?response_type={0}&client_id=foo'
 


### PR DESCRIPTION
When `get_default_redirect_uri()` is called, `oauthlib` must call `is_absolute_uri` to test the validity of the uri.

However, Authorization Code was missing this check, whereas Implicit was already checking it.