### PR TITLE
Clean doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ htmlcov*
 # Local file cruft/auto-backups
 .DS_Store
 *~
+**/#*#
+**/.#*
 
 # Sphinx
 docs/_build

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011 Idan Gazit and contributors
+Copyright (c) 2018 The OAuthlib Community
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,18 @@ License
 OAuthLib is yours to use and abuse according to the terms of the BSD license.
 Check the LICENSE file for full details.
 
+Credits
+-------
+
+OAuthLib has been started and maintained several years by Idan Gazit and other
+amazing `AUTHORS`_. Thanks to their wonderful work, the open-source `community`_
+creation has been possible and the project can stay active and reactive to users
+requests.
+
+
+.. _`AUTHORS`: https://github.com/oauthlib/oauthlib/blob/master/AUTHORS
+.. _`community`: https://github.com/oauthlib/
+
 Changelog
 ---------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'OAuthLib'
-copyright = u'2012, Idan Gazit and the Python Community'
+copyright = u'2018, The OAuthlib Community'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -150,6 +150,17 @@ version. For Ubuntu you can easily install all after adding one ppa.
 .. _`Tox`: https://tox.readthedocs.io/en/latest/install.html
 .. _`virtualenv`: https://virtualenv.pypa.io/en/latest/installation/
 
+Test upstream applications
+-----------------------------------
+
+Remember, OAuthLib is used by several 3rd party projects. If you think you
+submit a breaking change, confirm that other projects builds are not affected.
+
+.. sourcecode:: bash
+
+   $ make
+
+
 If you add code you need to add tests!
 --------------------------------------
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -35,7 +35,7 @@ Setting up topic branches and generating pull requests
 
 While it's handy to provide useful code snippets in an issue, it is better for
 you as a developer to submit pull requests. By submitting pull request your
-contribution to OpenComparison will be recorded by Github.
+contribution to OAuthlib will be recorded by Github.
 
 In git it is best to isolate each topic or feature into a "topic branch". While
 individual commits allow you control over how small individual changes are made
@@ -218,7 +218,7 @@ How pull requests are checked, tested, and done
 
 First we pull the code into a local branch::
 
-    git remote add <submitter-github-name> git@github.com:<submitter-github-name>/opencomparison.git
+    git remote add <submitter-github-name> git@github.com:<submitter-github-name>/oauthlib.git
     git fetch <submitter-github-name>
     git checkout -b <branch-name> <submitter-github-name>/<branch-name>
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -127,7 +127,7 @@ request that fails this test suite will be **rejected**.
 Testing multiple versions of Python
 -----------------------------------
 
-OAuthLib supports Python 2.6, 2.7, 3.2, 3.3 and experimentally PyPy. Testing
+OAuthLib supports Python 2.7, 3.4, 3.5, 3.6 and PyPy. Testing
 all versions conveniently can be done using `Tox`_.
 
 .. sourcecode:: bash

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -72,8 +72,8 @@ How do I use OAuthlib as a provider with Django, Flask and other web frameworks?
     - Pyramid `pyramid-oauthlib`_
     - Bottle `bottle-oauthlib`_
 
-    For other frameworks, please get in touch by opening a `GitHub issue`_, on `G+`_ or
-    on IRC #oauthlib irc.freenode.net. If you have written an OAuthLib package that
+    For other frameworks, please get in touch by opening a `GitHub issue`_ or
+    on `Gitter OAuthLib community`_. If you have written an OAuthLib package that
     supports your favorite framework, please open a Pull Request to update the docs.
 
 
@@ -101,5 +101,5 @@ Some argue OAuth 2 is worse than 1, is that true?
 .. _`pyramid-oauthlib`: https://github.com/tilgovi/pyramid-oauthlib
 .. _`bottle-oauthlib`: https://github.com/thomsonreuters/bottle-oauthlib
 .. _`GitHub issue`: https://github.com/oauthlib/oauthlib/issues/new
-.. _`G+`: https://plus.google.com/communities/101889017375384052571
+.. _`Gitter OAuthLib community`: https://gitter.im/oauthlib/Lobby
 .. _`difference`: https://www.cyberciti.biz/faq/authentication-vs-authorization/

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -14,19 +14,23 @@ What parts of OAuth 1 & 2 are supported?
 OAuth 1 with RSA-SHA1 signatures says "could not import cryptography". What should I do?
 ----------------------------------------------------------------------------------
 
-    Install cryptography via pip.
+    Install oauthlib with rsa flag or install cryptography manually via pip.
 
 .. code-block:: sh
 
+    $ pip install oauthlib[rsa]
+    ..or..
     $ pip install cryptography
 
 OAuth 2 ServiceApplicationClient and OAuth 1 with RSA-SHA1 signatures say "could not import jwt". What should I do?
 -------------------------------------------------------------------------------------------------------------------
 
-    Install pyjwt and cryptography with pip.
+    Install oauthlib with signedtoken flag or install pyjwt and cryptography manually with pip.
 
 .. code-block:: sh
 
+    $ pip install oauthlib[signedtoken]
+    ..or..
     $ pip install pyjwt cryptography
 
 What does ValueError `Only unicode objects are escapable. Got one of type X.` mean?

--- a/docs/oauth1/server.rst
+++ b/docs/oauth1/server.rst
@@ -433,9 +433,9 @@ shown below as well as run your flask server locally on port `5000`.
 7. Let us know how it went!
 ---------------------------
 
-Drop a line in our `G+ community`_ or open a `GitHub issue`_ =)
+Drop a line in our `Gitter OAuthLib community`_ or open a `GitHub issue`_ =)
 
-.. _`G+ community`: https://plus.google.com/communities/101889017375384052571
+.. _`Gitter OAuthLib community`: https://gitter.im/oauthlib/Lobby
 .. _`GitHub issue`: https://github.com/oauthlib/oauthlib/issues/new
 
 If you run into issues it can be helpful to enable debug logging::

--- a/docs/oauth2/server.rst
+++ b/docs/oauth2/server.rst
@@ -493,9 +493,9 @@ at runtime by a function, rather then by a list.
 6. Let us know how it went!
 ---------------------------
 
-Drop a line in our `G+ community`_ or open a `GitHub issue`_ =)
+Drop a line in our `Gitter OAuthLib community`_ or open a `GitHub issue`_ =)
 
-.. _`G+ community`: https://plus.google.com/communities/101889017375384052571
+.. _`Gitter OAuthLib community`: https://gitter.im/oauthlib/Lobby
 .. _`GitHub issue`: https://github.com/oauthlib/oauthlib/issues/new
 
 If you run into issues it can be helpful to enable debug logging.

--- a/docs/release_process.rst
+++ b/docs/release_process.rst
@@ -2,12 +2,12 @@ Release process
 ===============
 
 OAuthLib has got to a point where quite a few libraries and users depend on it.
-Because of this a more careful release procedure will be introduced to make
+Because of this, a more careful release procedure will be introduced to make
 sure all these lovely projects don't suddenly break.
 
 When approaching a release we will run the unittests for a set of downstream
 libraries using the unreleased version of OAuthLib. If OAuthLib is the cause of
-failing tests we will either
+failing tests we will either:
 
 1. Find a way to introduce the change without breaking downstream. However,
    this is not always the best long term option.
@@ -25,7 +25,7 @@ OAuthLib release issue on Github at least 2 days prior to release detailing the
 changes and pings the primary contacts for each downstream project.  Please
 respond within those 2 days if you have major concerns. 
 
-How to get on the notifcations list
+How to get on the notifications list
 -----------------------------------
 
 Which projects and the instructions for testing each will be defined in
@@ -45,8 +45,8 @@ A note on versioning
 --------------------
 
 Historically OAuthLib has not been very good at semantic versioning but that
-will change after the 1.0.0 release due late 2014. After that poing any major
-digit release (e.g. 2.0.0) may introduce non backwards compatible changes.
+has changed since the 1.0.0 in 2014. Since, any major digit release
+(e.g. 2.0.0) may introduce non backwards compatible changes.
 Minor point (1.1.0) releases will introduce non API breaking new features and
 changes. Bug releases (1.0.1) will include minor fixes that needs to be
 released quickly (e.g. after a bigger release unintentionally introduced a

--- a/oauthlib/__init__.py
+++ b/oauthlib/__init__.py
@@ -5,7 +5,7 @@
     A generic, spec-compliant, thorough implementation of the OAuth
     request-signing logic.
 
-    :copyright: (c) 2011 by Idan Gazit.
+    :copyright: (c) 2018 by The OAuthlib Community
     :license: BSD, see LICENSE for details.
 """
 import logging

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     version=oauthlib.__version__,
     description='A generic, spec-compliant, thorough implementation of the OAuth request-signing logic',
     long_description=fread('README.rst'),
-    author='Idan Gazit',
+    author='The OAuthlib Community',
     author_email='idan@gazit.me',
     maintainer='Ib Lundgren',
     maintainer_email='ib.lundgren@gmail.com',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,pypy,docs
+envlist = py27,py34,py35,py36,pypy,docs,readme
 
 [testenv]
 deps=
@@ -19,3 +19,12 @@ deps=sphinx
 changedir=docs
 whitelist_externals=make
 commands=make clean html
+
+# tox -e readme to mimick pypi long_description check
+[testenv:readme]
+skipsdist=True
+deps=readme
+whitelist_externals=echo
+commands=
+        python setup.py check -r -s
+        echo setup.py/long description is syntaxly correct


### PR DESCRIPTION
To replace https://github.com/oauthlib/oauthlib/pull/531, I created this PR to be mergeable into master.

> Wanted to improve documentation to both be sure we have no errors, nor misleading examples, and also be clear for new users.
> 
> Started with another round of review lead me to fix minors stuff (copyright, typo, ..), but also I have added a credits to previous team.
> 
> Also, setup.py/long_description aka README.rst is now tested locally before pushed to pypi (and github).