### PR TITLE
client_id is not passed to save_bearer_token

### DIFF
--- a/oauthlib/oauth2/rfc6749/request_validator.py
+++ b/oauthlib/oauth2/rfc6749/request_validator.py
@@ -346,7 +346,6 @@ class RequestValidator(object):
         the claims dict, which should be saved for later use when generating the
         id_token and/or UserInfo response content.
 
-        :param client_id: Unicode client identifier
         :param token: A Bearer token dict
         :param request: The HTTP Request (oauthlib.common.Request)
         :rtype: The default redirect URI for the client


### PR DESCRIPTION
fixed https://github.com/oauthlib/oauthlib/issues/234