### PR TITLE
initial docstring fixes

### DIFF
--- a/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
@@ -98,7 +98,11 @@ class AuthorizationCodeGrant(GrantTypeBase):
     response_types = ['code']
 
     def create_authorization_code(self, request):
-        """Generates an authorization grant represented as a dictionary."""
+        """
+        Generates an authorization grant represented as a dictionary.
+        
+        :param request: oauthlib.common.Request
+        """
         grant = {'code': common.generate_token()}
         if hasattr(request, 'state') and request.state:
             grant['state'] = request.state
@@ -135,7 +139,7 @@ class AuthorizationCodeGrant(GrantTypeBase):
         HTTP redirection response, or by other means available to it via the
         user-agent.
 
-        :param request: oauthlib.commong.Request
+        :param request: oauthlib.common.Request
         :param token_handler: A token handler instace, for example of type
                               oauthlib.oauth2.BearerToken.
         :returns: headers, body, status
@@ -220,6 +224,10 @@ class AuthorizationCodeGrant(GrantTypeBase):
         MUST deny the request and SHOULD revoke (when possible) all tokens
         previously issued based on that authorization code. The authorization
         code is bound to the client identifier and redirection URI.
+
+        :param request: oauthlib.common.Request
+        :param token_handler: A token handler instace, for example of type
+                              oauthlib.oauth2.BearerToken.
         """
         headers = {
             'Content-Type': 'application/json',
@@ -253,6 +261,8 @@ class AuthorizationCodeGrant(GrantTypeBase):
         missing. These must be caught by the provider and handled, how this
         is done is outside of the scope of OAuthLib but showing an error
         page describing the issue is a good idea.
+
+        :param request: oauthlib.common.Request
         """
 
         # First check for fatal errors
@@ -353,6 +363,9 @@ class AuthorizationCodeGrant(GrantTypeBase):
         return request.scopes, request_info
 
     def validate_token_request(self, request):
+        """
+        :param request: oauthlib.common.Request
+        """
         # REQUIRED. Value MUST be set to "authorization_code".
         if request.grant_type not in ('authorization_code', 'openid'):
             raise errors.UnsupportedGrantTypeError(request=request)

--- a/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
@@ -140,7 +140,6 @@ class AuthorizationCodeGrant(GrantTypeBase):
                               oauthlib.oauth2.BearerToken.
         :returns: headers, body, status
         :raises: FatalClientError on invalid redirect URI or client id.
-                 ValueError if scopes are not set on the request object.
 
         A few examples::
 
@@ -151,12 +150,6 @@ class AuthorizationCodeGrant(GrantTypeBase):
             >>> from oauthlib.oauth2 import AuthorizationCodeGrant, BearerToken
             >>> token = BearerToken(your_validator)
             >>> grant = AuthorizationCodeGrant(your_validator)
-            >>> grant.create_authorization_response(request, token)
-            Traceback (most recent call last):
-                File "<stdin>", line 1, in <module>
-                File "oauthlib/oauth2/rfc6749/grant_types.py", line 513, in create_authorization_response
-                    raise ValueError('Scopes must be set on post auth.')
-            ValueError: Scopes must be set on post auth.
             >>> request.scopes = ['authorized', 'in', 'some', 'form']
             >>> grant.create_authorization_response(request, token)
             (u'http://client.com/?error=invalid_request&error_description=Missing+response_type+parameter.', None, None, 400)
@@ -182,11 +175,6 @@ class AuthorizationCodeGrant(GrantTypeBase):
         .. _`Section 10.12`: https://tools.ietf.org/html/rfc6749#section-10.12
         """
         try:
-            # request.scopes is only mandated in post auth and both pre and
-            # post auth use validate_authorization_request
-            if not request.scopes:
-                raise ValueError('Scopes must be set on post auth.')
-
             self.validate_authorization_request(request)
             log.debug('Pre resource owner authorization validation ok for %r.',
                       request)

--- a/oauthlib/oauth2/rfc6749/grant_types/base.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/base.py
@@ -116,14 +116,29 @@ class GrantTypeBase(object):
     def register_token_modifier(self, modifier):
         self._token_modifiers.append(modifier)
 
-
     def create_authorization_response(self, request, token_handler):
+        """
+        :param request: oauthlib.common.Request
+        :param token_handler: A token handler instace, for example of type
+                              oauthlib.oauth2.BearerToken.
+        """
         raise NotImplementedError('Subclasses must implement this method.')
 
     def create_token_response(self, request, token_handler):
+        """
+        :param request: oauthlib.common.Request
+        :param token_handler: A token handler instace, for example of type
+                              oauthlib.oauth2.BearerToken.
+        """
         raise NotImplementedError('Subclasses must implement this method.')
 
     def add_token(self, token, token_handler, request):
+        """
+        :param token: 
+        :param token_handler: A token handler instace, for example of type
+                              oauthlib.oauth2.BearerToken.
+        :param request: oauthlib.common.Request
+        """
         # Only add a hybrid access token on auth step if asked for
         if not request.response_type in ["token", "code token", "id_token token", "code id_token token"]:
             return token
@@ -132,6 +147,9 @@ class GrantTypeBase(object):
         return token
 
     def validate_grant_type(self, request):
+        """
+        :param request: oauthlib.common.Request
+        """
         client_id = getattr(request, 'client_id', None)
         if not self.request_validator.validate_grant_type(client_id,
                                                           request.grant_type, request.client, request):
@@ -140,6 +158,9 @@ class GrantTypeBase(object):
             raise errors.UnauthorizedClientError(request=request)
 
     def validate_scopes(self, request):
+        """
+        :param request: oauthlib.common.Request
+        """
         if not request.scopes:
             request.scopes = utils.scope_to_list(request.scope) or utils.scope_to_list(
                 self.request_validator.get_default_scopes(request.client_id, request))
@@ -154,6 +175,12 @@ class GrantTypeBase(object):
 
         Base classes can define a default response mode for their authorization
         response by overriding the static `default_response_mode` member.
+
+        :param request: oauthlib.common.Request
+        :param token: 
+        :param headers: 
+        :param body: 
+        :param status: 
         """
         request.response_mode = request.response_mode or self.default_response_mode
 

--- a/oauthlib/oauth2/rfc6749/grant_types/client_credentials.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/client_credentials.py
@@ -59,6 +59,10 @@ class ClientCredentialsGrant(GrantTypeBase):
         failed client authentication or is invalid, the authorization server
         returns an error response as described in `Section 5.2`_.
 
+        :param request: oauthlib.common.Request
+        :param token_handler: A token handler instace, for example of type
+                              oauthlib.oauth2.BearerToken.
+
         .. _`Section 5.1`: https://tools.ietf.org/html/rfc6749#section-5.1
         .. _`Section 5.2`: https://tools.ietf.org/html/rfc6749#section-5.2
         """
@@ -85,6 +89,9 @@ class ClientCredentialsGrant(GrantTypeBase):
         return headers, json.dumps(token), 200
 
     def validate_token_request(self, request):
+        """
+        :param request: oauthlib.common.Request
+        """
         for validator in self.custom_validators.pre_token:
             validator(request)
 

--- a/oauthlib/oauth2/rfc6749/grant_types/implicit.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/implicit.py
@@ -200,11 +200,6 @@ class ImplicitGrant(GrantTypeBase):
         .. _`Section 7.1`: https://tools.ietf.org/html/rfc6749#section-7.1
         """
         try:
-            # request.scopes is only mandated in post auth and both pre and
-            # post auth use validate_authorization_request
-            if not request.scopes:
-                raise ValueError('Scopes must be set on post auth.')
-
             self.validate_token_request(request)
 
         # If the request fails due to a missing, invalid, or mismatching

--- a/oauthlib/oauth2/rfc6749/grant_types/implicit.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/implicit.py
@@ -152,6 +152,10 @@ class ImplicitGrant(GrantTypeBase):
         access token matches a redirection URI registered by the client as
         described in `Section 3.1.2`_.
 
+        :param request: oauthlib.common.Request
+        :param token_handler: A token handler instace, for example of type
+                              oauthlib.oauth2.BearerToken.
+
         .. _`Section 2.2`: https://tools.ietf.org/html/rfc6749#section-2.2
         .. _`Section 3.1.2`: https://tools.ietf.org/html/rfc6749#section-3.1.2
         .. _`Section 3.3`: https://tools.ietf.org/html/rfc6749#section-3.3
@@ -194,6 +198,10 @@ class ImplicitGrant(GrantTypeBase):
                 client.
 
         The authorization server MUST NOT issue a refresh token.
+
+        :param request: oauthlib.common.Request
+        :param token_handler: A token handler instace, for example of type
+                              oauthlib.oauth2.BearerToken.
 
         .. _`Appendix B`: https://tools.ietf.org/html/rfc6749#appendix-B
         .. _`Section 3.3`: https://tools.ietf.org/html/rfc6749#section-3.3
@@ -243,6 +251,9 @@ class ImplicitGrant(GrantTypeBase):
             request, token, {}, None, 302)
 
     def validate_authorization_request(self, request):
+        """
+        :param request: oauthlib.common.Request
+        """
         return self.validate_token_request(request)
 
     def validate_token_request(self, request):
@@ -260,6 +271,8 @@ class ImplicitGrant(GrantTypeBase):
         missing. These must be caught by the provider and handled, how this
         is done is outside of the scope of OAuthLib but showing an error
         page describing the issue is a good idea.
+
+        :param request: oauthlib.common.Request
         """
 
         # First check for fatal errors

--- a/oauthlib/oauth2/rfc6749/grant_types/refresh_token.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/refresh_token.py
@@ -46,6 +46,10 @@ class RefreshTokenGrant(GrantTypeBase):
         identical to that of the refresh token included by the client in the
         request.
 
+        :param request: oauthlib.common.Request
+        :param token_handler: A token handler instace, for example of type
+                              oauthlib.oauth2.BearerToken.
+
         .. _`Section 5.1`: https://tools.ietf.org/html/rfc6749#section-5.1
         .. _`Section 5.2`: https://tools.ietf.org/html/rfc6749#section-5.2
         """
@@ -72,6 +76,10 @@ class RefreshTokenGrant(GrantTypeBase):
         return headers, json.dumps(token), 200
 
     def validate_token_request(self, request):
+        """
+        :param request: oauthlib.common.Request
+        """
+    
         # REQUIRED. Value MUST be set to "refresh_token".
         if request.grant_type != 'refresh_token':
             raise errors.UnsupportedGrantTypeError(request=request)

--- a/oauthlib/oauth2/rfc6749/grant_types/resource_owner_password_credentials.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/resource_owner_password_credentials.py
@@ -79,6 +79,10 @@ class ResourceOwnerPasswordCredentialsGrant(GrantTypeBase):
         authentication or is invalid, the authorization server returns an
         error response as described in `Section 5.2`_.
 
+        :param request: oauthlib.common.Request
+        :param token_handler: A token handler instace, for example of type
+                              oauthlib.oauth2.BearerToken.
+
         .. _`Section 5.1`: https://tools.ietf.org/html/rfc6749#section-5.1
         .. _`Section 5.2`: https://tools.ietf.org/html/rfc6749#section-5.2
         """
@@ -152,6 +156,8 @@ class ResourceOwnerPasswordCredentialsGrant(GrantTypeBase):
         password, the authorization server MUST protect the endpoint against
         brute force attacks (e.g., using rate-limitation or generating
         alerts).
+
+        :param request: oauthlib.common.Request
 
         .. _`Section 3.3`: https://tools.ietf.org/html/rfc6749#section-3.3
         .. _`Section 3.2.1`: https://tools.ietf.org/html/rfc6749#section-3.2.1

--- a/oauthlib/oauth2/rfc6749/parameters.py
+++ b/oauthlib/oauth2/rfc6749/parameters.py
@@ -37,9 +37,9 @@ def prepare_grant_uri(uri, client_id, response_type, redirect_uri=None,
     using the ``application/x-www-form-urlencoded`` format as defined by
     [`W3C.REC-html401-19991224`_]:
 
+    :param client_id: The client identifier as described in `Section 2.2`_.
     :param response_type: To indicate which OAuth 2 grant/flow is required,
                           "code" and "token".
-    :param client_id: The client identifier as described in `Section 2.2`_.
     :param redirect_uri: The client provided URI to redirect back to after
                          authorization as described in `Section 3.1.2`_.
     :param scope: The scope of the access request as described by
@@ -133,14 +133,14 @@ def prepare_token_revocation_request(url, token, token_type_hint="access_token",
     using the "application/x-www-form-urlencoded" format in the HTTP request
     entity-body:
 
-    token   REQUIRED.  The token that the client wants to get revoked.
+    :param token:   REQUIRED.  The token that the client wants to get revoked.
 
-    token_type_hint  OPTIONAL.  A hint about the type of the token submitted
-    for revocation.  Clients MAY pass this parameter in order to help the
-    authorization server to optimize the token lookup.  If the server is unable
-    to locate the token using the given hint, it MUST extend its search across
-    all of its supported token types.  An authorization server MAY ignore this
-    parameter, particularly if it is able to detect the token type
+    :param token_type_hint:  OPTIONAL.  A hint about the type of the token
+    submitted for revocation.  Clients MAY pass this parameter in order to help
+    the authorization server to optimize the token lookup.  If the server is
+    unable to locate the token using the given hint, it MUST extend its search
+    across all of its supported token types.  An authorization server MAY ignore
+    this parameter, particularly if it is able to detect the token type
     automatically.  This specification defines two such values:
 
         * access_token: An access token as defined in [RFC6749],

--- a/oauthlib/oauth2/rfc6749/request_validator.py
+++ b/oauthlib/oauth2/rfc6749/request_validator.py
@@ -74,6 +74,7 @@ class RequestValidator(object):
         to set request.client to the client object associated with the
         given client_id.
 
+        :param client_id: Unicode client identifier
         :param request: oauthlib.common.Request
         :rtype: True or False
 
@@ -306,6 +307,9 @@ class RequestValidator(object):
         """Persist the token with a token type specific method.
 
         Currently, only save_bearer_token is supported.
+
+        :param token: A (Bearer) token dict
+        :param request: The HTTP Request (oauthlib.common.Request)
         """
         return self.save_bearer_token(token, request, *args, **kwargs)
 
@@ -509,6 +513,7 @@ class RequestValidator(object):
         to set request.client to the client object associated with the
         given client_id.
 
+        :param client_id: Unicode client identifier
         :param request: oauthlib.common.Request
         :rtype: True or False
 

--- a/oauthlib/oauth2/rfc6749/tokens.py
+++ b/oauthlib/oauth2/rfc6749/tokens.py
@@ -97,9 +97,9 @@ def prepare_mac_header(token, uri, key, http_method,
     .. _`extension algorithms`: https://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-01#section-7.1
 
     :param uri: Request URI.
-    :param headers: Request headers as a dictionary.
-    :param http_method: HTTP Request method.
     :param key: MAC given provided by token endpoint.
+    :param http_method: HTTP Request method.
+    :param headers: Request headers as a dictionary.
     :param hash_algorithm: HMAC algorithm provided by token endpoint.
     :param issue_time: Time when the MAC credentials were issued (datetime).
     :param draft: MAC authentication specification version.

--- a/tests/oauth2/rfc6749/endpoints/test_base_endpoint.py
+++ b/tests/oauth2/rfc6749/endpoints/test_base_endpoint.py
@@ -24,7 +24,9 @@ class BaseEndpointTest(TestCase):
         validator = RequestValidator()
         server = Server(validator)
         server.catch_errors = True
-        h, b, s = server.create_authorization_response('https://example.com')
+        h, b, s = server.create_token_response(
+            'https://example.com?grant_type=authorization_code&code=abc'
+        )
         self.assertIn("server_error", b)
         self.assertEqual(s, 500)
 

--- a/tests/oauth2/rfc6749/grant_types/test_authorization_code.py
+++ b/tests/oauth2/rfc6749/grant_types/test_authorization_code.py
@@ -77,6 +77,12 @@ class AuthorizationCodeGrantTest(TestCase):
         self.assertTrue(self.mock_validator.validate_response_type.called)
         self.assertTrue(self.mock_validator.validate_scopes.called)
 
+    def test_create_authorization_grant_no_scopes(self):
+        bearer = BearerToken(self.mock_validator)
+        self.request.response_mode = 'query'
+        self.request.scopes = []
+        self.auth.create_authorization_response(self.request, bearer)
+
     def test_create_authorization_grant_state(self):
         self.request.state = 'abc'
         self.request.redirect_uri = None


### PR DESCRIPTION
this is an initial attempt at #578

I reviewed the oauth2 docs for missing or out-of-order docstrings in general, and fixed what i could based on my familiarity with the library and existing strings for the param in other functions.

the following are still deficient. if someone can offer suggestions for them, I will integrate them into this PR>

# parameters.py

* `prepare_grant_uri` there is no docstring for the `uri` param. 
* `prepare_token_revocation_request` missing docstring for `uri` and `callback`
* `parse_implicit_response` missing docstring for `uri`, `state` and `scope`

# tokens.py

* `prepare_mac_header` there is no docstring for `token`, `nonce`, `body`, `ext`
* `prepare_bearer_uri` no docstrings for params
* `prepare_bearer_headers` no docstrings for params
* `prepare_bearer_body` no docstrings for params
* `BearerToken` no methods have docstrings for params

# grant_types/base

* `GrantTypeBase.add_token`  what is `token`?
* `GrantTypeBase.prepare_authorization_response`  what is `token`? headers, body, status


