### PR TITLE
Make scope optional for authorization code grant

### DIFF
--- a/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
@@ -140,7 +140,6 @@ class AuthorizationCodeGrant(GrantTypeBase):
                               oauthlib.oauth2.BearerToken.
         :returns: headers, body, status
         :raises: FatalClientError on invalid redirect URI or client id.
-                 ValueError if scopes are not set on the request object.
 
         A few examples::
 
@@ -151,12 +150,6 @@ class AuthorizationCodeGrant(GrantTypeBase):
             >>> from oauthlib.oauth2 import AuthorizationCodeGrant, BearerToken
             >>> token = BearerToken(your_validator)
             >>> grant = AuthorizationCodeGrant(your_validator)
-            >>> grant.create_authorization_response(request, token)
-            Traceback (most recent call last):
-                File "<stdin>", line 1, in <module>
-                File "oauthlib/oauth2/rfc6749/grant_types.py", line 513, in create_authorization_response
-                    raise ValueError('Scopes must be set on post auth.')
-            ValueError: Scopes must be set on post auth.
             >>> request.scopes = ['authorized', 'in', 'some', 'form']
             >>> grant.create_authorization_response(request, token)
             (u'http://client.com/?error=invalid_request&error_description=Missing+response_type+parameter.', None, None, 400)
@@ -182,11 +175,6 @@ class AuthorizationCodeGrant(GrantTypeBase):
         .. _`Section 10.12`: https://tools.ietf.org/html/rfc6749#section-10.12
         """
         try:
-            # request.scopes is only mandated in post auth and both pre and
-            # post auth use validate_authorization_request
-            if not request.scopes:
-                raise ValueError('Scopes must be set on post auth.')
-
             self.validate_authorization_request(request)
             log.debug('Pre resource owner authorization validation ok for %r.',
                       request)

--- a/tests/oauth2/rfc6749/endpoints/test_base_endpoint.py
+++ b/tests/oauth2/rfc6749/endpoints/test_base_endpoint.py
@@ -24,7 +24,9 @@ class BaseEndpointTest(TestCase):
         validator = RequestValidator()
         server = Server(validator)
         server.catch_errors = True
-        h, b, s = server.create_authorization_response('https://example.com')
+        h, b, s = server.create_token_response(
+            'https://example.com?grant_type=authorization_code&code=abc'
+        )
         self.assertIn("server_error", b)
         self.assertEqual(s, 500)
 

--- a/tests/oauth2/rfc6749/grant_types/test_authorization_code.py
+++ b/tests/oauth2/rfc6749/grant_types/test_authorization_code.py
@@ -77,6 +77,12 @@ class AuthorizationCodeGrantTest(TestCase):
         self.assertTrue(self.mock_validator.validate_response_type.called)
         self.assertTrue(self.mock_validator.validate_scopes.called)
 
+    def test_create_authorization_grant_no_scopes(self):
+        bearer = BearerToken(self.mock_validator)
+        self.request.response_mode = 'query'
+        self.request.scopes = []
+        self.auth.create_authorization_response(self.request, bearer)
+
     def test_create_authorization_grant_state(self):
         self.request.state = 'abc'
         self.request.redirect_uri = None


### PR DESCRIPTION
As discussed in #406.  Sibling PR to #475.

Currently a WIP.  I'm having some trouble perhaps someone can help with:  Remove the scopes check causes [this test](https://github.com/oauthlib/oauthlib/blob/master/tests/oauth2/rfc6749/endpoints/test_base_endpoint.py#L23) to fail, because the test was using it as an example of a server error.  However, I can't find another error raised that isn't an OAuth2Error or FatalClientError.