### PR TITLE
Remove workarounds for unsupported Python 2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,9 @@ def fread(fn):
     with open(join(dirname(__file__), fn), 'r') as f:
         return f.read()
 
-if sys.version_info[0] == 3:
-    tests_require = ['nose', 'cryptography', 'pyjwt>=1.0.0', 'blinker']
-else:
-    tests_require = ['nose', 'unittest2', 'cryptography', 'mock>=2.0', 'pyjwt>=1.0.0', 'blinker']
+tests_require = ['nose', 'cryptography', 'pyjwt>=1.0.0', 'blinker']
+if sys.version_info[0] == 2:
+    tests_require.append('mock>=2.0')
 rsa_require = ['cryptography']
 signedtoken_require = ['cryptography', 'pyjwt>=1.0.0']
 signals_require = ['blinker']

--- a/tests/unittest/__init__.py
+++ b/tests/unittest/__init__.py
@@ -1,32 +1,15 @@
 import collections
 import sys
+from unittest import TestCase
 try:
     import urlparse
 except ImportError:
     import urllib.parse as urlparse
 
-try:
-    # check the system path first
-    from unittest2 import *
-except ImportError:
-    if sys.version_info >= (2, 7):
-        # unittest2 features are native in Python 2.7
-        from unittest import *
-    else:
-        raise
-
-# Python 3.1 does not provide assertIsInstance
-if sys.version_info[1] == 1:
-    TestCase.assertIsInstance = lambda self, obj, cls: self.assertTrue(isinstance(obj, cls))
 
 # Somewhat consistent itemsequal between all python versions
-if sys.version_info[1] == 3:
+if sys.version_info[0] == 3:
     TestCase.assertItemsEqual = TestCase.assertCountEqual
-elif sys.version_info[0] == 2 and sys.version_info[1] == 6:
-    pass
-else:
-    TestCase.assertItemsEqual = lambda self, a, b: self.assertEqual(
-            collections.Counter(list(a)), collections.Counter(list(b)))
 
 
 # URL comparison where query param order is insignifcant

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,6 @@ deps=
     -rrequirements-test.txt
 commands=nosetests -s --with-coverage --cover-html --cover-html-dir={toxinidir}/htmlcov-{envname} --cover-erase --cover-package=oauthlib -w tests
 
-[testenv:py27]
-deps=unittest2
-     {[testenv]deps}
-
 # tox -e docs to mimick readthedocs build.
 # as of today, RTD is using python2.7 and doesn't run "setup.py install"
 [testenv:docs]


### PR DESCRIPTION
Python 2.6 support was removed in 91152df142bdde134d84ed27963cda8e6b878416.

Drop unittest2 dependency. All necessary testing features are included in the stdlib unittest.