### PR TITLE
Remove unnecessary workaround for bytes type

### DIFF
--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -54,10 +54,8 @@ PY3 = sys.version_info[0] == 3
 
 if PY3:
     unicode_type = str
-    bytes_type = bytes
 else:
     unicode_type = unicode
-    bytes_type = str
 
 
 # 'safe' must be bytes (Python 2.6 requires bytes, other versions allow either)
@@ -66,7 +64,7 @@ def quote(s, safe=b'/'):
     s = _quote(s, safe)
     # PY3 always returns unicode.  PY2 may return either, depending on whether
     # it had to modify the string.
-    if isinstance(s, bytes_type):
+    if isinstance(s, bytes):
         s = s.decode('utf-8')
     return s
 
@@ -76,7 +74,7 @@ def unquote(s):
     # PY3 always returns unicode.  PY2 seems to always return what you give it,
     # which differs from quote's behavior.  Just to be safe, make sure it is
     # unicode before we return.
-    if isinstance(s, bytes_type):
+    if isinstance(s, bytes):
         s = s.decode('utf-8')
     return s
 
@@ -109,8 +107,8 @@ def decode_params_utf8(params):
     decoded = []
     for k, v in params:
         decoded.append((
-            k.decode('utf-8') if isinstance(k, bytes_type) else k,
-            v.decode('utf-8') if isinstance(v, bytes_type) else v))
+            k.decode('utf-8') if isinstance(k, bytes) else k,
+            v.decode('utf-8') if isinstance(v, bytes) else v))
     return decoded
 
 
@@ -174,7 +172,7 @@ def extract_params(raw):
     empty list of parameters. Any other input will result in a return
     value of None.
     """
-    if isinstance(raw, bytes_type) or isinstance(raw, unicode_type):
+    if isinstance(raw, bytes) or isinstance(raw, unicode_type):
         try:
             params = urldecode(raw)
         except ValueError:
@@ -309,7 +307,7 @@ def to_unicode(data, encoding='UTF-8'):
     if isinstance(data, unicode_type):
         return data
 
-    if isinstance(data, bytes_type):
+    if isinstance(data, bytes):
         return unicode_type(data, encoding=encoding)
 
     if hasattr(data, '__iter__'):

--- a/oauthlib/oauth1/rfc5849/__init__.py
+++ b/oauthlib/oauth1/rfc5849/__init__.py
@@ -18,11 +18,6 @@ try:
 except ImportError:
     import urllib.parse as urlparse
 
-if sys.version_info[0] == 3:
-    bytes_type = bytes
-else:
-    bytes_type = str
-
 from oauthlib.common import Request, urlencode, generate_nonce
 from oauthlib.common import generate_timestamp, to_unicode
 from . import parameters, signature

--- a/oauthlib/oauth1/rfc5849/signature.py
+++ b/oauthlib/oauth1/rfc5849/signature.py
@@ -28,7 +28,7 @@ import hashlib
 import hmac
 import logging
 
-from oauthlib.common import (bytes_type, extract_params, safe_string_equals,
+from oauthlib.common import (extract_params, safe_string_equals,
                              unicode_type, urldecode)
 
 from . import utils
@@ -635,7 +635,7 @@ def verify_hmac_sha1(request, client_secret=None,
 
 
 def _prepare_key_plus(alg, keystr):
-    if isinstance(keystr, bytes_type):
+    if isinstance(keystr, bytes):
         keystr = keystr.decode('utf-8')
     return alg.prepare_key(keystr)
 

--- a/oauthlib/oauth1/rfc5849/utils.py
+++ b/oauthlib/oauth1/rfc5849/utils.py
@@ -8,7 +8,7 @@ spec.
 """
 from __future__ import absolute_import, unicode_literals
 
-from oauthlib.common import bytes_type, quote, unicode_type, unquote
+from oauthlib.common import quote, unicode_type, unquote
 
 try:
     import urllib2

--- a/tests/oauth1/rfc5849/test_client.py
+++ b/tests/oauth1/rfc5849/test_client.py
@@ -5,7 +5,7 @@ from oauthlib.common import Request
 from oauthlib.oauth1 import (SIGNATURE_PLAINTEXT, SIGNATURE_HMAC_SHA1,
                              SIGNATURE_HMAC_SHA256, SIGNATURE_RSA,
                              SIGNATURE_TYPE_BODY, SIGNATURE_TYPE_QUERY)
-from oauthlib.oauth1.rfc5849 import Client, bytes_type
+from oauthlib.oauth1.rfc5849 import Client
 
 from ...unittest import TestCase
 
@@ -39,7 +39,7 @@ class ClientConstructorTests(TestCase):
     def test_convert_to_unicode_resource_owner(self):
         client = Client('client-key',
                         resource_owner_key=b'owner key')
-        self.assertFalse(isinstance(client.resource_owner_key, bytes_type))
+        self.assertFalse(isinstance(client.resource_owner_key, bytes))
         self.assertEqual(client.resource_owner_key, 'owner key')
 
     def test_give_explicit_timestamp(self):
@@ -57,11 +57,11 @@ class ClientConstructorTests(TestCase):
         uri, headers, body = client.sign('http://a.b/path?query',
                 http_method='POST', body='a=b',
                 headers={'Content-Type': 'application/x-www-form-urlencoded'})
-        self.assertIsInstance(uri, bytes_type)
-        self.assertIsInstance(body, bytes_type)
+        self.assertIsInstance(uri, bytes)
+        self.assertIsInstance(body, bytes)
         for k, v in headers.items():
-            self.assertIsInstance(k, bytes_type)
-            self.assertIsInstance(v, bytes_type)
+            self.assertIsInstance(k, bytes)
+            self.assertIsInstance(v, bytes)
 
     def test_hmac_sha1(self):
         client = Client('client_key')

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -10,11 +10,6 @@ from oauthlib.common import (CaseInsensitiveDict, Request, add_params_to_uri,
 
 from .unittest import TestCase
 
-if sys.version_info[0] == 3:
-    bytes_type = bytes
-else:
-    bytes_type = lambda s, e: str(s)
-
 PARAMS_DICT = {'foo': 'bar', 'baz': '123', }
 PARAMS_TWOTUPLE = [('foo', 'bar'), ('baz', '123')]
 PARAMS_FORMENCODED = 'foo=bar&baz=123'
@@ -122,11 +117,11 @@ class RequestTest(TestCase):
 
     def test_non_unicode_params(self):
         r = Request(
-            bytes_type('http://a.b/path?query', 'utf-8'),
-            http_method=bytes_type('GET', 'utf-8'),
-            body=bytes_type('you=shall+pass', 'utf-8'),
+            b'http://a.b/path?query',
+            http_method=b'GET',
+            body=b'you=shall+pass',
             headers={
-                bytes_type('a', 'utf-8'): bytes_type('b', 'utf-8')
+                b'a': b'b',
             }
         )
         self.assertEqual(r.uri, 'http://a.b/path?query')


### PR DESCRIPTION
The type `bytes` is available on all supported Pythons. Likewise the byte literal `b'...'` is available on all supported Pythons. Use idiomatic Python and remove workaround for an issue that no longer exists. Makes the code more forward compatible with Python 3.