### PR TITLE
Remove unmaintained nose dependency from tests

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,3 @@
 -r requirements.txt
 coverage>=3.7.1
-nose==1.3.7
 mock>=2.0

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def fread(fn):
     with open(join(dirname(__file__), fn), 'r') as f:
         return f.read()
 
-tests_require = ['nose', 'cryptography', 'pyjwt>=1.0.0', 'blinker']
+tests_require = ['cryptography', 'pyjwt>=1.0.0', 'blinker']
 if sys.version_info[0] == 2:
     tests_require.append('mock>=2.0')
 rsa_require = ['cryptography']
@@ -40,7 +40,6 @@ setup(
     platforms='any',
     license='BSD',
     packages=find_packages(exclude=('docs', 'tests', 'tests.*')),
-    test_suite='nose.collector',
     tests_require=tests_require,
     extras_require={
         'test': tests_require,

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,10 @@ envlist = py27,py34,py35,py36,pypy,docs,readme
 [testenv]
 deps=
     -rrequirements-test.txt
-commands=nosetests -s --with-coverage --cover-html --cover-html-dir={toxinidir}/htmlcov-{envname} --cover-erase --cover-package=oauthlib -w tests
+commands=
+    coverage run --source oauthlib -m unittest discover
+    coverage report
+
 
 # tox -e docs to mimick readthedocs build.
 # as of today, RTD is using python2.7 and doesn't run "setup.py install"


### PR DESCRIPTION
The nose project has ceased development. From their docs page:

https://nose.readthedocs.io/

> Note to Users
>
> Nose has been in maintenance mode for the past several years and will likely cease without a new person/team to take over maintainership. New projects should consider using Nose2, py.test, or just plain unittest/unittest2.

Simplify test infrastructure by using the stdlib unittest discover command. One fewer dependency.