### PR TITLE
Correct capitalization of PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ logic for Python 2.7 and 3.4+.*
   :alt: Coveralls
 .. image:: https://img.shields.io/pypi/pyversions/oauthlib.svg
   :target: https://pypi.org/project/oauthlib/
-  :alt: Download from PyPi
+  :alt: Download from PyPI
 .. image:: https://img.shields.io/pypi/l/oauthlib.svg
   :target: https://pypi.org/project/oauthlib/
   :alt: License

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,7 +9,7 @@ For various reasons you may wish to install using your OS packaging system and
 install instructions for a few are shown below. Please send a PR to add a
 missing one.
 
-Latest release on PYPI
+Latest release on PyPI
 ----------------------
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ changedir=docs
 whitelist_externals=make
 commands=make clean html
 
-# tox -e readme to mimick pypi long_description check
+# tox -e readme to mimick PyPI long_description check
 [testenv:readme]
 skipsdist=True
 deps=readme


### PR DESCRIPTION
As spelled on https://pypi.org/.