### PR TITLE
Wrong Client is also a FatalClientError

### DIFF
--- a/oauthlib/oauth2/rfc6749/errors.py
+++ b/oauthlib/oauth2/rfc6749/errors.py
@@ -224,7 +224,7 @@ class TemporarilyUnavailableError(OAuth2Error):
     error = 'temporarily_unavailable'
 
 
-class InvalidClientError(OAuth2Error):
+class InvalidClientError(FatalClientError):
     """
     Client authentication failed (e.g. unknown client, no client
     authentication included, or unsupported authentication method).


### PR DESCRIPTION
FatalClientError is it SHOULD NOT be redirected to client (redirect_uri), but MUST be redirected to USERS (error_uri).

Fix https://github.com/oauthlib/oauthlib/issues/606