### PR TITLE
613 oidc dispatcher

### DIFF
--- a/oauthlib/openid/__init__.py
+++ b/oauthlib/openid/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+"""
+oauthlib.openid
+~~~~~~~~~~~~~~
+
+"""
+from __future__ import absolute_import, unicode_literals
+
+from .connect.core.endpoints import Server

--- a/oauthlib/openid/connect/core/endpoints/__init__.py
+++ b/oauthlib/openid/connect/core/endpoints/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+"""
+oauthlib.oopenid.core
+~~~~~~~~~~~~~~~~~~~~~~~
+
+This module is an implementation of various logic needed
+for consuming and providing OpenID Connect
+"""
+from __future__ import absolute_import, unicode_literals
+
+from .pre_configured import Server

--- a/oauthlib/openid/connect/core/endpoints/pre_configured.py
+++ b/oauthlib/openid/connect/core/endpoints/pre_configured.py
@@ -72,8 +72,8 @@ class Server(AuthorizationEndpoint, TokenEndpoint, ResourceEndpoint,
         jwt = JWTToken(request_validator, token_generator,
                        token_expires_in, refresh_token_generator)
 
-        auth_grant_choice = AuthorizationCodeGrantDispatcher(default_auth_grant=auth_grant, oidc_auth_grant=openid_connect_auth)
-        implicit_grant_choice = ImplicitTokenGrantDispatcher(default_implicit_grant=implicit_grant, oidc_implicit_grant=openid_connect_implicit)
+        auth_grant_choice = AuthorizationCodeGrantDispatcher(default_grant=auth_grant, oidc_grant=openid_connect_auth)
+        implicit_grant_choice = ImplicitTokenGrantDispatcher(default_grant=implicit_grant, oidc_grant=openid_connect_implicit)
 
         # See http://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#Combinations for valid combinations
         # internally our AuthorizationEndpoint will ensure they can appear in any order for any valid combination
@@ -90,7 +90,7 @@ class Server(AuthorizationEndpoint, TokenEndpoint, ResourceEndpoint,
                                        },
                                        default_token_type=bearer)
 
-        token_grant_choice = AuthorizationTokenGrantDispatcher(request_validator, default_token_grant=auth_grant, oidc_token_grant=openid_connect_auth)
+        token_grant_choice = AuthorizationTokenGrantDispatcher(request_validator, default_grant=auth_grant, oidc_grant=openid_connect_auth)
 
         TokenEndpoint.__init__(self, default_grant_type='authorization_code',
                                grant_types={

--- a/oauthlib/openid/connect/core/grant_types/dispatchers.py
+++ b/oauthlib/openid/connect/core/grant_types/dispatchers.py
@@ -2,20 +2,25 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class AuthorizationCodeGrantDispatcher(object):
+class Dispatcher(object):
+    default_grant = None
+    oidc_grant = None
+
+
+class AuthorizationCodeGrantDispatcher(Dispatcher):
     """
     This is an adapter class that will route simple Authorization Code requests, those that have response_type=code and a scope
-    including 'openid' to either the default_auth_grant or the oidc_auth_grant based on the scopes requested.
+    including 'openid' to either the default_grant or the oidc_grant based on the scopes requested.
     """
-    def __init__(self, default_auth_grant=None, oidc_auth_grant=None):
-        self.default_auth_grant = default_auth_grant
-        self.oidc_auth_grant = oidc_auth_grant
+    def __init__(self, default_grant=None, oidc_grant=None):
+        self.default_grant = default_grant
+        self.oidc_grant = oidc_grant
 
     def _handler_for_request(self, request):
-        handler = self.default_auth_grant
+        handler = self.default_grant
 
         if request.scopes and "openid" in request.scopes:
-            handler = self.oidc_auth_grant
+            handler = self.oidc_grant
 
         log.debug('Selecting handler for request %r.', handler)
         return handler
@@ -27,20 +32,20 @@ class AuthorizationCodeGrantDispatcher(object):
         return self._handler_for_request(request).validate_authorization_request(request)
 
 
-class ImplicitTokenGrantDispatcher(object):
+class ImplicitTokenGrantDispatcher(Dispatcher):
     """
     This is an adapter class that will route simple Authorization Code requests, those that have response_type=code and a scope
-    including 'openid' to either the default_auth_grant or the oidc_auth_grant based on the scopes requested.
+    including 'openid' to either the default_grant or the oidc_grant based on the scopes requested.
     """
-    def __init__(self, default_implicit_grant=None, oidc_implicit_grant=None):
-        self.default_implicit_grant = default_implicit_grant
-        self.oidc_implicit_grant = oidc_implicit_grant
+    def __init__(self, default_grant=None, oidc_grant=None):
+        self.default_grant = default_grant
+        self.oidc_grant = oidc_grant
 
     def _handler_for_request(self, request):
-        handler = self.default_implicit_grant
+        handler = self.default_grant
 
         if request.scopes and "openid" in request.scopes and 'id_token' in request.response_type:
-            handler = self.oidc_implicit_grant
+            handler = self.oidc_grant
 
         log.debug('Selecting handler for request %r.', handler)
         return handler
@@ -52,31 +57,31 @@ class ImplicitTokenGrantDispatcher(object):
         return self._handler_for_request(request).validate_authorization_request(request)
 
 
-class AuthorizationTokenGrantDispatcher(object):
+class AuthorizationTokenGrantDispatcher(Dispatcher):
     """
     This is an adapter class that will route simple Token requests, those that authorization_code have a scope
-    including 'openid' to either the default_token_grant or the oidc_token_grant based on the scopes requested.
+    including 'openid' to either the default_grant or the oidc_grant based on the scopes requested.
     """
-    def __init__(self, request_validator, default_token_grant=None, oidc_token_grant=None):
-        self.default_token_grant = default_token_grant
-        self.oidc_token_grant = oidc_token_grant
+    def __init__(self, request_validator, default_grant=None, oidc_grant=None):
+        self.default_grant = default_grant
+        self.oidc_grant = oidc_grant
         self.request_validator = request_validator
 
     def _handler_for_request(self, request):
-        handler = self.default_token_grant
+        handler = self.default_grant
         scopes = ()
         parameters = dict(request.decoded_body)
         client_id = parameters.get('client_id', None)
         code = parameters.get('code', None)
         redirect_uri = parameters.get('redirect_uri', None)
 
-        # If code is not pressent fallback to `default_token_grant` wich will
+        # If code is not pressent fallback to `default_grant` wich will
         # raise an error for the missing `code` in `create_token_response` step.
         if code:
             scopes = self.request_validator.get_authorization_code_scopes(client_id, code, redirect_uri, request)
 
         if 'openid' in scopes:
-            handler = self.oidc_token_grant
+            handler = self.oidc_grant
 
         log.debug('Selecting handler for request %r.', handler)
         return handler

--- a/tests/openid/connect/core/grant_types/test_dispatchers.py
+++ b/tests/openid/connect/core/grant_types/test_dispatchers.py
@@ -28,8 +28,8 @@ class ImplicitTokenGrantDispatcherTest(TestCase):
         openid_connect_implicit = ImplicitGrant(request_validator)
 
         self.dispatcher = ImplicitTokenGrantDispatcher(
-            default_implicit_grant=implicit_grant,
-            oidc_implicit_grant=openid_connect_implicit
+            default_grant=implicit_grant,
+            oidc_grant=openid_connect_implicit
         )
 
     def test_create_authorization_response_openid(self):
@@ -76,8 +76,8 @@ class AuthTokenGrantDispatcherOpenIdTest(DispatcherTest):
         self.request_validator.get_authorization_code_scopes.return_value = ('hello', 'openid')
         self.dispatcher = AuthorizationTokenGrantDispatcher(
             self.request_validator,
-            default_token_grant=self.auth_grant,
-            oidc_token_grant=self.openid_connect_auth
+            default_grant=self.auth_grant,
+            oidc_grant=self.openid_connect_auth
         )
 
     def test_create_token_response_openid(self):
@@ -98,8 +98,8 @@ class AuthTokenGrantDispatcherOpenIdWithoutCodeTest(DispatcherTest):
         self.request_validator.get_authorization_code_scopes.return_value = ('hello', 'openid')
         self.dispatcher = AuthorizationTokenGrantDispatcher(
             self.request_validator,
-            default_token_grant=self.auth_grant,
-            oidc_token_grant=self.openid_connect_auth
+            default_grant=self.auth_grant,
+            oidc_grant=self.openid_connect_auth
         )
 
     def test_create_token_response_openid_without_code(self):
@@ -115,8 +115,8 @@ class AuthTokenGrantDispatcherOAuthTest(DispatcherTest):
         self.request_validator.get_authorization_code_scopes.return_value = ('hello', 'world')
         self.dispatcher = AuthorizationTokenGrantDispatcher(
             self.request_validator,
-            default_token_grant=self.auth_grant,
-            oidc_token_grant=self.openid_connect_auth
+            default_grant=self.auth_grant,
+            oidc_grant=self.openid_connect_auth
         )
 
     def test_create_token_response_oauth(self):


### PR DESCRIPTION
While working toward https://github.com/oauthlib/oauthlib/issues/613, it does not solve the issue completely.

However, this PR has two benefits:
- increases user-experience for OIDC (by using `import oauthlib.openid.Server` instead of `import oauthlib.openid.core.pre_configured.endpoints.Server`
- custom_validators are now "reasonnably" doable, even though not really simple

Example of adding a custom_validator+code_modifier for OIDC (same need as explained in #613):

```python
    done = []
    for response_type, handler in oauthlib_server._response_types.items():
        if handler in done:
            continue

        handler.default_grant.custom_validators.pre_auth.append(myhook)
        handler.oidc_grant.custom_validators.pre_auth.append(myhook)
        if "code" in response_type:
            handler.default_grant.register_code_modifier(mymodifier)
            handler.oidc_grant.register_code_modifier(mymodifier)
        done.append(handler)
```