### PR TITLE
Support for Python 3.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+.idea
 *.sublime-project
 *.sublime-workspace
 *.swp
@@ -22,6 +23,7 @@ develop-eggs
 pip-log.txt
 
 # Unit test / coverage reports
+.cache
 .coverage
 .tox
 coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ matrix:
     env: TOXENV=py36
   - python: 3.7
     env: TOXENV=py37
-  - python: pypy-5.3
-    env: TOXENV=pypy
+  - python: pypy3.5
+    env: TOXENV=pypy3
 install:
 - pip install -U setuptools
 - pip install tox coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+python: 3.7
+dist: xenial
 sudo: false
 cache: pip
 matrix:
@@ -11,6 +13,8 @@ matrix:
     env: TOXENV=py35
   - python: 3.6
     env: TOXENV=py36
+  - python: 3.7
+    env: TOXENV=py37
   - python: pypy-5.3
     env: TOXENV=pypy
 install:

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,pypy,docs,readme
+envlist = py27,py34,py35,py36,py37,pypy,docs,readme
 
 [testenv]
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,pypy,docs,readme
+envlist = py27,py34,py35,py36,py37,pypy,pypy3,docs,readme
 
 [testenv]
 deps=


### PR DESCRIPTION
This adds Python 3.7 to the Tox and Travis configs. 

Switching to Travis' Xenial image means we need to switch to PyPy 3.5 as well.