### PR TITLE
Fix issue when using Metadata Endpoint with OIDC PreConfigured server.

### DIFF
--- a/oauthlib/oauth2/rfc6749/endpoints/metadata.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/metadata.py
@@ -98,7 +98,7 @@ class MetadataEndpoint(BaseEndpoint):
         self.validate_metadata(claims, "token_endpoint", is_required=True, is_url=True)
 
     def validate_metadata_authorization(self, claims, endpoint):
-        claims.setdefault("response_types_supported", list(self._response_types.keys()))
+        claims.setdefault("response_types_supported", list(endpoint._response_types.keys()))
         claims.setdefault("response_modes_supported", ["query", "fragment"])
 
         self.validate_metadata(claims, "response_types_supported", is_required=True, is_list=True)

--- a/oauthlib/openid/connect/core/endpoints/pre_configured.py
+++ b/oauthlib/openid/connect/core/endpoints/pre_configured.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import, unicode_literals
 
 from oauthlib.oauth2.rfc6749.endpoints import (
     AuthorizationEndpoint,
+    IntrospectEndpoint,
     ResourceEndpoint,
     RevocationEndpoint,
     TokenEndpoint
@@ -35,8 +36,8 @@ from ..grant_types.dispatchers import (
 from ..tokens import JWTToken
 
 
-class Server(AuthorizationEndpoint, TokenEndpoint, ResourceEndpoint,
-             RevocationEndpoint):
+class Server(AuthorizationEndpoint, IntrospectEndpoint, TokenEndpoint,
+             ResourceEndpoint, RevocationEndpoint):
 
     """An all-in-one endpoint featuring all four major grant types."""
 
@@ -103,3 +104,4 @@ class Server(AuthorizationEndpoint, TokenEndpoint, ResourceEndpoint,
         ResourceEndpoint.__init__(self, default_token='Bearer',
                                   token_types={'Bearer': bearer, 'JWT': jwt})
         RevocationEndpoint.__init__(self, request_validator)
+        IntrospectEndpoint.__init__(self, request_validator)

--- a/tests/oauth2/rfc6749/endpoints/test_metadata.py
+++ b/tests/oauth2/rfc6749/endpoints/test_metadata.py
@@ -13,6 +13,33 @@ class MetadataEndpointTest(TestCase):
             "issuer": 'https://foo.bar'
         }
 
+    def test_openid_oauth2_preconfigured(self):
+        default_claims = {
+            "issuer": 'https://foo.bar',
+            "authorization_endpoint": "https://foo.bar/authorize",
+            "revocation_endpoint": "https://foo.bar/revoke",
+            "introspection_endpoint": "https://foo.bar/introspect",
+            "token_endpoint": "https://foo.bar/token"
+        }
+        from oauthlib.oauth2 import Server as OAuth2Server
+        from oauthlib.openid import Server as OpenIDServer
+
+        endpoint = OAuth2Server(None)
+        metadata = MetadataEndpoint([endpoint], default_claims)
+        oauth2_claims = metadata.claims
+
+        endpoint = OpenIDServer(None)
+        metadata = MetadataEndpoint([endpoint], default_claims)
+        openid_claims = metadata.claims
+
+        # Pure OAuth2 Authorization Metadata are similar with OpenID but
+        # response_type not! (OIDC contains "id_token" and hybrid flows)
+        del oauth2_claims['response_types_supported']
+        del openid_claims['response_types_supported']
+
+        self.maxDiff = None
+        self.assertEqual(openid_claims, oauth2_claims)
+
     def test_token_endpoint(self):
         endpoint = TokenEndpoint(None, None, grant_types={"password": None})
         metadata = MetadataEndpoint([endpoint], {


### PR DESCRIPTION
When migrating a OAuth2 Preconfigured Server into a OIDC Preconfigured Server, the Metadata Endpoint stop fonctionning.
Added an unit test in addition to cover that.