### PR TITLE
Fix invalid escape sequence in tests

### DIFF
--- a/tests/oauth1/rfc5849/endpoints/test_base.py
+++ b/tests/oauth1/rfc5849/endpoints/test_base.py
@@ -60,7 +60,7 @@ class BaseEndpointTest(TestCase):
     def test_expired_timestamp(self):
         headers = {}
         for pattern in ('12345678901', '4567890123', '123456789K'):
-            headers['Authorization'] = sub('timestamp="\d*k?"',
+            headers['Authorization'] = sub(r'timestamp="\d*k?"',
                     'timestamp="%s"' % pattern,
                      self.headers['Authorization'])
             h, b, s = self.endpoint.create_request_token_response(


### PR DESCRIPTION
Fixes warning when running tests:

```
tests/oauth1/rfc5849/endpoints/test_base.py:63
  oauthlib/tests/oauth1/rfc5849/endpoints/test_base.py:63: DeprecationWarning: invalid escape sequence \d
    headers['Authorization'] = sub('timestamp="\d*k?"',
```