### PR TITLE
Remove unused 'tests_require' from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,7 @@ def fread(fn):
     with open(join(dirname(__file__), fn), 'r') as f:
         return f.read()
 
-tests_require = ['cryptography', 'pyjwt>=1.0.0', 'blinker']
-if sys.version_info[0] == 2:
-    tests_require.append('mock>=2.0')
+
 rsa_require = ['cryptography']
 signedtoken_require = ['cryptography', 'pyjwt>=1.0.0']
 signals_require = ['blinker']
@@ -40,9 +38,7 @@ setup(
     platforms='any',
     license='BSD',
     packages=find_packages(exclude=('docs', 'tests', 'tests.*')),
-    tests_require=tests_require,
     extras_require={
-        'test': tests_require,
         'rsa': rsa_require,
         'signedtoken': signedtoken_require,
         'signals': signals_require,


### PR DESCRIPTION
Neither used by Travis CI nor by tox.ini. The mock package was out of
sync with requirements-tests.txt for Python 3 environments. Rather than
maintain this duplicate, unused list of requirements just remove it.