### PR TITLE
Fixed graphviz/dot graph & improved clarity

### DIFF
--- a/docs/oauth2/oauth2provider-legend.dot
+++ b/docs/oauth2/oauth2provider-legend.dot
@@ -18,8 +18,8 @@ digraph oauthlib_legend {
         flow_introspect [shape=none,label="Token Introspection"];
         flow_revoke [shape=none,label="Token Revoke"];
         flow_resource [shape=none,label="Resource Access"];
-        flow_code_token -> a [style=bold,color=green];
-        flow_code_auth -> b [style=bold,color=darkgreen];
+        flow_code_token -> a [style=bold,color=darkgreen];
+        flow_code_auth -> b [style=bold,color=green];
         flow_implicit -> c [style=bold,color=orange];
         flow_password -> d [style=bold,color=red];
         flow_clicreds -> e [style=bold,color=blue];

--- a/docs/oauth2/oauth2provider-server.dot
+++ b/docs/oauth2/oauth2provider-server.dot
@@ -100,7 +100,7 @@ digraph oauthlib {
         if_redirect_uri_missing -> f_get_default_redirect_uri;
 
         f_confirm_redirect_uri:true:s -> f_save_bearer_token;
-        f_get_default_redirect_uri -> f_save_bearer_token;
+        f_get_default_redirect_uri:redirect_uri:s -> f_save_bearer_token;
 
         f_save_bearer_token -> f_invalidate_authorization_code;
         f_invalidate_authorization_code -> webapi_response;
@@ -121,7 +121,7 @@ digraph oauthlib {
         r_redirect_uri_code -> f_validate_response_type;v
         f_validate_response_type:true:s -> f_is_pkce_required;
         f_is_pkce_required:true:s -> if_code_challenge;
-        f_is_pkce_required:false -> f_validate_scopes;
+        f_is_pkce_required:false:s -> f_validate_scopes;
 
         if_code_challenge -> f_validate_scopes [ label="present" ];
         if_code_challenge -> e_normal [ label="missing" ];
@@ -175,7 +175,7 @@ digraph oauthlib {
         edge [ color=blue ];
 
         endpoint_token:client_credentials:s -> f_authenticate_client;
-        f_authenticate_client -> f_validate_grant_type;
+        f_authenticate_client:true:s -> f_validate_grant_type;
         f_validate_grant_type:true:s -> f_validate_scopes;
         f_validate_scopes:true:s -> f_save_bearer_token;
         f_save_bearer_token -> webapi_response;

--- a/docs/oauth2/oauth2provider-server.dot
+++ b/docs/oauth2/oauth2provider-server.dot
@@ -74,9 +74,7 @@ digraph oauthlib {
     if_all [ label="all(request_scopes not in scopes)"; ];
 
     /* OAuthlib functions returns helpers */
-    r_client_authenticated [ shape=none,label="True"; ];
-    r_redirect_uri_code [ shape=none,label="",width=0,height=0 ];
-    r_redirect_uri_token [ shape=none,label="",width=0,height=0 ];
+    r_client_authenticated [ shape=none,label="client authenticated"; ];
 
     /* OAuthlib errors */
     e_normal [ shape=none,label="ERROR" ];

--- a/docs/oauth2/oauth2provider-server.dot
+++ b/docs/oauth2/oauth2provider-server.dot
@@ -71,7 +71,7 @@ digraph oauthlib {
 
     /* Authorization Code - Access Token Request */
     {
-        edge [ color=green ];
+        edge [ color=darkgreen ];
 
         endpoint_token:authorization_code:s -> f_client_authentication_required;
         f_client_authentication_required:true:s -> f_authenticate_client;
@@ -94,7 +94,7 @@ digraph oauthlib {
     }
     /* Authorization Code - Authorization Request */
     {
-        edge [ color=darkgreen ];
+        edge [ color=green ];
 
         endpoint_authorize:code:s -> f_validate_client_id;
         f_validate_client_id:true:s -> if_redirect_uri;

--- a/docs/oauth2/oauth2provider-server.dot
+++ b/docs/oauth2/oauth2provider-server.dot
@@ -113,6 +113,7 @@ digraph oauthlib {
         if_code_challenge -> e_normal [ label="missing" ];
 
         f_validate_scopes:true:s -> f_save_authorization_code;
+        f_save_authorization_code -> webapi_response;
     }
 
     /* Implicit */ 
@@ -130,6 +131,7 @@ digraph oauthlib {
         f_get_default_redirect_uri -> f_validate_response_type;
         f_validate_response_type:true:s -> f_validate_scopes;
         f_validate_scopes:true:s -> f_save_bearer_token;
+        f_save_bearer_token -> webapi_response;
     }
 
     /* Resource Owner Password Grant */

--- a/docs/oauth2/oauth2provider-server.dot
+++ b/docs/oauth2/oauth2provider-server.dot
@@ -187,7 +187,7 @@ digraph oauthlib {
     {
         edge [ color=yellow ];
 
-        endpoint_introspect:s -> f_client_authentication_required [ label="" ];
+        endpoint_introspect:s -> f_client_authentication_required;
         f_client_authentication_required:true:s -> f_authenticate_client;
         f_client_authentication_required:false -> f_authenticate_client_id;
         f_authenticate_client:true:s -> f_introspect_token;

--- a/docs/oauth2/oauth2provider-server.dot
+++ b/docs/oauth2/oauth2provider-server.dot
@@ -73,6 +73,11 @@ digraph oauthlib {
     if_scopes [ label="if scopes"; ];
     if_all [ label="all(request_scopes not in scopes)"; ];
 
+    /* OAuthlib functions returns helpers */
+    r_client_authenticated [ shape=none,label="True"; ];
+    r_redirect_uri_code [ shape=none,label="",width=0,height=0 ];
+    r_redirect_uri_token [ shape=none,label="",width=0,height=0 ];
+
     /* OAuthlib errors */
     e_normal [ shape=none,label="ERROR" ];
 
@@ -82,9 +87,10 @@ digraph oauthlib {
 
         endpoint_token:authorization_code:s -> f_client_authentication_required;
         f_client_authentication_required:true:s -> f_authenticate_client;
-        f_client_authentication_required:false -> f_authenticate_client_id;
-        f_authenticate_client:true:s -> f_validate_grant_type;
-        f_authenticate_client_id:true:s -> f_validate_grant_type;
+        f_client_authentication_required:false:s -> f_authenticate_client_id;
+        f_authenticate_client:true:s -> r_client_authenticated [ arrowhead=none ];
+        f_authenticate_client_id:true:s -> r_client_authenticated [ arrowhead=none ];
+        r_client_authenticated -> f_validate_grant_type;
         f_validate_grant_type:true:s -> f_validate_code;
 
         f_validate_code:true:s -> if_redirect_uri;
@@ -110,8 +116,9 @@ digraph oauthlib {
         if_redirect_uri_present -> f_validate_redirect_uri;
         if_redirect_uri_missing -> f_get_default_redirect_uri;
 
-        f_validate_redirect_uri:true:s -> f_validate_response_type;
-        f_get_default_redirect_uri -> f_validate_response_type;
+        f_validate_redirect_uri:true:s -> r_redirect_uri_code [ arrowhead=none ];
+        f_get_default_redirect_uri:redirect_uri:s -> r_redirect_uri_code [ arrowhead=none ];
+        r_redirect_uri_code -> f_validate_response_type;v
         f_validate_response_type:true:s -> f_is_pkce_required;
         f_is_pkce_required:true:s -> if_code_challenge;
         f_is_pkce_required:false -> f_validate_scopes;
@@ -134,8 +141,9 @@ digraph oauthlib {
         if_redirect_uri_present -> f_validate_redirect_uri;
         if_redirect_uri_missing -> f_get_default_redirect_uri;
 
-        f_validate_redirect_uri:true:s -> f_validate_response_type;
-        f_get_default_redirect_uri -> f_validate_response_type;
+        f_validate_redirect_uri:true:s -> r_redirect_uri_token [ arrowhead=none ];
+        f_get_default_redirect_uri:redirect_uri:s -> r_redirect_uri_token [ arrowhead=none ];
+        r_redirect_uri_token -> f_validate_response_type;
         f_validate_response_type:true:s -> f_validate_scopes;
         f_validate_scopes:true:s -> f_save_bearer_token;
         f_save_bearer_token -> webapi_response;
@@ -147,9 +155,10 @@ digraph oauthlib {
 
         endpoint_token:password:s -> f_client_authentication_required;
         f_client_authentication_required:true:s -> f_authenticate_client;
-        f_client_authentication_required:false -> f_authenticate_client_id;
-        f_authenticate_client:true:s -> f_validate_user;
-        f_authenticate_client_id:true:s -> f_validate_user;
+        f_client_authentication_required:false:s -> f_authenticate_client_id;
+        f_authenticate_client:true:s -> r_client_authenticated [ arrowhead=none ];
+        f_authenticate_client_id:true:s -> r_client_authenticated [ arrowhead=none ];
+        r_client_authenticated -> f_validate_user;
         f_validate_user:true:s -> f_validate_grant_type;
 
         f_validate_grant_type:true:s -> if_scopes;
@@ -178,9 +187,11 @@ digraph oauthlib {
 
         endpoint_token:refresh_token:s -> f_client_authentication_required;
         f_client_authentication_required:true:s -> f_authenticate_client;
-        f_client_authentication_required:false -> f_authenticate_client_id;
-        f_authenticate_client:true:s -> f_validate_grant_type;
-        f_authenticate_client_id:true:s -> f_validate_grant_type;
+        f_client_authentication_required:false:s -> f_authenticate_client_id;
+        f_authenticate_client:true:s -> r_client_authenticated [ arrowhead=none ];
+        f_authenticate_client_id:true:s -> r_client_authenticated [ arrowhead=none ];
+        r_client_authenticated -> f_validate_grant_type;
+
         f_validate_grant_type:true:s -> f_validate_refresh_token;
         f_validate_refresh_token:true:s -> f_get_original_scopes;
         f_get_original_scopes -> if_all;
@@ -196,9 +207,10 @@ digraph oauthlib {
 
         endpoint_introspect:s -> f_client_authentication_required;
         f_client_authentication_required:true:s -> f_authenticate_client;
-        f_client_authentication_required:false -> f_authenticate_client_id;
-        f_authenticate_client:true:s -> f_introspect_token;
-        f_authenticate_client_id:true:s -> f_introspect_token;
+        f_client_authentication_required:false:s -> f_authenticate_client_id;
+        f_authenticate_client:true:s -> r_client_authenticated [ arrowhead=none ];
+        f_authenticate_client_id:true:s -> r_client_authenticated [ arrowhead=none ];
+        r_client_authenticated -> f_introspect_token;
         f_introspect_token:claims -> webapi_response;
     }
 
@@ -208,9 +220,10 @@ digraph oauthlib {
 
         endpoint_revoke:s -> f_client_authentication_required;
         f_client_authentication_required:true:s -> f_authenticate_client;
-        f_client_authentication_required:false -> f_authenticate_client_id;
-        f_authenticate_client:true:s -> f_revoke_token;
-        f_authenticate_client_id:true:s -> f_revoke_token;
+        f_client_authentication_required:false:s -> f_authenticate_client_id;
+        f_authenticate_client:true:s -> r_client_authenticated [ arrowhead=none ];
+        f_authenticate_client_id:true:s -> r_client_authenticated [ arrowhead=none ];
+        r_client_authenticated -> f_revoke_token;
         f_revoke_token:s -> webapi_response;
     }
 

--- a/docs/oauth2/oauth2provider-server.dot
+++ b/docs/oauth2/oauth2provider-server.dot
@@ -81,6 +81,43 @@ digraph oauthlib {
     /* OAuthlib errors */
     e_normal [ shape=none,label="ERROR" ];
 
+    /* Ranking by functional roles */
+    {
+        rank = same;
+        f_validate_client_id;
+        f_validate_code;
+        /* f_validate_user; */
+        f_validate_bearer_token;
+        f_validate_refresh_token;
+        f_introspect_token;
+        f_revoke_token;
+    }
+    {
+        rank = same;
+        f_validate_redirect_uri;
+        f_get_default_redirect_uri;
+        f_confirm_redirect_uri;
+    }
+    {
+        rank = same;
+        f_save_bearer_token;
+        f_save_authorization_code;
+    }
+    {
+        rank = same;
+        f_invalidate_authorization_code;
+    }
+    {
+        rank = same;
+        f_get_original_scopes;
+        f_get_default_scopes;
+    }
+    {
+        rank = same;
+        f_is_within_original_scope;
+        f_validate_scopes;
+    }
+
     /* Authorization Code - Access Token Request */
     {
         edge [ color=darkgreen ];
@@ -116,15 +153,14 @@ digraph oauthlib {
         if_redirect_uri_present -> f_validate_redirect_uri;
         if_redirect_uri_missing -> f_get_default_redirect_uri;
 
-        f_validate_redirect_uri:true:s -> r_redirect_uri_code [ arrowhead=none ];
-        f_get_default_redirect_uri:redirect_uri:s -> r_redirect_uri_code [ arrowhead=none ];
-        r_redirect_uri_code -> f_validate_response_type;v
+        f_validate_redirect_uri:true:s -> f_validate_response_type;
+        f_get_default_redirect_uri:redirect_uri:s -> f_validate_response_type;
         f_validate_response_type:true:s -> f_is_pkce_required;
         f_is_pkce_required:true:s -> if_code_challenge;
         f_is_pkce_required:false:s -> f_validate_scopes;
 
         if_code_challenge -> f_validate_scopes [ label="present" ];
-        if_code_challenge -> e_normal [ label="missing" ];
+        if_code_challenge -> e_normal [ label="missing",style=dashed ];
 
         f_validate_scopes:true:s -> f_save_authorization_code;
         f_save_authorization_code -> webapi_response;
@@ -141,9 +177,8 @@ digraph oauthlib {
         if_redirect_uri_present -> f_validate_redirect_uri;
         if_redirect_uri_missing -> f_get_default_redirect_uri;
 
-        f_validate_redirect_uri:true:s -> r_redirect_uri_token [ arrowhead=none ];
-        f_get_default_redirect_uri:redirect_uri:s -> r_redirect_uri_token [ arrowhead=none ];
-        r_redirect_uri_token -> f_validate_response_type;
+        f_validate_redirect_uri:true:s -> f_validate_response_type;
+        f_get_default_redirect_uri:redirect_uri:s -> f_validate_response_type;
         f_validate_response_type:true:s -> f_validate_scopes;
         f_validate_scopes:true:s -> f_save_bearer_token;
         f_save_bearer_token -> webapi_response;

--- a/docs/oauth2/oauth2provider-server.dot
+++ b/docs/oauth2/oauth2provider-server.dot
@@ -1,4 +1,11 @@
 digraph oauthlib {
+    /* Naming conventions:
+    f_ : functions in shape=record
+    endpoint_ : endpoints in shape=record
+    webapi_ : oauthlib entry/exit points in shape=hexagon
+    if_ : internal conditions
+    r_ : used when returning from two functions into one for improving clarity
+    */
     center="1"
     edge [ style=bold ];
 

--- a/docs/oauth2/oauth2provider-server.dot
+++ b/docs/oauth2/oauth2provider-server.dot
@@ -93,7 +93,6 @@ digraph oauthlib {
     {
         rank = same;
         f_validate_redirect_uri;
-        f_get_default_redirect_uri;
         f_confirm_redirect_uri;
     }
     {
@@ -107,13 +106,13 @@ digraph oauthlib {
     }
     {
         rank = same;
+        f_validate_scopes;
         f_get_original_scopes;
         f_get_default_scopes;
     }
     {
         rank = same;
         f_is_within_original_scope;
-        f_validate_scopes;
     }
 
     /* Authorization Code - Access Token Request */
@@ -133,10 +132,9 @@ digraph oauthlib {
         if_redirect_uri -> if_redirect_uri_missing [ arrowhead=none ];
         if_redirect_uri_present -> f_confirm_redirect_uri;
         if_redirect_uri_missing -> f_get_default_redirect_uri;
+        f_get_default_redirect_uri:redirect_uri:s -> f_confirm_redirect_uri;
 
         f_confirm_redirect_uri:true:s -> f_save_bearer_token;
-        f_get_default_redirect_uri:redirect_uri:s -> f_save_bearer_token;
-
         f_save_bearer_token -> f_invalidate_authorization_code;
         f_invalidate_authorization_code -> webapi_response;
     }


### PR DESCRIPTION
I fixed graphviz missing output to web responses (see image of https://github.com/oauthlib/oauthlib/pull/639), and I have added a fixed rank (`rank=same`) when functions are achieving an identical goal. E.g. `validate_client_id`, `validate_user`, `validate_bearer_token` are unique for each flows, or, e.g. `confirm_redirect_uri`, `validate_redirect_uri` together, and so on.

![graphviz-0cc58e8637b94d7402eda45a1fef6e68889bd8e1](https://user-images.githubusercontent.com/820496/50830407-042ad600-1348-11e9-936a-03d07f42494f.png)
