### PR TITLE
Fix 644, Add tests for BasicAuth credentials for all endpoints

### DIFF
--- a/oauthlib/oauth2/rfc6749/endpoints/introspect.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/introspect.py
@@ -56,7 +56,7 @@ class IntrospectEndpoint(BaseEndpoint):
         an introspection response indicating the token is not active
         as described in Section 2.2.
         """
-        headers = {
+        resp_headers = {
             'Content-Type': 'application/json',
             'Cache-Control': 'no-store',
             'Pragma': 'no-cache',
@@ -67,8 +67,8 @@ class IntrospectEndpoint(BaseEndpoint):
             log.debug('Token introspect valid for %r.', request)
         except OAuth2Error as e:
             log.debug('Client error during validation of %r. %r.', request, e)
-            headers.update(e.headers)
-            return headers, e.json, e.status_code
+            resp_headers.update(e.headers)
+            return resp_headers, e.json, e.status_code
 
         claims = self.request_validator.introspect_token(
             request.token,
@@ -76,10 +76,10 @@ class IntrospectEndpoint(BaseEndpoint):
             request
         )
         if claims is None:
-            return headers, json.dumps(dict(active=False)), 200
+            return resp_headers, json.dumps(dict(active=False)), 200
         if "active" in claims:
             claims.pop("active")
-        return headers, json.dumps(dict(active=True, **claims)), 200
+        return resp_headers, json.dumps(dict(active=True, **claims)), 200
 
     def validate_introspect_request(self, request):
         """Ensure the request is valid.

--- a/oauthlib/oauth2/rfc6749/endpoints/revocation.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/revocation.py
@@ -58,7 +58,7 @@ class RevocationEndpoint(BaseEndpoint):
         An invalid token type hint value is ignored by the authorization server
         and does not influence the revocation response.
         """
-        headers = {
+        resp_headers = {
             'Content-Type': 'application/json',
             'Cache-Control': 'no-store',
             'Pragma': 'no-cache',
@@ -73,8 +73,8 @@ class RevocationEndpoint(BaseEndpoint):
             response_body = e.json
             if self.enable_jsonp and request.callback:
                 response_body = '%s(%s);' % (request.callback, response_body)
-            headers.update(e.headers)
-            return headers, response_body, e.status_code
+            resp_headers.update(e.headers)
+            return resp_headers, response_body, e.status_code
 
         self.request_validator.revoke_token(request.token,
                                             request.token_type_hint, request)

--- a/tests/oauth2/rfc6749/endpoints/test_introspect_endpoint.py
+++ b/tests/oauth2/rfc6749/endpoints/test_introspect_endpoint.py
@@ -123,7 +123,6 @@ class IntrospectEndpointTest(TestCase):
         self.assertEqual(loads(b)['error'], 'invalid_client')
         self.assertEqual(s, 401)
 
-
     def test_introspect_unsupported_token(self):
         endpoint = IntrospectEndpoint(self.validator,
                                       supported_token_types=['access_token'])


### PR DESCRIPTION
Test Introspect, Revoke, Token (web, legacy, backend) endpoints with authenticate_client and HTTP Basic Auth.