### PR TITLE
Fixed space encoding in base string URI used in the signature base st…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+TBD
+---
+
+* Fixed space encoding in base string URI used in the signature base string.
+
 3.0.0 (2019-01-01)
 ------------------
 OAuth2.0 Provider - outstanding Features

--- a/oauthlib/oauth1/rfc5849/__init__.py
+++ b/oauthlib/oauth1/rfc5849/__init__.py
@@ -137,7 +137,7 @@ class Client(object):
         log.debug("Normalized params: {0}".format(normalized_params))
         log.debug("Normalized URI: {0}".format(normalized_uri))
 
-        base_string = signature.construct_base_string(request.http_method,
+        base_string = signature.signature_base_string(request.http_method,
                                                       normalized_uri, normalized_params)
 
         log.debug("Signing: signature base string: {0}".format(base_string))

--- a/oauthlib/oauth1/rfc5849/__init__.py
+++ b/oauthlib/oauth1/rfc5849/__init__.py
@@ -133,8 +133,7 @@ class Client(object):
         log.debug("Collected params: {0}".format(collected_params))
 
         normalized_params = signature.normalize_parameters(collected_params)
-        normalized_uri = signature.normalize_base_string_uri(uri,
-                                                             headers.get('Host', None))
+        normalized_uri = signature.base_string_uri(uri, headers.get('Host', None))
         log.debug("Normalized params: {0}".format(normalized_params))
         log.debug("Normalized URI: {0}".format(normalized_uri))
 

--- a/tests/oauth1/rfc5849/test_signatures.py
+++ b/tests/oauth1/rfc5849/test_signatures.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 
 from oauthlib.common import unicode_type
 from oauthlib.oauth1.rfc5849.signature import (collect_parameters,
-                                               construct_base_string,
+                                               signature_base_string,
                                                base_string_uri,
                                                normalize_parameters,
                                                sign_hmac_sha1,
@@ -79,7 +79,7 @@ class SignatureTests(TestCase):
             resource_owner_secret = self.resource_owner_secret
         )
 
-    def test_construct_base_string(self):
+    def test_signature_base_string(self):
         """
         Example text to be turned into a base string::
 
@@ -104,20 +104,20 @@ class SignatureTests(TestCase):
             D%2522137131201%2522%252Coauth_nonce%253D%25227d8f3e4a%2522%252Coau
             th_signature%253D%2522bYT5CMsGcbgUdFHObYMEfcx6bsw%25253D%2522
         """
-        self.assertRaises(ValueError, construct_base_string,
+        self.assertRaises(ValueError, signature_base_string,
                           self.http_method,
                           self.base_string_url,
                           self.normalized_encoded_request_parameters)
-        self.assertRaises(ValueError, construct_base_string,
+        self.assertRaises(ValueError, signature_base_string,
                           self.http_method.decode('utf-8'),
                           self.base_string_url,
                           self.normalized_encoded_request_parameters)
-        self.assertRaises(ValueError, construct_base_string,
+        self.assertRaises(ValueError, signature_base_string,
                           self.http_method.decode('utf-8'),
                           self.base_string_url.decode('utf-8'),
                           self.normalized_encoded_request_parameters)
 
-        base_string = construct_base_string(
+        base_string = signature_base_string(
             self.http_method.decode('utf-8'),
             self.base_string_url.decode('utf-8'),
             self.normalized_encoded_request_parameters.decode('utf-8')

--- a/tests/oauth1/rfc5849/test_signatures.py
+++ b/tests/oauth1/rfc5849/test_signatures.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, unicode_literals
 from oauthlib.common import unicode_type
 from oauthlib.oauth1.rfc5849.signature import (collect_parameters,
                                                construct_base_string,
-                                               normalize_base_string_uri,
+                                               base_string_uri,
                                                normalize_parameters,
                                                sign_hmac_sha1,
                                                sign_hmac_sha1_with_client,
@@ -125,7 +125,7 @@ class SignatureTests(TestCase):
 
         self.assertEqual(self.control_base_string, base_string)
 
-    def test_normalize_base_string_uri(self):
+    def test_base_string_uri(self):
         """
         Example text to be turned into a normalized base string uri::
 
@@ -137,33 +137,44 @@ class SignatureTests(TestCase):
             https://www.example.net:8080/
         """
 
+        # test first example from RFC 5849 section 3.4.1.2.
+        # Note: there is a space between "r" and "v"
+        uri = 'http://EXAMPLE.COM:80/r v/X?id=123'
+        self.assertEqual(base_string_uri(uri),
+                         'http://example.com/r%20v/X')
+
+        # test second example from RFC 5849 section 3.4.1.2.
+        uri = 'https://www.example.net:8080/?q=1'
+        self.assertEqual(base_string_uri(uri),
+                         'https://www.example.net:8080/')
+
         # test for unicode failure
         uri = b"www.example.com:8080"
-        self.assertRaises(ValueError, normalize_base_string_uri, uri)
+        self.assertRaises(ValueError, base_string_uri, uri)
 
         # test for missing scheme
         uri = "www.example.com:8080"
-        self.assertRaises(ValueError, normalize_base_string_uri, uri)
+        self.assertRaises(ValueError, base_string_uri, uri)
 
         # test a URI with the default port
         uri = "http://www.example.com:80/"
-        self.assertEqual(normalize_base_string_uri(uri),
+        self.assertEqual(base_string_uri(uri),
                          "http://www.example.com/")
 
         # test a URI missing a path
         uri = "http://www.example.com"
-        self.assertEqual(normalize_base_string_uri(uri),
+        self.assertEqual(base_string_uri(uri),
                          "http://www.example.com/")
 
         # test a relative URI
         uri = "/a-host-relative-uri"
         host = "www.example.com"
-        self.assertRaises(ValueError, normalize_base_string_uri, (uri, host))
+        self.assertRaises(ValueError, base_string_uri, (uri, host))
 
         # test overriding the URI's netloc with a host argument
         uri = "http://www.example.com/a-path"
         host = "alternatehost.example.com"
-        self.assertEqual(normalize_base_string_uri(uri, host),
+        self.assertEqual(base_string_uri(uri, host),
                          "http://alternatehost.example.com/a-path")
 
     def test_collect_parameters(self):


### PR DESCRIPTION
Encode spaces in the URI correctly as "%20" in the _base string URI_.
This pull request addresses issue <https://github.com/oauthlib/oauthlib/issues/650>.

The _base string URI_ is used in the _signature base string_, which is the value that is signed. Before this fix, any spaces were not encoded and that caused the wrong signature to be generated, or for signature verification to fail.

Comments have been added to point out that RFC 5849 is deficient in this area, and the only indication that spaces must be encoded is in one of its examples. It is not known whether other special characters need to be encoded too.

The function "normalize_base_string_uri" has been renamed to `base_string_uri`, since it just calculates the [base string URI](https://tools.ietf.org/html/rfc5849#section-3.4.1.2). There is no "normalisation" (whatever that means) of the "base string URI" value. Suggestion: rename _construct_base_string_ to _construct_signature_base_string_ or _signature_base_string_ (since it calculates the [signature base string](https://tools.ietf.org/html/rfc5849#section-3.4.1), not something called a "base string").