### PR TITLE
Remove usage of "state" for code/token response.

### DIFF
--- a/examples/skeleton_oauth2_web_application_server.py
+++ b/examples/skeleton_oauth2_web_application_server.py
@@ -48,7 +48,7 @@ class SkeletonValidator(RequestValidator):
 
     def save_authorization_code(self, client_id, code, request, *args, **kwargs):
         # Remember to associate it with request.scopes, request.redirect_uri
-        # request.client, request.state and request.user (the last is passed in
+        # request.client and request.user (the last is passed in
         # post_authorization credentials, i.e. { 'user': request.user}.
         pass
 
@@ -63,8 +63,8 @@ class SkeletonValidator(RequestValidator):
         return False
 
     def validate_code(self, client_id, code, client, request, *args, **kwargs):
-        # Validate the code belongs to the client. Add associated scopes,
-        # state and user to request.scopes and request.user.
+        # Validate the code belongs to the client. Add associated scopes
+        # and user to request.scopes and request.user.
         pass
 
     def confirm_redirect_uri(self, client_id, code, redirect_uri, client, request, *args, **kwargs):

--- a/oauthlib/oauth2/rfc6749/request_validator.py
+++ b/oauthlib/oauth2/rfc6749/request_validator.py
@@ -266,7 +266,6 @@ class RequestValidator(object):
             - the redirect URI used (``request.redirect_uri``)
             - a resource owner / user (``request.user``)
             - the authorized scopes (``request.scopes``)
-            - the client state, if given (``code.get('state')``)
 
         To support PKCE, you MUST associate the code with:
             - Code Challenge (``request.code_challenge``) and
@@ -276,10 +275,6 @@ class RequestValidator(object):
         ``code`` key with the actual authorization code:
 
             ``{'code': 'sdf345jsdf0934f'}``
-
-        It may also have a ``state`` key containing a nonce for the client, if it
-        chose to send one.  That value should be saved and used in
-        ``.validate_code``.
 
         It may also have a ``claims`` parameter which, when present, will be a dict
         deserialized from JSON as described at
@@ -352,7 +347,7 @@ class RequestValidator(object):
                 'expires_in': 3600,
                 'scope': 'string of space separated authorized scopes',
                 'refresh_token': '23sdf876234',  # if issued
-                'state': 'given_by_client',  # if supplied by client
+                'state': 'given_by_client',  # if supplied by client (implicit ONLY)
             }
 
         Note that while "scope" is a string-separated list of authorized scopes,
@@ -559,7 +554,6 @@ class RequestValidator(object):
         with the code in 'save_authorization_code':
 
             - request.user
-            - request.state (if given)
             - request.scopes
             - request.claims (if given)
         OBS! The request.user attribute should be set to the resource owner

--- a/tests/openid/connect/core/grant_types/test_authorization_code.py
+++ b/tests/openid/connect/core/grant_types/test_authorization_code.py
@@ -116,7 +116,6 @@ class OpenIDAuthCodeTest(TestCase):
 
     def set_scopes(self, client_id, code, client, request):
         request.scopes = self.request.scopes
-        request.state = self.request.state
         request.user = 'bob'
         return True
 


### PR DESCRIPTION
Removed a couple of mentions from the documentation where oauthlib wrongly mention that we have to store `state` alongs with the authorization code.