### PR TITLE
fix include_client_id argument

### DIFF
--- a/oauthlib/oauth2/rfc6749/clients/backend_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/backend_application.py
@@ -29,11 +29,11 @@ class BackendApplicationClient(Client):
     Since the client authentication is used as the authorization grant,
     no additional authorization request is needed.
     """
-    
+
     grant_type = 'client_credentials'
-    
+
     def prepare_request_body(self, body='', scope=None,
-                             include_client_id=None, **kwargs):
+                             include_client_id=False, **kwargs):
         """Add the client credentials to the request body.
 
         The client makes a request to the token endpoint by adding the
@@ -45,11 +45,11 @@ class BackendApplicationClient(Client):
         :param scope:   The scope of the access request as described by
                         `Section 3.3`_.
 
-        :param include_client_id: `True` to send the `client_id` in the body of
-                                  the upstream request. Default `None`. This is
-                                  required if the client is not authenticating
-                                  with the authorization server as described
-                                  in `Section 3.2.1`_.
+        :param include_client_id: `True` to send the `client_id` in the
+                                  body of the upstream request. This is required
+                                  if the client is not authenticating with the
+                                  authorization server as described in
+                                  `Section 3.2.1`_. False otherwise (default).
         :type include_client_id: Boolean
 
         :param kwargs:  Extra credentials to include in the token request.

--- a/oauthlib/oauth2/rfc6749/clients/legacy_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/legacy_application.py
@@ -34,14 +34,14 @@ class LegacyApplicationClient(Client):
     credentials is beyond the scope of this specification.  The client
     MUST discard the credentials once an access token has been obtained.
     """
-    
+
     grant_type = 'password'
 
     def __init__(self, client_id, **kwargs):
         super(LegacyApplicationClient, self).__init__(client_id, **kwargs)
 
     def prepare_request_body(self, username, password, body='', scope=None,
-                             include_client_id=None, **kwargs):
+                             include_client_id=False, **kwargs):
         """Add the resource owner password and username to the request body.
 
         The client makes a request to the token endpoint by adding the
@@ -54,11 +54,11 @@ class LegacyApplicationClient(Client):
                      into. This may contain extra paramters. Default ''.
         :param scope:   The scope of the access request as described by
                         `Section 3.3`_.
-        :param include_client_id: `True` to send the `client_id` in the body of
-                                  the upstream request. Default `None`. This is
-                                  required if the client is not authenticating
-                                  with the authorization server as described
-                                  in `Section 3.2.1`_.
+        :param include_client_id: `True` to send the `client_id` in the
+                                  body of the upstream request. This is required
+                                  if the client is not authenticating with the
+                                  authorization server as described in
+                                  `Section 3.2.1`_. False otherwise (default).
         :type include_client_id: Boolean
         :param kwargs:  Extra credentials to include in the token request.
 

--- a/oauthlib/oauth2/rfc6749/clients/service_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/service_application.py
@@ -41,20 +41,20 @@ class ServiceApplicationClient(Client):
         :param private_key: Private key used for signing and encrypting.
                             Must be given as a string.
 
-        :param subject: The principal that is the subject of the JWT, i.e. 
+        :param subject: The principal that is the subject of the JWT, i.e.
                         which user is the token requested on behalf of.
                         For example, ``foo@example.com.
 
         :param issuer: The JWT MUST contain an "iss" (issuer) claim that
                        contains a unique identifier for the entity that issued
-                       the JWT. For example, ``your-client@provider.com``. 
+                       the JWT. For example, ``your-client@provider.com``.
 
         :param audience: A value identifying the authorization server as an
                          intended audience, e.g.
                          ``https://provider.com/oauth2/token``.
 
         :param kwargs: Additional arguments to pass to base client, such as
-                       state and token. See ``Client.__init__.__doc__`` for 
+                       state and token. See ``Client.__init__.__doc__`` for
                        details.
         """
         super(ServiceApplicationClient, self).__init__(client_id, **kwargs)
@@ -63,17 +63,17 @@ class ServiceApplicationClient(Client):
         self.issuer = issuer
         self.audience = audience
 
-    def prepare_request_body(self, 
+    def prepare_request_body(self,
                              private_key=None,
-                             subject=None, 
-                             issuer=None, 
-                             audience=None, 
-                             expires_at=None, 
+                             subject=None,
+                             issuer=None,
+                             audience=None,
+                             expires_at=None,
                              issued_at=None,
                              extra_claims=None,
-                             body='', 
+                             body='',
                              scope=None,
-                             include_client_id=None,
+                             include_client_id=False,
                              **kwargs):
         """Create and add a JWT assertion to the request body.
 
@@ -86,7 +86,7 @@ class ServiceApplicationClient(Client):
 
         :param issuer: (iss) The JWT MUST contain an "iss" (issuer) claim that
                        contains a unique identifier for the entity that issued
-                       the JWT. For example, ``your-client@provider.com``. 
+                       the JWT. For example, ``your-client@provider.com``.
 
         :param audience: (aud) A value identifying the authorization server as an
                          intended audience, e.g.
@@ -105,11 +105,11 @@ class ServiceApplicationClient(Client):
 
         :param scope: The scope of the access request.
 
-        :param include_client_id: `True` to send the `client_id` in the body of
-                                  the upstream request. Default `None`. This is
-                                  required if the client is not authenticating
-                                  with the authorization server as described
-                                  in `Section 3.2.1`_.
+        :param include_client_id: `True` to send the `client_id` in the
+                                  body of the upstream request. This is required
+                                  if the client is not authenticating with the
+                                  authorization server as described in
+                                  `Section 3.2.1`_. False otherwise (default).
         :type include_client_id: Boolean
 
         :param not_before: A unix timestamp after which the JWT may be used.
@@ -129,7 +129,7 @@ class ServiceApplicationClient(Client):
         [I-D.ietf-oauth-assertions] specification, to indicate the requested
         scope.
 
-        Authentication of the client is optional, as described in 
+        Authentication of the client is optional, as described in
         `Section 3.2.1`_ of OAuth 2.0 [RFC6749] and consequently, the
         "client_id" is only needed when a form of client authentication that
         relies on the parameter is used.
@@ -186,5 +186,5 @@ class ServiceApplicationClient(Client):
         return prepare_token_request(self.grant_type,
                                      body=body,
                                      assertion=assertion,
-                                     scope=scope, 
+                                     scope=scope,
                                      **kwargs)

--- a/oauthlib/oauth2/rfc6749/parameters.py
+++ b/oauthlib/oauth2/rfc6749/parameters.py
@@ -98,7 +98,7 @@ def prepare_token_request(grant_type, body='', include_client_id=True, **kwargs)
                        "authorization_code" or "client_credentials".
 
     :param body: Existing request body (URL encoded string) to embed parameters
-                 into. This may contain extra paramters. Default ''.
+                 into. This may contain extra parameters. Default ''.
 
     :param include_client_id: `True` (default) to send the `client_id` in the
                               body of the upstream request. This is required
@@ -142,7 +142,7 @@ def prepare_token_request(grant_type, body='', include_client_id=True, **kwargs)
     if 'scope' in kwargs:
         kwargs['scope'] = list_to_scope(kwargs['scope'])
 
-    # pull the `client_id` out of the kwargs. 
+    # pull the `client_id` out of the kwargs.
     client_id = kwargs.pop('client_id', None)
     if include_client_id:
         if client_id is not None:


### PR DESCRIPTION
None values are passed to `oauthlib.oauth2.rfc6749.parameters.prepare_token_request`'s `include_client_id` argument, while this function only accepts booleans. Taken documentation and default value from `prepare_token_request` and updated the clients.
Problems are caused by b4ceb8a7

An alternative is to make None a valid input again, and include some auto behaviour on whether to include client_id or not.