### PR TITLE
Fix issue #665: Add method to get / set debug flag (#668)Merge pull request #668 from Abhishek8394/issue-665

### DIFF
--- a/docs/error_reporting.rst
+++ b/docs/error_reporting.rst
@@ -10,15 +10,19 @@ case where that is not true please let us know!
 
 When reporting bugs, especially when they are hard or impossible to reproduce,
 it is useful to include logging output. You can enable logging for all
-oauthlib modules by adding a logger to the `oauthlib` namespace. 
+oauthlib modules by adding a logger to the `oauthlib` namespace. You might also
+want to enable debugging mode to include request data in output.
 
 .. code-block:: python
 
     import logging
+    import oauthlib
     import sys
+    oauthlib.set_debug(True)
     log = logging.getLogger('oauthlib')
     log.addHandler(logging.StreamHandler(sys.stdout))
     log.setLevel(logging.DEBUG)
+
 
 If you are using a library that builds upon OAuthLib please also enable the
 logging for their modules, e.g. for `requests-oauthlib`

--- a/docs/oauth1/server.rst
+++ b/docs/oauth1/server.rst
@@ -441,7 +441,9 @@ Drop a line in our `Gitter OAuthLib community`_ or open a `GitHub issue`_ =)
 If you run into issues it can be helpful to enable debug logging::
 
     import logging
+    import oauthlib
     import sys
+    oauthlib.set_debug(True)
     log = logging.getLogger('oauthlib')
     log.addHandler(logging.StreamHandler(sys.stdout))
     log.setLevel(logging.DEBUG)

--- a/docs/oauth2/server.rst
+++ b/docs/oauth2/server.rst
@@ -524,7 +524,10 @@ If you run into issues it can be helpful to enable debug logging.
 .. code-block:: python
 
     import logging
+    import oauthlib
     import sys
+
+    oauthlib.set_debug(True)    
     log = logging.getLogger('oauthlib')
     log.addHandler(logging.StreamHandler(sys.stdout))
     log.setLevel(logging.DEBUG)

--- a/oauthlib/__init__.py
+++ b/oauthlib/__init__.py
@@ -19,8 +19,16 @@ logging.getLogger('oauthlib').addHandler(NullHandler())
 _DEBUG = False
 
 def set_debug(debug_val):
+	"""Set value of debug flag
+	
+    :param debug_val: Value to set. Must be a bool value.
+	"""
 	global _DEBUG
 	_DEBUG = debug_val
 
 def get_debug_flag():
+	"""Get debug mode value. 
+	
+	:return: `True` if debug mode is on, `False` otherwise
+	"""
 	return _DEBUG	

--- a/oauthlib/__init__.py
+++ b/oauthlib/__init__.py
@@ -26,7 +26,7 @@ def set_debug(debug_val):
 	global _DEBUG
 	_DEBUG = debug_val
 
-def get_debug_flag():
+def get_debug():
 	"""Get debug mode value. 
 	
 	:return: `True` if debug mode is on, `False` otherwise

--- a/oauthlib/__init__.py
+++ b/oauthlib/__init__.py
@@ -15,3 +15,12 @@ __author__ = 'The OAuthlib Community'
 __version__ = '3.0.2-dev'
 
 logging.getLogger('oauthlib').addHandler(NullHandler())
+
+_DEBUG = False
+
+def set_debug(debug_val):
+	global _DEBUG
+	_DEBUG = debug_val
+
+def get_debug_flag():
+	return _DEBUG	

--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -14,6 +14,7 @@ import logging
 import re
 import sys
 import time
+from . import get_debug_flag
 
 try:
     from secrets import randbits
@@ -435,6 +436,8 @@ class Request(object):
             raise AttributeError(name)
 
     def __repr__(self):
+        if not get_debug_flag():
+            return "<oauthlib.Request SANITIZED>"
         body = self.body
         headers = self.headers.copy()
         if body:

--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -14,7 +14,7 @@ import logging
 import re
 import sys
 import time
-from . import get_debug_flag
+from . import get_debug
 
 try:
     from secrets import randbits
@@ -436,7 +436,7 @@ class Request(object):
             raise AttributeError(name)
 
     def __repr__(self):
-        if not get_debug_flag():
+        if not get_debug():
             return "<oauthlib.Request SANITIZED>"
         body = self.body
         headers = self.headers.copy()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+import oauthlib
+
+oauthlib.set_debug(True)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
+import os
 import sys
 
+import oauthlib
 from oauthlib.common import (CaseInsensitiveDict, Request, add_params_to_uri,
                              extract_params, generate_client_id,
                              generate_nonce, generate_timestamp,
@@ -213,6 +215,20 @@ class RequestTest(TestCase):
         r = Request(URI, headers={'token': 'foobar'}, body='token=banana')
         self.assertEqual(r.headers['token'], 'foobar')
         self.assertEqual(r.token, 'banana')
+
+    def test_sanitized_request_non_debug_mode(self):
+        """make sure requests are sanitized when in non debug mode.
+        For the debug mode, the other tests checking sanitization should prove
+        that debug mode is working.
+        """
+        try:
+            oauthlib.set_debug(False)
+            r = Request(URI, headers={'token': 'foobar'}, body='token=banana')
+            self.assertNotIn('token', repr(r))
+            self.assertIn('SANITIZED', repr(r))
+        finally:
+            # set flag back for other tests
+            oauthlib.set_debug(True)
 
 
 class CaseInsensitiveDictTest(TestCase):


### PR DESCRIPTION
Fixes issue #665 
- By default debug mode is always off
- Debug mode turned on automatically for tests
- Request `repr` output completely sanitized in non debug mode
- Modules can check for debug mode with `oauthlib.get_debug_flag` method.