### PR TITLE
Add case-insensitive headers to oauth1 BaseEndpoint

### DIFF
--- a/oauthlib/oauth1/rfc5849/endpoints/base.py
+++ b/oauthlib/oauth1/rfc5849/endpoints/base.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, unicode_literals
 
 import time
 
-from oauthlib.common import Request, generate_token
+from oauthlib.common import CaseInsensitiveDict, Request, generate_token
 
 from .. import (CONTENT_TYPE_FORM_URLENCODED, SIGNATURE_HMAC, SIGNATURE_RSA,
                 SIGNATURE_TYPE_AUTH_HEADER, SIGNATURE_TYPE_BODY,
@@ -67,7 +67,7 @@ class BaseEndpoint(object):
 
     def _create_request(self, uri, http_method, body, headers):
         # Only include body data from x-www-form-urlencoded requests
-        headers = headers or {}
+        headers = CaseInsensitiveDict(headers or {})
         if ("Content-Type" in headers and
                 CONTENT_TYPE_FORM_URLENCODED in headers["Content-Type"]):
             request = Request(uri, http_method, body, headers)

--- a/tests/oauth1/rfc5849/endpoints/test_base.py
+++ b/tests/oauth1/rfc5849/endpoints/test_base.py
@@ -4,7 +4,7 @@ from re import sub
 
 from mock import MagicMock
 
-from oauthlib.common import safe_string_equals
+from oauthlib.common import CaseInsensitiveDict, safe_string_equals
 from oauthlib.oauth1 import Client, RequestValidator
 from oauthlib.oauth1.rfc5849 import (SIGNATURE_HMAC, SIGNATURE_PLAINTEXT,
                                      SIGNATURE_RSA, errors)
@@ -178,6 +178,17 @@ class BaseEndpointTest(TestCase):
                 URLENCODED)
         self.assertRaises(errors.InvalidRequestError,
                 e._check_mandatory_parameters, r)
+
+    def test_case_insensitive_headers(self):
+        """Ensure headers are case-insensitive"""
+        v = RequestValidator()
+        e = BaseEndpoint(v)
+        r = e._create_request('https://a.b', 'POST',
+                ('oauth_signature=a&oauth_consumer_key=b&oauth_nonce=c&'
+                 'oauth_version=1.0&oauth_signature_method=RSA-SHA1&'
+                 'oauth_timestamp=123456789a'),
+                URLENCODED)
+        self.assertIsInstance(r.headers, CaseInsensitiveDict)
 
     def test_signature_method_validation(self):
         """Ensure valid signature method is used."""


### PR DESCRIPTION
Add support for case-insensitive headers to the oauth1 `BaseEndpoint._create_request` to ensure headers are recognized in all endpoints.