### PR TITLE
Fix 670. AuthCode API must return the new PKCE attribute

### DIFF
--- a/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
@@ -405,12 +405,15 @@ class AuthorizationCodeGrant(GrantTypeBase):
                 raise errors.MissingCodeChallengeError(request=request)
 
         if request.code_challenge is not None:
+            request_info["code_challenge"] = request.code_challenge
+
             # OPTIONAL, defaults to "plain" if not present in the request.
             if request.code_challenge_method is None:
                 request.code_challenge_method = "plain"
 
             if request.code_challenge_method not in self._code_challenge_methods:
                 raise errors.UnsupportedCodeChallengeMethodError(request=request)
+            request_info["code_challenge_method"] = request.code_challenge_method
 
         # OPTIONAL. The scope of the access request as described by Section 3.3
         # https://tools.ietf.org/html/rfc6749#section-3.3

--- a/tests/oauth2/rfc6749/grant_types/test_authorization_code.py
+++ b/tests/oauth2/rfc6749/grant_types/test_authorization_code.py
@@ -215,8 +215,10 @@ class AuthorizationCodeGrantTest(TestCase):
             self.mock_validator.is_pkce_required.return_value = required
             self.request.code_challenge = "present"
             _, ri = self.auth.validate_authorization_request(self.request)
-            self.assertIsNotNone(ri["request"].code_challenge_method)
-            self.assertEqual(ri["request"].code_challenge_method, "plain")
+            self.assertIn("code_challenge", ri)
+            self.assertIn("code_challenge_method", ri)
+            self.assertEqual(ri["code_challenge"], "present")
+            self.assertEqual(ri["code_challenge_method"], "plain")
 
     def test_pkce_wrong_method(self):
         for required in [True, False]:


### PR DESCRIPTION
Fix #670 and allow https://github.com/jazzband/django-oauth-toolkit/pull/707 to revert their workaround.