### PR TITLE
token_type should be case insensitive

### DIFF
--- a/oauthlib/oauth2/rfc6749/tokens.py
+++ b/oauthlib/oauth2/rfc6749/tokens.py
@@ -254,7 +254,7 @@ def get_token_from_header(request):
 
     if 'Authorization' in request.headers:
         split_header = request.headers.get('Authorization').split()
-        if len(split_header) == 2 and split_header[0] == 'Bearer':
+        if len(split_header) == 2 and split_header[0].lower() == 'bearer':
             token = split_header[1]
     else:
         token = request.access_token
@@ -353,7 +353,7 @@ class BearerToken(TokenBase):
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
         """
-        if request.headers.get('Authorization', '').split(' ')[0] == 'Bearer':
+        if request.headers.get('Authorization', '').split(' ')[0].lower() == 'bearer':
             return 9
         elif request.access_token is not None:
             return 5

--- a/tests/oauth2/rfc6749/test_tokens.py
+++ b/tests/oauth2/rfc6749/test_tokens.py
@@ -68,6 +68,7 @@ class TokenTest(TestCase):
     bearer_headers = {
         'Authorization': 'Bearer vF9dft4qmT'
     }
+    valid_bearer_header_lowercase = {"Authorization": "bearer vF9dft4qmT"}
     fake_bearer_headers = [
         {'Authorization': 'Beaver vF9dft4qmT'},
         {'Authorization': 'BeavervF9dft4qmT'},
@@ -103,6 +104,26 @@ class TokenTest(TestCase):
         self.assertEqual(prepare_bearer_body(self.token), self.bearer_body)
         self.assertEqual(prepare_bearer_uri(self.token, uri=self.uri), self.bearer_uri)
 
+    def test_valid_bearer_is_validated(self):
+        request_validator = mock.MagicMock()
+        request_validator.validate_bearer_token = self._mocked_validate_bearer_token
+
+        request = Request("/", headers=self.bearer_headers)
+        result = BearerToken(request_validator=request_validator).validate_request(
+            request
+        )
+        self.assertTrue(result)
+
+    def test_lowercase_bearer_is_validated(self):
+        request_validator = mock.MagicMock()
+        request_validator.validate_bearer_token = self._mocked_validate_bearer_token
+
+        request = Request("/", headers=self.valid_bearer_header_lowercase)
+        result = BearerToken(request_validator=request_validator).validate_request(
+            request
+        )
+        self.assertTrue(result)
+
     def test_fake_bearer_is_not_validated(self):
         request_validator = mock.MagicMock()
         request_validator.validate_bearer_token = self._mocked_validate_bearer_token
@@ -125,6 +146,13 @@ class TokenTest(TestCase):
         )
 
         self.assertTrue(result)
+
+    def test_estimate_type(self):
+        request_validator = mock.MagicMock()
+        request_validator.validate_bearer_token = self._mocked_validate_bearer_token
+        request = Request("/", headers=self.bearer_headers)
+        result = BearerToken(request_validator=request_validator).estimate_type(request)
+        self.assertEqual(result, 9)
 
     def test_estimate_type_with_fake_header_returns_type_0(self):
         request_validator = mock.MagicMock()

--- a/tests/oauth2/rfc6749/test_tokens.py
+++ b/tests/oauth2/rfc6749/test_tokens.py
@@ -1,10 +1,14 @@
 from __future__ import absolute_import, unicode_literals
 
+import mock
+
+from oauthlib.common import Request
 from oauthlib.oauth2.rfc6749.tokens import (
-    prepare_mac_header,
-    prepare_bearer_headers,
+    BearerToken,
     prepare_bearer_body,
+    prepare_bearer_headers,
     prepare_bearer_uri,
+    prepare_mac_header,
 )
 
 from ...unittest import TestCase
@@ -98,3 +102,46 @@ class TokenTest(TestCase):
         self.assertEqual(prepare_bearer_headers(self.token), self.bearer_headers)
         self.assertEqual(prepare_bearer_body(self.token), self.bearer_body)
         self.assertEqual(prepare_bearer_uri(self.token, uri=self.uri), self.bearer_uri)
+
+    def test_fake_bearer_is_not_validated(self):
+        request_validator = mock.MagicMock()
+        request_validator.validate_bearer_token = self._mocked_validate_bearer_token
+
+        for fake_header in self.fake_bearer_headers:
+            request = Request("/", headers=fake_header)
+            result = BearerToken(request_validator=request_validator).validate_request(
+                request
+            )
+
+            self.assertFalse(result)
+
+    def test_header_with_multispaces_is_validated(self):
+        request_validator = mock.MagicMock()
+        request_validator.validate_bearer_token = self._mocked_validate_bearer_token
+
+        request = Request("/", headers=self.valid_header_with_multiple_spaces)
+        result = BearerToken(request_validator=request_validator).validate_request(
+            request
+        )
+
+        self.assertTrue(result)
+
+    def test_estimate_type_with_fake_header_returns_type_0(self):
+        request_validator = mock.MagicMock()
+        request_validator.validate_bearer_token = self._mocked_validate_bearer_token
+
+        for fake_header in self.fake_bearer_headers:
+            request = Request("/", headers=fake_header)
+            result = BearerToken(request_validator=request_validator).estimate_type(
+                request
+            )
+
+            if (
+                fake_header["Authorization"].count(" ") == 2
+                and fake_header["Authorization"].split()[0] == "Bearer"
+            ):
+                # If we're dealing with the header containing 2 spaces, it will be recognized
+                # as a Bearer valid header, the token itself will be invalid by the way.
+                self.assertEqual(result, 9)
+            else:
+                self.assertEqual(result, 0)


### PR DESCRIPTION
According to RFC, token_type is case insensitive.
https://tools.ietf.org/html/rfc6749#section-4.2.2

Some softwares check Bearer as case insensitive.
https://github.com/keycloak/keycloak/blob/b478472b3578b8980d7b5f1642e91e75d1e78d16/services/src/main/java/org/keycloak/services/managers/AppAuthManager.java#L50

This pull request allows case insensitive `bearer` string.