### PR TITLE
Check for errors in authorization code response

### DIFF
--- a/oauthlib/oauth2/rfc6749/parameters.py
+++ b/oauthlib/oauth2/rfc6749/parameters.py
@@ -264,11 +264,14 @@ def parse_authorization_code_response(uri, state=None):
     query = urlparse.urlparse(uri).query
     params = dict(urlparse.parse_qsl(query))
 
-    if not 'code' in params:
-        raise MissingCodeError("Missing code parameter in response.")
-
     if state and params.get('state', None) != state:
         raise MismatchingStateError()
+
+    if 'error' in params:
+        raise_from_error(params.get('error'), params)
+
+    if not 'code' in params:
+        raise MissingCodeError("Missing code parameter in response.")
 
     return params
 

--- a/tests/oauth2/rfc6749/test_parameters.py
+++ b/tests/oauth2/rfc6749/test_parameters.py
@@ -73,7 +73,8 @@ class ParameterTests(TestCase):
     error_nocode = 'https://client.example.com/cb?state=xyz'
     error_nostate = 'https://client.example.com/cb?code=SplxlOBeZQQYbYS6WxSbIA'
     error_wrongstate = 'https://client.example.com/cb?code=SplxlOBeZQQYbYS6WxSbIA&state=abc'
-    error_response = 'https://client.example.com/cb?error=access_denied&state=xyz'
+    error_denied = 'https://client.example.com/cb?error=access_denied&state=xyz'
+    error_invalid = 'https://client.example.com/cb?error=invalid_request&state=xyz'
 
     implicit_base = 'https://example.com/cb#access_token=2YotnFZFEjr1zCsicMWpAA&scope=abc&'
     implicit_response = implicit_base + 'state={0}&token_type=example&expires_in=3600'.format(state)
@@ -180,8 +181,10 @@ class ParameterTests(TestCase):
 
         self.assertRaises(MissingCodeError, parse_authorization_code_response,
                 self.error_nocode)
-        self.assertRaises(MissingCodeError, parse_authorization_code_response,
-                self.error_response)
+        self.assertRaises(AccessDeniedError, parse_authorization_code_response,
+                self.error_denied)
+        self.assertRaises(InvalidRequestFatalError, parse_authorization_code_response,
+                self.error_invalid)
         self.assertRaises(MismatchingStateError, parse_authorization_code_response,
                 self.error_nostate, state=self.state)
         self.assertRaises(MismatchingStateError, parse_authorization_code_response,


### PR DESCRIPTION
Fixes #290 by adding error checking to `parse_authorization_code_response()` before any validation of the `code` param is done.

Note that I also shifted the `state` check before both the error and code checks - `state` is required in the response and if it isn't correct, why would we trust any of the other params?  This is a little out-of-scope so let me know if you'd prefer I revert that bit.

Also note that this is a breaking change as I mentioned in https://github.com/oauthlib/oauthlib/issues/290#issuecomment-499331868 because client error handling behaviour will need to change.