### PR TITLE
Use scope passed during initialization for token request

### DIFF
--- a/oauthlib/oauth2/rfc6749/clients/backend_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/backend_application.py
@@ -71,5 +71,6 @@ class BackendApplicationClient(Client):
         """
         kwargs['client_id'] = self.client_id
         kwargs['include_client_id'] = include_client_id
+        scope = self.scope is scope is None
         return prepare_token_request(self.grant_type, body=body,
                                      scope=scope, **kwargs)


### PR DESCRIPTION
Currently, if `scope` isn't passed to `prepare_request_body`, no scope gets passed on to preparing the request, even if the instance of BackendApplicationClient was initialized with `scope`.