### PR TITLE
Fix BackendApplicationClient.prepare_request_body

### DIFF
--- a/oauthlib/oauth2/rfc6749/clients/backend_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/backend_application.py
@@ -71,5 +71,6 @@ class BackendApplicationClient(Client):
         """
         kwargs['client_id'] = self.client_id
         kwargs['include_client_id'] = include_client_id
+        scope = self.scope if scope is None else scope
         return prepare_token_request(self.grant_type, body=body,
                                      scope=scope, **kwargs)


### PR DESCRIPTION
Currently, if no `scope` is passed to `prepare_request_body`, None will be passed on to `prepare_token_request`, even if BackendApplicationClient was initialized with `scope`.