### PR TITLE
add HMAC-SHA256 signature validation

### DIFF
--- a/oauthlib/oauth1/rfc5849/endpoints/base.py
+++ b/oauthlib/oauth1/rfc5849/endpoints/base.py
@@ -12,7 +12,7 @@ import time
 
 from oauthlib.common import CaseInsensitiveDict, Request, generate_token
 
-from .. import (CONTENT_TYPE_FORM_URLENCODED, SIGNATURE_HMAC, SIGNATURE_RSA,
+from .. import (CONTENT_TYPE_FORM_URLENCODED, SIGNATURE_HMAC_SHA1, SIGNATURE_HMAC_SHA256, SIGNATURE_RSA,
                 SIGNATURE_TYPE_AUTH_HEADER, SIGNATURE_TYPE_BODY,
                 SIGNATURE_TYPE_QUERY, errors, signature, utils)
 
@@ -204,8 +204,11 @@ class BaseEndpoint(object):
                     resource_owner_secret = self.request_validator.get_access_token_secret(
                         request.client_key, request.resource_owner_key, request)
 
-            if request.signature_method == SIGNATURE_HMAC:
+            if request.signature_method == SIGNATURE_HMAC_SHA1:
                 valid_signature = signature.verify_hmac_sha1(request,
+                                                             client_secret, resource_owner_secret)
+            elif request.signature_method == SIGNATURE_HMAC_SHA256:
+                valid_signature = signature.verify_hmac_sha256(request,
                                                              client_secret, resource_owner_secret)
             else:
                 valid_signature = signature.verify_plaintext(request,

--- a/oauthlib/oauth1/rfc5849/signature.py
+++ b/oauthlib/oauth1/rfc5849/signature.py
@@ -661,6 +661,36 @@ def verify_hmac_sha1(request, client_secret=None,
     return match
 
 
+def verify_hmac_sha256(request, client_secret=None,
+                     resource_owner_secret=None):
+    """Verify a HMAC-SHA256 signature.
+
+    Per `section 3.4`_ of the spec.
+
+    .. _`section 3.4`: https://tools.ietf.org/html/rfc5849#section-3.4
+
+    To satisfy `RFC2616 section 5.2`_ item 1, the request argument's uri
+    attribute MUST be an absolute URI whose netloc part identifies the
+    origin server or gateway on which the resource resides. Any Host
+    item of the request argument's headers dict attribute will be
+    ignored.
+
+    .. _`RFC2616 section 5.2`: https://tools.ietf.org/html/rfc2616#section-5.2
+
+    """
+    norm_params = normalize_parameters(request.params)
+    bs_uri = base_string_uri(request.uri)
+    sig_base_str = signature_base_string(request.http_method, bs_uri,
+                                         norm_params)
+    signature = sign_hmac_sha256(sig_base_str, client_secret,
+                               resource_owner_secret)
+    match = safe_string_equals(signature, request.signature)
+    if not match:
+        log.debug('Verify HMAC-SHA256 failed: signature base string: %s',
+                  sig_base_str)
+    return match
+
+
 def _prepare_key_plus(alg, keystr):
     if isinstance(keystr, bytes):
         keystr = keystr.decode('utf-8')


### PR DESCRIPTION
Addresses #690. The client can generate HMAC-SHA256, but the validation code doesn't currently handle it.