### PR TITLE
Initial custom grant type documentation.

### DIFF
--- a/docs/oauth2/grants/custom_grant.rst
+++ b/docs/oauth2/grants/custom_grant.rst
@@ -7,10 +7,9 @@ which is in an early draft, or implement a grant provided by a
 specific OAuth2.0 Authorization Server documentation but not provided
 by oauthlib. For information, any grant types with a clear
 specification can be integrated in oauthlib, just make a PR for that
-!. See :doc:`how to contribute here </contributing>`.
+! See :doc:`how to contribute here </contributing>`.
 
-Please find below an example of how to create a new grant and use it
-in an endpoint:
+Please find how to create a new grant and use it in an endpoint:
 
 .. contents:: Tutorial Contents
     :depth: 3
@@ -18,46 +17,62 @@ in an endpoint:
 
 1. Define your Grant Type
 -------------------------
-
 The heart of your code is done by subclassing
-:py:class:`oauthlib.oauth2.rfc6749.grant_types.base.GrantTypeBase`.
-If you want to use it in the Authorize endpoint, you will have to
-implement `create_authorization_response`, if in the Token endpoint,
-implement `create_token_response`.
+:py:class:`GrantTypeBase`.  If you want to use it in the Authorize
+endpoint, you will have to implement
+:py:meth:`create_authorization_response`, if you want to use the Token
+endpoint, implement :py:meth:`create_token_response`. You can also
+implement both.
 
+2. Implement the grant
+----------------------
+Inside the method's implementation, you will have to:
 
-2. Associate it with Endpoints
+* add validations of the request (syntax, parameters, ...)
+* call and orchestrate one or multiple Request Validators calls
+* generate and return HTTP response
+
+You can define new Request Validator methods if needed, or reuse the
+existing ones.
+
+3. Associate it with Endpoints
 ------------------------------
-Then, once declared, you have to create an instance of your grant and
-add it to your
-endpoint. I.e. :py:class:`oauthlib.oauth2.rfc6749.endpoints.AuthorizationEndpoint`
-or :py:class:`oauthlib.oauth2.rfc6749.endpoints.TokenEndpoint`. You
-can see concrete examples in
-:py:class:`oauthlib.oauth2.rfc6749.endpoints.pre_configured.Server`
-for examples.
+Then, once implemented, you have to instanciate the grant object and
+bind it to your endpoint. Either :py:class:`AuthorizationEndpoint`,
+:py:class:`TokenEndpoint` or both.
 
-3. Example
+4. Example
 ----------
+This example shows how to add a simple extension to the `Token endpoint`:
 
-Sample below shows the creation of a new custom `grant_type` parameter
-and declare it in the `/token` endpoint of your `Server`. Note that
-you can reuse `pre_configured.Server` or use your own class inheriting
-of the `Endpoint` classes you have decided.
+* creation of a new class ``MyCustomGrant``, and implement ``create_token_response``.
+* do basics and custom request validations, then call a custom method
+  of `Request Validator` to extend the interface for the implementor.
+* instanciate the new grant, and bind it with an existing ``Server``.
 
 .. code-block:: python
 
+    grant_name = 'urn:ietf:params:oauth:grant-type:my-custom-grant'
+
     class MyCustomGrant(GrantTypeBase):
         def create_token_response(self, request, token_handler):
-            if not request.grant_type == 'urn:ietf:params:oauth:grant-type:my-custom-grant':
+            if not request.grant_type == grant_name:
                 raise errors.UnsupportedGrantTypeError(request=request)
+
             # implement your custom validation checks
             # ..
+            self.request_validator.your_custom_check(request)
 
-            token = token_handler.create_token(request,
-                                               refresh_token=self.issue_new_refresh_tokens)
+            token = token_handler.create_token(request)
             return self._get_default_headers(), json.dumps(token), 200
 
     def setup_oauthlib():
         my_custom_grant = MyCustomGrant()
         server = Server(request_validator)
-        server.grant_types["urn:ietf:params:oauth:grant-type:my-custom-grant"] = my_custom_grant
+        server.grant_types[grant_name] = my_custom_grant
+
+
+You can find concrete examples directly in the code source of existing
+grants and existing servers. See Grant Types in
+:py:mod:`oauthlib.oauth2.rfc749.grant_types`, and Servers in
+:py:mod:`oauthlib.oauth2.rfc749.endpoints.pre_configured`

--- a/docs/oauth2/grants/custom_grant.rst
+++ b/docs/oauth2/grants/custom_grant.rst
@@ -6,8 +6,8 @@ Writing a custom grant type can be useful to implement a specification
 which is in an early draft, or implement a grant provided by a
 specific OAuth2.0 Authorization Server documentation but not provided
 by oauthlib. For information, any grant types with a clear
-specification can be integrated in oauthlib, just make a PR for that
-! See :doc:`how to contribute here </contributing>`.
+specification can be integrated in oauthlib, just make a PR for that !
+See :doc:`how to contribute here </contributing>`.
 
 Please find how to create a new grant and use it in an endpoint:
 

--- a/docs/oauth2/grants/custom_grant.rst
+++ b/docs/oauth2/grants/custom_grant.rst
@@ -1,0 +1,49 @@
+Custom Grant type
+-----------------
+
+Writing a custom grant type can be useful to implement a specification
+which is in an early draft, or implement a grant provided by a
+specific OAuth2.0 Authorization Server documentation but not provided
+by oauthlib. For information, any grant types with a clear
+specification can be integrated in oauthlib, just make a PR for that
+!. See :doc:`how to contribute here </contributing>`.
+
+Please find below an example of how to create a new grant and use it
+in an endpoint:
+
+.. contents:: Tutorial Contents
+    :depth: 3
+
+
+1. Define your Grant Type
+-------------------------
+
+The heart of your code is done by subclassing
+:py:class:`oauthlib.oauth2.rfc6749.grant_types.base.GrantTypeBase`.
+If you want to use it in the Authorize endpoint, you will have to
+implement `create_authorization_response`, if in the Token endpoint,
+implement `create_token_response`.
+
+
+2. Associate it with Endpoints
+------------------------------
+Then, once declared, you have to create an instance of your grant and
+add it to your
+endpoint. I.e. :py:class:`oauthlib.oauth2.rfc6749.endpoints.AuthorizationEndpoint`
+or :py:class:`oauthlib.oauth2.rfc6749.endpoints.TokenEndpoint`. You
+can see concrete examples in
+:py:class:`oauthlib.oauth2.rfc6749.endpoints.pre_configured.Server`
+for examples.
+
+3. Example
+----------
+
+To be completed.
+
+.. code-block:: python
+    class XXXZZZGrant(GrantTypeBase):
+        def create_token_response(self, request, token_handler):
+            if not request.grant_type == 'xxx_zzz':
+                raise errors.UnsupportedGrantTypeError(request=request)
+            ...
+         

--- a/docs/oauth2/grants/custom_grant.rst
+++ b/docs/oauth2/grants/custom_grant.rst
@@ -1,5 +1,6 @@
+=================
 Custom Grant type
------------------
+=================
 
 Writing a custom grant type can be useful to implement a specification
 which is in an early draft, or implement a grant provided by a
@@ -38,12 +39,25 @@ for examples.
 3. Example
 ----------
 
-To be completed.
+Sample below shows the creation of a new custom `grant_type` parameter
+and declare it in the `/token` endpoint of your `Server`. Note that
+you can reuse `pre_configured.Server` or use your own class inheriting
+of the `Endpoint` classes you have decided.
 
 .. code-block:: python
-    class XXXZZZGrant(GrantTypeBase):
+
+    class MyCustomGrant(GrantTypeBase):
         def create_token_response(self, request, token_handler):
-            if not request.grant_type == 'xxx_zzz':
+            if not request.grant_type == 'urn:ietf:params:oauth:grant-type:my-custom-grant':
                 raise errors.UnsupportedGrantTypeError(request=request)
-            ...
-         
+            # implement your custom validation checks
+            # ..
+
+            token = token_handler.create_token(request,
+                                               refresh_token=self.issue_new_refresh_tokens)
+            return self._get_default_headers(), json.dumps(token), 200
+
+    def setup_oauthlib():
+        my_custom_grant = MyCustomGrant()
+        server = Server(request_validator)
+        server.grant_types["urn:ietf:params:oauth:grant-type:my-custom-grant"] = my_custom_grant

--- a/docs/oauth2/grants/custom_validators.rst
+++ b/docs/oauth2/grants/custom_validators.rst
@@ -1,5 +1,15 @@
 Custom Validators
 -----------------
 
-.. autoclass:: oauthlib.oauth2.rfc6749.grant_types.base.ValidatorsContainer
+The Custom validators are useful when you want to change a particular
+behavior of an existing grant. That is often needed because of the
+diversity of the identity softwares and to let the oauthlib framework to be
+flexible as possible.
+
+However, if you are looking into writing a custom grant type, please
+refer to the :doc:`Custom Grant Type </oauth2/grants/custom_grant>`
+instead.
+
+.. autoclass::
+               oauthlib.oauth2.rfc6749.grant_types.base.ValidatorsContainer
     :members:

--- a/docs/oauth2/grants/grants.rst
+++ b/docs/oauth2/grants/grants.rst
@@ -21,8 +21,10 @@ serves less secure applications such as Mobile Applications or
 Single-Page Applications, the :doc:`Client Credentials grant
 </oauth2/grants/credentials>` is excellent for embedded services and
 backend applications. We have also the :doc:`Resource Owner Password
-Credentials grant </oauth2/grants/password>` for legacy applications
-to incrementally transition to OAuth 2.
+Credentials grant </oauth2/grants/password>` when there is a high
+degree of trust between the resource owner and the client, and when
+other authorization grant types are not available. This is also often
+used for legacy applications to incrementally transition to OAuth 2.
 
 The main purpose of the grant types is to authorize access to protected
 resources in various ways with different security credentials.

--- a/docs/oauth2/grants/grants.rst
+++ b/docs/oauth2/grants/grants.rst
@@ -9,23 +9,30 @@ Grant types
     implicit
     password
     credentials
-    custom_validators
+    refresh
     jwt
+    custom_validators
+    custom_grant
 
-Grant types are what make OAuth 2 so flexible. The Authorization Code grant is
-very similar to OAuth 1 (with less crypto), the Implicit grant serves less
-secure applications such as mobile applications, the Resource Owner Password
-Credentials grant allows for legacy applications to incrementally transition to
-OAuth 2, the Client Credentials grant is excellent for embedded services and
-backend applications.
+Grant types are what make OAuth 2 so flexible. The :doc:`Authorization
+Code grant </oauth2/grants/authcode>` is the default for almost all
+Web Applications, the :doc:`Implicit grant </oauth2/grants/implicit>`
+serves less secure applications such as Mobile Applications or
+Single-Page Applications, the :doc:`Client Credentials grant
+</oauth2/grants/credentials>` is excellent for embedded services and
+backend applications. We have also the :doc:`Resource Owner Password
+Credentials grant </oauth2/grants/password>` for legacy applications
+to incrementally transition to OAuth 2.
 
 The main purpose of the grant types is to authorize access to protected
 resources in various ways with different security credentials.
 
 Naturally, OAuth 2 allows for extension grant types to be defined and OAuthLib
-attempts to cater for easy inclusion of this as much as possible.
+attempts to cater for easy inclusion of this as much as possible. See
+:doc:`Custom Grant Type </oauth2/grants/custom_grant>`.
 
-OAuthlib also offers hooks for registering your own custom validations for use
+OAuthlib also offers hooks for registering your own :doc:`Custom
+Validators </oauth2/grants/custom_validators>` for use
 with the existing grant type handlers
 (:py:class:`oauthlib.oauth2.rfc6749.grant_types.base.ValidatorsContainer`).
 In some situations, this may be more convenient than subclassing or writing
@@ -36,6 +43,7 @@ client to request new tokens for as long as you as provider allow them too. In
 general, OAuth 2 tokens should expire quickly and rather than annoying the user
 by require them to go through the authorization redirect loop you may use the
 refresh token to get a new access token. Refresh tokens, contrary to what their
-name suggest, are components of a grant type rather than token types (like
+name suggest, are components of a grant type (see :doc:`Refresh Token
+grant </oauth2/grants/refresh>`) rather than token types (like
 Bearer tokens), much like the authorization code in the authorization code
 grant.

--- a/docs/oauth2/grants/refresh.rst
+++ b/docs/oauth2/grants/refresh.rst
@@ -1,0 +1,6 @@
+Refresh Token Grant
+------------------------
+
+.. autoclass:: oauthlib.oauth2.RefreshTokenGrant
+    :members:
+    :inherited-members:

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands=
 # tox -e docs to mimick readthedocs build.
 # as of today, RTD is using python2.7 and doesn't run "setup.py install"
 [testenv:docs]
-basepython=python2.7
+basepython=python3.6
 skipsdist=True
 deps=
         sphinx


### PR DESCRIPTION
Improved Grant Type section to let developers create or implement their own custom grant type. Or also help them implementing new RFC.

Related to https://github.com/oauthlib/oauthlib/issues/111 and https://github.com/oauthlib/oauthlib/issues/686 and probably some others (https://github.com/oauthlib/oauthlib/pull/640 ?).