### PR TITLE
typo in log message for client_credentials

### DIFF
--- a/oauthlib/oauth2/rfc6749/grant_types/client_credentials.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/client_credentials.py
@@ -117,7 +117,7 @@ class ClientCredentialsGrant(GrantTypeBase):
         # Ensure client is authorized use of this grant type
         self.validate_grant_type(request)
 
-        log.debug('Authorizing access to user %r.', request.user)
+        log.debug('Authorizing access to client %r.', request.client.client_id)
         request.client_id = request.client_id or request.client.client_id
         self.validate_scopes(request)
 

--- a/oauthlib/oauth2/rfc6749/grant_types/client_credentials.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/client_credentials.py
@@ -117,8 +117,8 @@ class ClientCredentialsGrant(GrantTypeBase):
         # Ensure client is authorized use of this grant type
         self.validate_grant_type(request)
 
-        log.debug('Authorizing access to client %r.', request.client.client_id)
         request.client_id = request.client_id or request.client.client_id
+        log.debug('Authorizing access to client %r.', request.client_id)
         self.validate_scopes(request)
 
         for validator in self.custom_validators.post_token:


### PR DESCRIPTION
there is no user in client credentials grant type, so I assume it's a typo