### PR TITLE
Update server.rst docs to include request uri in auth code

### DIFF
--- a/docs/oauth2/server.rst
+++ b/docs/oauth2/server.rst
@@ -239,6 +239,17 @@ the token.
         # the scopes into a string.
         scopes = django.db.models.TextField()
 
+**Redirect URI**:
+
+    If the client specifies a redirect_uri when obtaining code then that
+    redirect URI must be bound to the code and verified equal in this
+    method, according to RFC 6749 section 4.1. This field holds that
+    bound value.
+
+    .. code-block:: python
+
+        redirect_uri = django.db.models.TextField()
+
 **Authorization Code**:
 
     An unguessable unique string of characters.


### PR DESCRIPTION
This PR resolves issue: https://github.com/oauthlib/oauthlib/issues/712

From the issue:

The authorization_code model description here does not include a redirect_uri field. In oauthlib/oauth2/rfc6749/request_validator.py it states that the redirect_uri should be compared against the authorization_code and not the client.

To support this, the authorization_code model description in the docs should include the redirect_uri used.