### PR TITLE
Rework client authentication in SkeletonValidator for clarity

### DIFF
--- a/examples/skeleton_oauth2_web_application_server.py
+++ b/examples/skeleton_oauth2_web_application_server.py
@@ -54,13 +54,18 @@ class SkeletonValidator(RequestValidator):
 
     # Token request
 
+    def client_authentication_required(self, request, *args, **kwargs):
+        # Check if the client provided authentication information that needs to
+        # be validated, e.g. HTTP Basic auth
+        pass
+
     def authenticate_client(self, request, *args, **kwargs):
         # Whichever authentication method suits you, HTTP Basic might work
         pass
 
     def authenticate_client_id(self, client_id, request, *args, **kwargs):
-        # Don't allow public (non-authenticated) clients
-        return False
+        # The client_id must match an existing public (non-confidential) client
+        pass
 
     def validate_code(self, client_id, code, client, request, *args, **kwargs):
         # Validate the code belongs to the client. Add associated scopes


### PR DESCRIPTION
SkeletonValidator was seemingly written to not support public clients at
all. Its authenticate_client_id() explicitly returned `False`, rather than
`pass`-ing like the other methods, and client_authentication_required()
was missing entirely (the default implementation always returns `True`).

This opinionated approach is confusing, especially when writing an
implementation that allows public clients.

The comment on the authenticate_client_id() method is particularly
confusing. Unlike the comments on other methods, which explain the method,
it explains the implementation (returning `False`). As a result, it appears
to say the method should return `False` for public clients, when it should
actually return `False` for confidential clients (and `True` for valid
public clients).

To reduce this confusion, include a client_authentication_required() stub,
`pass` rather than returning `False` in authenticate_client_id(), and
update its comment to describe the method.