### PR TITLE
Replaced mention of flask-oauthlib with authlib

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ Which web frameworks are supported?
 The following packages provide OAuth support using OAuthLib.
 
 - For Django there is `django-oauth-toolkit`_, which includes `Django REST framework`_ support.
-- For Flask there is `flask-oauthlib`_ and `Flask-Dance`_.
+- For Flask there is `authlib`_ and `Flask-Dance`_.
 - For Pyramid there is `pyramid-oauthlib`_.
 - For Bottle there is `bottle-oauthlib`_.
 
@@ -84,7 +84,7 @@ If you have written an OAuthLib package that supports your favorite framework,
 please open a Pull Request, updating the documentation.
 
 .. _`django-oauth-toolkit`: https://github.com/evonove/django-oauth-toolkit
-.. _`flask-oauthlib`: https://github.com/lepture/flask-oauthlib
+.. _`authlib`: https://github.com/lepture/authlib
 .. _`Django REST framework`: http://django-rest-framework.org
 .. _`Flask-Dance`: https://github.com/singingwolfboy/flask-dance
 .. _`pyramid-oauthlib`: https://github.com/tilgovi/pyramid-oauthlib


### PR DESCRIPTION
From the GitHub page, it looks like https://github.com/lepture/flask-oauthlib has been deprecated in favor of https://github.com/lepture/authlib. I replaced the link/mention to maintain consistency and keep the README up to date.