### PR TITLE
Use unittest.mock instead of external mock

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,3 @@
 -r requirements.txt
-mock>=2.0
 pytest>=4.0
 pytest-cov>=2.6

--- a/tests/oauth1/rfc5849/endpoints/test_access_token.py
+++ b/tests/oauth1/rfc5849/endpoints/test_access_token.py
@@ -1,4 +1,4 @@
-from mock import ANY, MagicMock
+from unittest.mock import ANY, MagicMock
 
 from oauthlib.oauth1 import RequestValidator
 from oauthlib.oauth1.rfc5849 import Client

--- a/tests/oauth1/rfc5849/endpoints/test_authorization.py
+++ b/tests/oauth1/rfc5849/endpoints/test_authorization.py
@@ -1,4 +1,4 @@
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from oauthlib.oauth1 import RequestValidator
 from oauthlib.oauth1.rfc5849 import errors

--- a/tests/oauth1/rfc5849/endpoints/test_base.py
+++ b/tests/oauth1/rfc5849/endpoints/test_base.py
@@ -1,6 +1,6 @@
 from re import sub
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from oauthlib.common import CaseInsensitiveDict, safe_string_equals
 from oauthlib.oauth1 import Client, RequestValidator

--- a/tests/oauth1/rfc5849/endpoints/test_request_token.py
+++ b/tests/oauth1/rfc5849/endpoints/test_request_token.py
@@ -1,4 +1,4 @@
-from mock import ANY, MagicMock
+from unittest.mock import ANY, MagicMock
 
 from oauthlib.oauth1 import RequestValidator
 from oauthlib.oauth1.rfc5849 import Client

--- a/tests/oauth1/rfc5849/endpoints/test_resource.py
+++ b/tests/oauth1/rfc5849/endpoints/test_resource.py
@@ -1,4 +1,4 @@
-from mock import ANY, MagicMock
+from unittest.mock import ANY, MagicMock
 
 from oauthlib.oauth1 import RequestValidator
 from oauthlib.oauth1.rfc5849 import Client

--- a/tests/oauth1/rfc5849/endpoints/test_signature_only.py
+++ b/tests/oauth1/rfc5849/endpoints/test_signature_only.py
@@ -1,4 +1,4 @@
-from mock import ANY, MagicMock
+from unittest.mock import ANY, MagicMock
 
 from oauthlib.oauth1 import RequestValidator
 from oauthlib.oauth1.rfc5849 import Client

--- a/tests/oauth2/rfc6749/clients/test_backend_application.py
+++ b/tests/oauth2/rfc6749/clients/test_backend_application.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 
-from mock import patch
+from unittest.mock import patch
 
 from oauthlib import signals
 from oauthlib.oauth2 import BackendApplicationClient

--- a/tests/oauth2/rfc6749/clients/test_legacy_application.py
+++ b/tests/oauth2/rfc6749/clients/test_legacy_application.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 
-from mock import patch
+from unittest.mock import patch
 
 from oauthlib import signals
 from oauthlib.oauth2 import LegacyApplicationClient

--- a/tests/oauth2/rfc6749/clients/test_mobile_application.py
+++ b/tests/oauth2/rfc6749/clients/test_mobile_application.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 
-from mock import patch
+from unittest.mock import patch
 
 from oauthlib import signals
 from oauthlib.oauth2 import MobileApplicationClient

--- a/tests/oauth2/rfc6749/clients/test_service_application.py
+++ b/tests/oauth2/rfc6749/clients/test_service_application.py
@@ -3,7 +3,7 @@ import os
 from time import time
 
 import jwt
-from mock import patch
+from unittest.mock import patch
 
 from oauthlib.common import Request
 from oauthlib.oauth2 import ServiceApplicationClient

--- a/tests/oauth2/rfc6749/clients/test_web_application.py
+++ b/tests/oauth2/rfc6749/clients/test_web_application.py
@@ -2,7 +2,7 @@
 import os
 import warnings
 
-from mock import patch
+from unittest.mock import patch
 
 from oauthlib import common, signals
 from oauthlib.oauth2 import (BackendApplicationClient, Client,

--- a/tests/oauth2/rfc6749/endpoints/test_client_authentication.py
+++ b/tests/oauth2/rfc6749/endpoints/test_client_authentication.py
@@ -11,7 +11,7 @@ prevents this check from being circumvented with a client form parameter.
 """
 import json
 
-import mock
+from unittest import mock
 
 from oauthlib.oauth2 import (BackendApplicationServer, LegacyApplicationServer,
                              MobileApplicationServer, RequestValidator,

--- a/tests/oauth2/rfc6749/endpoints/test_credentials_preservation.py
+++ b/tests/oauth2/rfc6749/endpoints/test_credentials_preservation.py
@@ -5,7 +5,7 @@ uri and the Implicit Grant will need to preserve state.
 """
 import json
 
-import mock
+from unittest import mock
 
 from oauthlib.oauth2 import (MobileApplicationServer, RequestValidator,
                              WebApplicationServer)

--- a/tests/oauth2/rfc6749/endpoints/test_error_responses.py
+++ b/tests/oauth2/rfc6749/endpoints/test_error_responses.py
@@ -2,7 +2,7 @@
 """
 import json
 
-import mock
+from unittest import mock
 
 from oauthlib.common import urlencode
 from oauthlib.oauth2 import (BackendApplicationServer, LegacyApplicationServer,

--- a/tests/oauth2/rfc6749/endpoints/test_extra_credentials.py
+++ b/tests/oauth2/rfc6749/endpoints/test_extra_credentials.py
@@ -1,6 +1,6 @@
 """Ensure extra credentials can be supplied for inclusion in tokens.
 """
-import mock
+from unittest import mock
 
 from oauthlib.oauth2 import (BackendApplicationServer, LegacyApplicationServer,
                              MobileApplicationServer, RequestValidator,

--- a/tests/oauth2/rfc6749/endpoints/test_introspect_endpoint.py
+++ b/tests/oauth2/rfc6749/endpoints/test_introspect_endpoint.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from json import loads
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from oauthlib.common import urlencode
 from oauthlib.oauth2 import RequestValidator, IntrospectEndpoint

--- a/tests/oauth2/rfc6749/endpoints/test_resource_owner_association.py
+++ b/tests/oauth2/rfc6749/endpoints/test_resource_owner_association.py
@@ -2,7 +2,7 @@
 """
 import json
 
-import mock
+from unittest import mock
 
 from oauthlib.oauth2 import (BackendApplicationServer, LegacyApplicationServer,
                              MobileApplicationServer, RequestValidator,

--- a/tests/oauth2/rfc6749/endpoints/test_revocation_endpoint.py
+++ b/tests/oauth2/rfc6749/endpoints/test_revocation_endpoint.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from json import loads
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from oauthlib.common import urlencode
 from oauthlib.oauth2 import RequestValidator, RevocationEndpoint

--- a/tests/oauth2/rfc6749/endpoints/test_scope_handling.py
+++ b/tests/oauth2/rfc6749/endpoints/test_scope_handling.py
@@ -5,7 +5,7 @@ need to be persisted temporarily in an authorization code.
 """
 import json
 
-import mock
+from unittest import mock
 
 from oauthlib.oauth2 import (BackendApplicationServer, LegacyApplicationServer,
                              MobileApplicationServer, RequestValidator, Server,

--- a/tests/oauth2/rfc6749/grant_types/test_authorization_code.py
+++ b/tests/oauth2/rfc6749/grant_types/test_authorization_code.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 
-import mock
+from unittest import mock
 
 from oauthlib.common import Request
 from oauthlib.oauth2.rfc6749 import errors

--- a/tests/oauth2/rfc6749/grant_types/test_client_credentials.py
+++ b/tests/oauth2/rfc6749/grant_types/test_client_credentials.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 
-import mock
+from unittest import mock
 
 from oauthlib.common import Request
 from oauthlib.oauth2.rfc6749.grant_types import ClientCredentialsGrant

--- a/tests/oauth2/rfc6749/grant_types/test_implicit.py
+++ b/tests/oauth2/rfc6749/grant_types/test_implicit.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 
 from oauthlib.common import Request
 from oauthlib.oauth2.rfc6749.grant_types import ImplicitGrant

--- a/tests/oauth2/rfc6749/grant_types/test_refresh_token.py
+++ b/tests/oauth2/rfc6749/grant_types/test_refresh_token.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 
-import mock
+from unittest import mock
 
 from oauthlib.common import Request
 from oauthlib.oauth2.rfc6749 import errors

--- a/tests/oauth2/rfc6749/grant_types/test_resource_owner_password.py
+++ b/tests/oauth2/rfc6749/grant_types/test_resource_owner_password.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 
-import mock
+from unittest import mock
 
 from oauthlib.common import Request
 from oauthlib.oauth2.rfc6749 import errors

--- a/tests/oauth2/rfc6749/test_parameters.py
+++ b/tests/oauth2/rfc6749/test_parameters.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 
 from oauthlib import signals
 from oauthlib.oauth2.rfc6749.errors import *

--- a/tests/oauth2/rfc6749/test_server.py
+++ b/tests/oauth2/rfc6749/test_server.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 
-import mock
+from unittest import mock
 
 from oauthlib import common
 from oauthlib.oauth2.rfc6749 import errors, tokens

--- a/tests/oauth2/rfc6749/test_tokens.py
+++ b/tests/oauth2/rfc6749/test_tokens.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from oauthlib.common import Request
 from oauthlib.oauth2.rfc6749.tokens import (

--- a/tests/openid/connect/core/endpoints/test_claims_handling.py
+++ b/tests/openid/connect/core/endpoints/test_claims_handling.py
@@ -6,7 +6,7 @@ The claims parameter is an optional query param for the Authorization Request en
  request the claims should be transferred (via the oauthlib request) to be persisted
  with the Access Token when it is created.
 """
-import mock
+from unittest import mock
 
 from oauthlib.openid import RequestValidator
 from oauthlib.openid.connect.core.endpoints.pre_configured import Server

--- a/tests/openid/connect/core/endpoints/test_openid_connect_params_handling.py
+++ b/tests/openid/connect/core/endpoints/test_openid_connect_params_handling.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from oauthlib.oauth2 import InvalidRequestError
 from oauthlib.oauth2.rfc6749.endpoints.authorization import \

--- a/tests/openid/connect/core/endpoints/test_userinfo_endpoint.py
+++ b/tests/openid/connect/core/endpoints/test_userinfo_endpoint.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 import json
 
 from oauthlib.openid import RequestValidator

--- a/tests/openid/connect/core/grant_types/test_authorization_code.py
+++ b/tests/openid/connect/core/grant_types/test_authorization_code.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 
-import mock
+from unittest import mock
 
 from oauthlib.common import Request
 from oauthlib.oauth2.rfc6749.tokens import BearerToken

--- a/tests/openid/connect/core/grant_types/test_base.py
+++ b/tests/openid/connect/core/grant_types/test_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 import time
 
 from oauthlib.common import Request

--- a/tests/openid/connect/core/grant_types/test_dispatchers.py
+++ b/tests/openid/connect/core/grant_types/test_dispatchers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 
 from oauthlib.common import Request
 

--- a/tests/openid/connect/core/grant_types/test_hybrid.py
+++ b/tests/openid/connect/core/grant_types/test_hybrid.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 
 from oauthlib.oauth2.rfc6749 import errors
 from oauthlib.oauth2.rfc6749.tokens import BearerToken

--- a/tests/openid/connect/core/grant_types/test_implicit.py
+++ b/tests/openid/connect/core/grant_types/test_implicit.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 
 from oauthlib.common import Request
 from oauthlib.oauth2.rfc6749 import errors

--- a/tests/openid/connect/core/test_server.py
+++ b/tests/openid/connect/core/test_server.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 
-import mock
+from unittest import mock
 
 from oauthlib.oauth2.rfc6749 import errors
 from oauthlib.oauth2.rfc6749.endpoints.authorization import AuthorizationEndpoint

--- a/tests/openid/connect/core/test_tokens.py
+++ b/tests/openid/connect/core/test_tokens.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from oauthlib.openid.connect.core.tokens import JWTToken
 


### PR DESCRIPTION
Replace the use of external 'mock' package with built-in Python
unittest.mock (present since py3.3).  This also fixes all test failures
for me.