### PR TITLE
OAuth2 `LegacyApplicationClient.prepare_request_body` now correctly uses the default `scope` provided in constructor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,8 +25,9 @@ OAuth2.0 Provider - Bugfixes
 OAuth2.0 Client - Bugfixes
 
   * #290: Fix Authorization Code's errors processing
-  * #603: BackendApplication.Client.prepare_request_body use the `scope` argument as intended.
+  * #603: BackendApplicationClient.prepare_request_body use the `scope` argument as intended.
   * #672: Fix edge case when `expires_in=Null`
+  * #725: LegacyApplicationClient.prepare_request_body now correctly uses the default `scope` provided in constructor
 
 OAuth1.0 Client
 

--- a/oauthlib/oauth2/rfc6749/clients/legacy_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/legacy_application.py
@@ -79,8 +79,6 @@ class LegacyApplicationClient(Client):
         """
         kwargs['client_id'] = self.client_id
         kwargs['include_client_id'] = include_client_id
-        if scope is None:
-            # use default scopes
-            scope = self.scope
+        scope = self.scope if scope is None else scope
         return prepare_token_request(self.grant_type, body=body, username=username,
                                      password=password, scope=scope, **kwargs)

--- a/oauthlib/oauth2/rfc6749/clients/legacy_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/legacy_application.py
@@ -79,5 +79,8 @@ class LegacyApplicationClient(Client):
         """
         kwargs['client_id'] = self.client_id
         kwargs['include_client_id'] = include_client_id
+        if scope is None:
+            # use default scopes
+            scope = self.scope
         return prepare_token_request(self.grant_type, body=body, username=username,
                                      password=password, scope=scope, **kwargs)


### PR DESCRIPTION
Fixes #725