### PR TITLE
OAuth2 `xxxApplicationClient` now correctly use the default `scope` provided in constructor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,10 @@ OAuth2.0 Client - Bugfixes
   * #290: Fix Authorization Code's errors processing
   * #603: BackendApplication.Client.prepare_request_body use the `scope` argument as intended.
   * #672: Fix edge case when `expires_in=Null`
+  * #726: MobileApplicationClient.prepare_request_uri and MobileApplicationClient.parse_request_uri_response,
+    ServiceApplicationClient.prepare_request_body,
+    and WebApplicationClient.prepare_request_uri now correctly use the default `scope` provided in
+    constructor.
 
 OAuth1.0 Client
 

--- a/oauthlib/oauth2/rfc6749/clients/mobile_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/mobile_application.py
@@ -91,6 +91,7 @@ class MobileApplicationClient(Client):
         .. _`Section 3.3`: https://tools.ietf.org/html/rfc6749#section-3.3
         .. _`Section 10.12`: https://tools.ietf.org/html/rfc6749#section-10.12
         """
+        scope = self.scope if scope is None else scope
         return prepare_grant_uri(uri, self.client_id, self.response_type,
                                  redirect_uri=redirect_uri, state=state, scope=scope, **kwargs)
 
@@ -167,6 +168,7 @@ class MobileApplicationClient(Client):
         .. _`Section 7.1`: https://tools.ietf.org/html/rfc6749#section-7.1
         .. _`Section 3.3`: https://tools.ietf.org/html/rfc6749#section-3.3
         """
+        scope = self.scope if scope is None else scope
         self.token = parse_implicit_response(uri, state=state, scope=scope)
         self.populate_token_attributes(self.token)
         return self.token

--- a/oauthlib/oauth2/rfc6749/clients/service_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/service_application.py
@@ -181,6 +181,7 @@ class ServiceApplicationClient(Client):
 
         kwargs['client_id'] = self.client_id
         kwargs['include_client_id'] = include_client_id
+        scope = self.scope if scope is None else scope
         return prepare_token_request(self.grant_type,
                                      body=body,
                                      assertion=assertion,

--- a/oauthlib/oauth2/rfc6749/clients/web_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/web_application.py
@@ -84,6 +84,7 @@ class WebApplicationClient(Client):
         .. _`Section 3.3`: https://tools.ietf.org/html/rfc6749#section-3.3
         .. _`Section 10.12`: https://tools.ietf.org/html/rfc6749#section-10.12
         """
+        scope = self.scope if scope is None else scope
         return prepare_grant_uri(uri, self.client_id, 'code',
                                  redirect_uri=redirect_uri, scope=scope, state=state, **kwargs)
 


### PR DESCRIPTION
Fixes #728 