### PR TITLE
Fix OAuth2 base `Client` inconsistent `scope` handling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,11 @@ OAuth2.0 Client - Bugfixes
   * #290: Fix Authorization Code's errors processing
   * #603: BackendApplication.Client.prepare_request_body use the `scope` argument as intended.
   * #672: Fix edge case when `expires_in=Null`
+  * #730: Base OAuth2 Client now has a consistent way of managing the `scope`: it consistently
+    relies on the `scope` provided in the constructor if any, except if overridden temporarily
+    in a method call. Note that in particular providing a non-None `scope` in
+    `prepare_authorization_request` or `prepare_refresh_token` does not override anymore
+    `self.scope` forever, it is just used temporarily.
 
 OAuth1.0 Client
 

--- a/oauthlib/oauth2/rfc6749/clients/base.py
+++ b/oauthlib/oauth2/rfc6749/clients/base.py
@@ -220,7 +220,10 @@ class Client:
         the provider. If provided then it must also be provided in the
         token request.
 
-        :param scope:
+        :param scope: List of scopes to request. Must be equal to
+        or a subset of the scopes granted when obtaining the refresh
+        token. If none is provided, the ones provided in the constructor are
+        used.
 
         :param kwargs: Additional parameters to included in the request.
 
@@ -231,10 +234,11 @@ class Client:
 
         self.state = state or self.state_generator()
         self.redirect_url = redirect_url or self.redirect_url
-        self.scope = scope or self.scope
+        # do not assign scope to self automatically anymore
+        scope = self.scope if scope is None else scope
         auth_url = self.prepare_request_uri(
             authorization_url, redirect_uri=self.redirect_url,
-            scope=self.scope, state=self.state, **kwargs)
+            scope=scope, state=self.state, **kwargs)
         return auth_url, FORM_ENC_HEADERS, ''
 
     def prepare_token_request(self, token_url, authorization_response=None,
@@ -295,7 +299,8 @@ class Client:
 
         :param scope: List of scopes to request. Must be equal to
         or a subset of the scopes granted when obtaining the refresh
-        token.
+        token. If none is provided, the ones provided in the constructor are
+        used.
 
         :param kwargs: Additional parameters to included in the request.
 
@@ -304,9 +309,10 @@ class Client:
         if not is_secure_transport(token_url):
             raise InsecureTransportError()
 
-        self.scope = scope or self.scope
+        # do not assign scope to self automatically anymore
+        scope = self.scope if scope is None else scope
         body = self.prepare_refresh_body(body=body,
-                                         refresh_token=refresh_token, scope=self.scope, **kwargs)
+                                         refresh_token=refresh_token, scope=scope, **kwargs)
         return token_url, FORM_ENC_HEADERS, body
 
     def prepare_token_revocation_request(self, revocation_url, token,
@@ -380,7 +386,8 @@ class Client:
         returns an error response as described in `Section 5.2`_.
 
         :param body: The response body from the token request.
-        :param scope: Scopes originally requested.
+        :param scope: Scopes originally requested. If none is provided, the ones
+        provided in the constructor are used.
         :return: Dictionary of token parameters.
         :raises: Warning if scope has changed. OAuth2Error if response is invalid.
 
@@ -416,6 +423,7 @@ class Client:
         .. _`Section 5.2`: https://tools.ietf.org/html/rfc6749#section-5.2
         .. _`Section 7.1`: https://tools.ietf.org/html/rfc6749#section-7.1
         """
+        scope = self.scope if scope is None else scope
         self.token = parse_token_response(body, scope=scope)
         self.populate_token_attributes(self.token)
         return self.token
@@ -437,9 +445,11 @@ class Client:
                 Section 3.3.  The requested scope MUST NOT include any scope
                 not originally granted by the resource owner, and if omitted is
                 treated as equal to the scope originally granted by the
-                resource owner.
+                resource owner. Note that if none is provided, the ones provided
+                in the constructor are used if any.
         """
         refresh_token = refresh_token or self.refresh_token
+        scope = self.scope if scope is None else scope
         return prepare_token_request(self.refresh_token_key, body=body, scope=scope,
                                      refresh_token=refresh_token, **kwargs)
 


### PR DESCRIPTION
This is the final step after PRs #682 #726 and #729 : I found out that even the base `Client` has inconsistent management of the `scope` attribute.

 - in `prepare_authorization_request` and `prepare_refresh_token_request` if a `scope` is provided, it is assigned to `self` forever, overriding any scope provided in the constructor

 - in `parse_request_body_response` and `prepare_refresh_body`, if no scope is provided the one from the constructor is not used !

This PR is an attempt to uniformize everything, but I think that we should ask ourselves the question: will it have side-effects ? (are there enough tests as of today to ensure non-regression)

