### PR TITLE
Use request.nonce when generating hybrid id token

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,3 +29,4 @@ Brendan McCollam
 Jonathan Huot
 Pieter Ennes
 Olaf Conradi
+Tom Evans

--- a/oauthlib/openid/connect/core/grant_types/hybrid.py
+++ b/oauthlib/openid/connect/core/grant_types/hybrid.py
@@ -35,6 +35,9 @@ class HybridGrant(GrantTypeBase):
         self.register_code_modifier(self.add_id_token)
         self.register_token_modifier(self.add_id_token)
 
+    def add_id_token(self, token, token_handler, request):
+        return super().add_id_token(token, token_handler, request, nonce=request.nonce)
+
     def openid_authorization_validator(self, request):
         """Additional validation when following the Authorization Code flow.
         """

--- a/tests/openid/connect/core/grant_types/test_hybrid.py
+++ b/tests/openid/connect/core/grant_types/test_hybrid.py
@@ -67,6 +67,15 @@ class OpenIDHybridCodeIdTokenTest(OpenIDAuthCodeTest):
         self.assertIsNone(b)
         self.assertEqual(s, 302)
 
+    def test_id_token_contains_nonce(self):
+        token = {}
+        self.mock_validator.get_id_token.side_effect = None
+        self.mock_validator.get_id_token.return_value = None
+        token = self.auth.add_id_token(token, None, self.request)
+        assert self.mock_validator.finalize_id_token.call_count == 1
+        claims = self.mock_validator.finalize_id_token.call_args[0][0]
+        assert "nonce" in claims
+
 
 class OpenIDHybridCodeIdTokenTokenTest(OpenIDAuthCodeTest):
 


### PR DESCRIPTION
Like with the implicit grant, we need to override `add_id_token` to pass the nonce from the current request to `GrantBase.add_id_token` in order for the ID token to have the correct nonce.

Add test that the nonce is in ID token from hybrid OIDC flow.

Fixes: #746