### PR TITLE
Oidc refresh

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ OAuth2.0 Provider - Bugfixes
 
   * #753: Fix acceptance of valid IPv6 addresses in URI validation
 
+OAuth2.0 Provider - Features
+  * #751: OIDC add support of refreshing ID Tokens
+
 OAuth2.0 Client - Bugfixes
 
   * #730: Base OAuth2 Client now has a consistent way of managing the `scope`: it consistently
@@ -25,6 +28,8 @@ OAuth2.0 Provider - Bugfixes
   * #746: OpenID Connect Hybrid - fix nonce not passed to add_id_token
   * #756: Different prompt values are now handled according to spec (e.g. prompt=none)
   * #759: OpenID Connect - fix Authorization: Basic parsing
+  * #751: The RefreshTokenGrant modifiers now take the same arguments as the
+    AuthorizationCodeGrant modifiers (`token`, `token_handler`, `request`).
 
 General
   * #716: improved skeleton validator for public vs private client

--- a/docs/oauth2/oidc/refresh_token.rst
+++ b/docs/oauth2/oidc/refresh_token.rst
@@ -1,0 +1,6 @@
+OpenID Authorization Code
+-------------------------
+
+.. autoclass:: oauthlib.openid.connect.core.grant_types.RefreshTokenGrant
+    :members:
+    :inherited-members:

--- a/oauthlib/oauth2/rfc6749/grant_types/refresh_token.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/refresh_token.py
@@ -63,7 +63,7 @@ class RefreshTokenGrant(GrantTypeBase):
                                            refresh_token=self.issue_new_refresh_tokens)
 
         for modifier in self._token_modifiers:
-            token = modifier(token)
+            token = modifier(token, token_handler, request)
 
         self.request_validator.save_token(token, request)
 

--- a/oauthlib/openid/connect/core/grant_types/__init__.py
+++ b/oauthlib/openid/connect/core/grant_types/__init__.py
@@ -10,3 +10,4 @@ from .dispatchers import (
 )
 from .hybrid import HybridGrant
 from .implicit import ImplicitGrant
+from .refresh_token import RefreshTokenGrant

--- a/oauthlib/openid/connect/core/grant_types/refresh_token.py
+++ b/oauthlib/openid/connect/core/grant_types/refresh_token.py
@@ -1,0 +1,36 @@
+"""
+oauthlib.openid.connect.core.grant_types
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+import logging
+
+from oauthlib.oauth2.rfc6749.grant_types.refresh_token import (
+    RefreshTokenGrant as OAuth2RefreshTokenGrant,
+)
+
+from .base import GrantTypeBase
+
+log = logging.getLogger(__name__)
+
+
+class RefreshTokenGrant(GrantTypeBase):
+
+    def __init__(self, refresh_id_token=True, request_validator=None, **kwargs):
+        self.refresh_id_token = refresh_id_token
+        self.proxy_target = OAuth2RefreshTokenGrant(
+            request_validator=request_validator, **kwargs)
+        self.register_token_modifier(self.add_id_token)
+
+    def add_id_token(self, token, token_handler, request):
+        """
+        Construct an initial version of id_token, and let the
+        request_validator sign or encrypt it.
+
+        The authorization_code version of this method is used to
+        retrieve the nonce accordingly to the code storage.
+        """
+        # Treat it as normal OAuth 2 auth code request if openid is not present
+        if not self.refresh_id_token:
+            return token
+
+        return super().add_id_token(token, token_handler, request)

--- a/oauthlib/openid/connect/core/grant_types/refresh_token.py
+++ b/oauthlib/openid/connect/core/grant_types/refresh_token.py
@@ -15,8 +15,7 @@ log = logging.getLogger(__name__)
 
 class RefreshTokenGrant(GrantTypeBase):
 
-    def __init__(self, refresh_id_token=True, request_validator=None, **kwargs):
-        self.refresh_id_token = refresh_id_token
+    def __init__(self, request_validator=None, **kwargs):
         self.proxy_target = OAuth2RefreshTokenGrant(
             request_validator=request_validator, **kwargs)
         self.register_token_modifier(self.add_id_token)
@@ -29,8 +28,7 @@ class RefreshTokenGrant(GrantTypeBase):
         The authorization_code version of this method is used to
         retrieve the nonce accordingly to the code storage.
         """
-        # Treat it as normal OAuth 2 auth code request if openid is not present
-        if not self.refresh_id_token:
+        if not self.request_validator.refresh_id_token(request):
             return token
 
         return super().add_id_token(token, token_handler, request)

--- a/oauthlib/openid/connect/core/request_validator.py
+++ b/oauthlib/openid/connect/core/request_validator.py
@@ -306,3 +306,15 @@ class RequestValidator(OAuth2RequestValidator):
         Method is used by:
             UserInfoEndpoint
         """
+
+    def refresh_id_token(self, request):
+        """Whether the id token should be refreshed. Default, True
+
+        :param request: OAuthlib request.
+        :type request: oauthlib.common.Request
+        :rtype: True or False
+
+        Method is used by:
+            RefreshTokenGrant
+        """
+        return True

--- a/tests/openid/connect/core/grant_types/test_refresh_token.py
+++ b/tests/openid/connect/core/grant_types/test_refresh_token.py
@@ -1,0 +1,99 @@
+import json
+from unittest import mock
+
+from oauthlib.common import Request
+from oauthlib.oauth2.rfc6749.tokens import BearerToken
+from oauthlib.openid.connect.core.grant_types import RefreshTokenGrant
+
+from tests.oauth2.rfc6749.grant_types.test_refresh_token import (
+    RefreshTokenGrantTest,
+)
+from tests.unittest import TestCase
+
+
+def get_id_token_mock(token, token_handler, request):
+    return "MOCKED_TOKEN"
+
+
+class OpenIDRefreshTokenInterferenceTest(RefreshTokenGrantTest):
+    """Test that OpenID don't interfere with normal OAuth 2 flows."""
+
+    def setUp(self):
+        super().setUp()
+        self.auth = RefreshTokenGrant(request_validator=self.mock_validator)
+
+
+class OpenIDRefreshTokenTest(TestCase):
+
+    def setUp(self):
+        self.request = Request('http://a.b/path')
+        self.request.grant_type = 'refresh_token'
+        self.request.refresh_token = 'lsdkfhj230'
+        self.request.scope = ('hello', 'openid')
+        self.mock_validator = mock.MagicMock()
+
+        self.mock_validator = mock.MagicMock()
+        self.mock_validator.authenticate_client.side_effect = self.set_client
+        self.mock_validator.get_id_token.side_effect = get_id_token_mock
+        self.auth = RefreshTokenGrant(request_validator=self.mock_validator)
+
+    def set_client(self, request):
+        request.client = mock.MagicMock()
+        request.client.client_id = 'mocked'
+        return True
+
+    def test_refresh_id_token(self):
+        self.mock_validator.get_original_scopes.return_value = [
+            'hello', 'openid'
+        ]
+        bearer = BearerToken(self.mock_validator)
+
+        headers, body, status_code = self.auth.create_token_response(
+            self.request, bearer
+        )
+
+        token = json.loads(body)
+        self.assertEqual(self.mock_validator.save_token.call_count, 1)
+        self.assertIn('access_token', token)
+        self.assertIn('refresh_token', token)
+        self.assertIn('id_token', token)
+        self.assertIn('token_type', token)
+        self.assertIn('expires_in', token)
+        self.assertEqual(token['scope'], 'hello openid')
+
+    def test_refresh_id_token_false(self):
+        self.auth.refresh_id_token = False
+        self.mock_validator.get_original_scopes.return_value = [
+            'hello', 'openid'
+        ]
+        bearer = BearerToken(self.mock_validator)
+
+        headers, body, status_code = self.auth.create_token_response(
+            self.request, bearer
+        )
+
+        token = json.loads(body)
+        self.assertEqual(self.mock_validator.save_token.call_count, 1)
+        self.assertIn('access_token', token)
+        self.assertIn('refresh_token', token)
+        self.assertIn('token_type', token)
+        self.assertIn('expires_in', token)
+        self.assertEqual(token['scope'], 'hello openid')
+        self.assertNotIn('id_token', token)
+
+    def test_refresh_token_without_openid_scope(self):
+        self.request.scope = "hello"
+        bearer = BearerToken(self.mock_validator)
+
+        headers, body, status_code = self.auth.create_token_response(
+            self.request, bearer
+        )
+
+        token = json.loads(body)
+        self.assertEqual(self.mock_validator.save_token.call_count, 1)
+        self.assertIn('access_token', token)
+        self.assertIn('refresh_token', token)
+        self.assertIn('token_type', token)
+        self.assertIn('expires_in', token)
+        self.assertNotIn('id_token', token)
+        self.assertEqual(token['scope'], 'hello')

--- a/tests/openid/connect/core/grant_types/test_refresh_token.py
+++ b/tests/openid/connect/core/grant_types/test_refresh_token.py
@@ -60,9 +60,12 @@ class OpenIDRefreshTokenTest(TestCase):
         self.assertIn('token_type', token)
         self.assertIn('expires_in', token)
         self.assertEqual(token['scope'], 'hello openid')
+        self.mock_validator.refresh_id_token.assert_called_once_with(
+            self.request
+        )
 
     def test_refresh_id_token_false(self):
-        self.auth.refresh_id_token = False
+        self.mock_validator.refresh_id_token.return_value = False
         self.mock_validator.get_original_scopes.return_value = [
             'hello', 'openid'
         ]
@@ -80,6 +83,9 @@ class OpenIDRefreshTokenTest(TestCase):
         self.assertIn('expires_in', token)
         self.assertEqual(token['scope'], 'hello openid')
         self.assertNotIn('id_token', token)
+        self.mock_validator.refresh_id_token.assert_called_once_with(
+            self.request
+        )
 
     def test_refresh_token_without_openid_scope(self):
         self.request.scope = "hello"


### PR DESCRIPTION
Fixes #751 

This PR adds support for refreshing ID Tokens.

This PR breaks backwards compatibility with `RefreshTokenGrant` modifiers. If this is a problem, I could change the `RefreshTokenGrant` modifiers only for OIDC in order to remain backwards compatible.