### PR TITLE
Issue759/check authz type

### DIFF
--- a/oauthlib/openid/connect/core/tokens.py
+++ b/oauthlib/openid/connect/core/tokens.py
@@ -37,7 +37,9 @@ class JWTToken(TokenBase):
     def validate_request(self, request):
         token = None
         if 'Authorization' in request.headers:
-            token = request.headers.get('Authorization')[7:]
+            split_header = request.headers.get('Authorization').split()
+            if len(split_header) == 2 and split_header[0].lower() == 'bearer':
+                token = split_header[1]
         else:
             token = request.access_token
         return self.request_validator.validate_jwt_bearer_token(

--- a/oauthlib/openid/connect/core/tokens.py
+++ b/oauthlib/openid/connect/core/tokens.py
@@ -46,8 +46,9 @@ class JWTToken(TokenBase):
             token, request.scopes, request)
 
     def estimate_type(self, request):
-        token = request.headers.get('Authorization', '')[7:]
-        if token.startswith('ey') and token.count('.') in (2, 4):
-            return 10
-        else:
-            return 0
+        split_header = request.headers.get('Authorization').split()
+        if len(split_header) == 2 and split_header[0].lower() == 'bearer':
+            token = split_header[1]
+            if token.startswith('ey') and token.count('.') in (2, 4):
+                return 10
+        return 0

--- a/oauthlib/openid/connect/core/tokens.py
+++ b/oauthlib/openid/connect/core/tokens.py
@@ -4,7 +4,7 @@ authlib.openid.connect.core.tokens
 
 This module contains methods for adding JWT tokens to requests.
 """
-from oauthlib.oauth2.rfc6749.tokens import TokenBase, random_token_generator
+from oauthlib.oauth2.rfc6749.tokens import TokenBase, random_token_generator, get_token_from_header
 
 
 class JWTToken(TokenBase):
@@ -35,20 +35,12 @@ class JWTToken(TokenBase):
         return self.request_validator.get_jwt_bearer_token(None, None, request)
 
     def validate_request(self, request):
-        token = None
-        if 'Authorization' in request.headers:
-            split_header = request.headers.get('Authorization').split()
-            if len(split_header) == 2 and split_header[0].lower() == 'bearer':
-                token = split_header[1]
-        else:
-            token = request.access_token
+        token = get_token_from_header(request)
         return self.request_validator.validate_jwt_bearer_token(
             token, request.scopes, request)
 
     def estimate_type(self, request):
-        split_header = request.headers.get('Authorization').split()
-        if len(split_header) == 2 and split_header[0].lower() == 'bearer':
-            token = split_header[1]
-            if token.startswith('ey') and token.count('.') in (2, 4):
-                return 10
+        token = get_token_from_header(request)
+        if token and token.startswith('ey') and token.count('.') in (2, 4):
+            return 10
         return 0

--- a/tests/openid/connect/core/test_tokens.py
+++ b/tests/openid/connect/core/test_tokens.py
@@ -76,6 +76,32 @@ class JWTTokenTestCase(TestCase):
                                                                                      request.scopes,
                                                                                      request)
 
+    def test_validate_request_token_from_headers_basic(self):
+        """
+        Wrong kind of token (Basic) retrieved from headers. Confirm token is not parsed.
+        """
+
+        with mock.patch('oauthlib.common.Request', autospec=True) as RequestMock, \
+                mock.patch('oauthlib.openid.RequestValidator',
+                           autospec=True) as RequestValidatorMock:
+            request_validator_mock = RequestValidatorMock()
+
+            token = JWTToken(request_validator=request_validator_mock)
+
+            request = RequestMock('/uri')
+            # Scopes is retrieved using the __call__ method which is not picked up correctly by mock.patch
+            # with autospec=True
+            request.scopes = mock.MagicMock()
+            request.headers = {
+                'Authorization': 'Basic some-token-from-header'
+            }
+
+            token.validate_request(request=request)
+
+            request_validator_mock.validate_jwt_bearer_token.assert_called_once_with(None,
+                                                                                     request.scopes,
+                                                                                     request)
+
     def test_validate_token_from_request(self):
         """
         Token get retrieved from request object.


### PR DESCRIPTION
Fixes: #759 

Fixes the case where an Authorization header that is **not** a Bearer is misinterpreted as a Bearer -- and misaligned as well, if, for instance, the header is a Basic.
