### PR TITLE
3.1.1 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,20 +27,20 @@ notifications:
     on_failure: always
     on_start: never
 deploy:
-  - provider: pypi
-    user: JonathanHuot
-    password:
-      secure: "OozNM16flVLvqDoNzmoTENchhS1w0/dEJZvXBQK2KWmh8fyGj2UZus1vkl6bA5V3Yu9MZLYFpDcltl/qraY3Up6iXQpwKz4q+ICygAudYM2kJ5l8ZEe+wy2FikWbD6LkXf5uKIJJnPNSC8AI86ZyxM/XZxbYjj/+jXyJ1YFZwwQ="
-    distributions: sdist bdist_wheel
+  - provider: releases
+    api_key:
+      secure: "eqEWOzKWZCuvd1a77CA03OX/HCrsYlsu1/Sz/RhXQIEhKz6tKp10KGw9zr57bHAIl0OfJFK9k63lI2HOctAmwkKeeQ4HdNqw4pHFa8Gk3liGp31KSmshVtHX8Rtn0DuFA028Wm7w5n+fOVc8tJVU/UsKjsfsAzRHnQjMamckoXU="
+    skip_cleanup: true
     on:
       tags: true
       all_branches: true
       condition: $TOXENV = py36
       repo: oauthlib/oauthlib
-  - provider: releases
-    api_key:
-      secure: "eqEWOzKWZCuvd1a77CA03OX/HCrsYlsu1/Sz/RhXQIEhKz6tKp10KGw9zr57bHAIl0OfJFK9k63lI2HOctAmwkKeeQ4HdNqw4pHFa8Gk3liGp31KSmshVtHX8Rtn0DuFA028Wm7w5n+fOVc8tJVU/UsKjsfsAzRHnQjMamckoXU="
-    skip_cleanup: true
+  - provider: pypi
+    user: JonathanHuot
+    password:
+      secure: "OozNM16flVLvqDoNzmoTENchhS1w0/dEJZvXBQK2KWmh8fyGj2UZus1vkl6bA5V3Yu9MZLYFpDcltl/qraY3Up6iXQpwKz4q+ICygAudYM2kJ5l8ZEe+wy2FikWbD6LkXf5uKIJJnPNSC8AI86ZyxM/XZxbYjj/+jXyJ1YFZwwQ="
+    distributions: sdist bdist_wheel
     on:
       tags: true
       all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,7 @@ matrix:
   - python: 3.7
     env: TOXENV=py37
   - python: 3.8
-    env: TOXENV=py38
-  - python: 3.8
-    env: TOXENV=bandit
+    env: TOXENV=py38,bandit,docs,readme
   - python: pypy3
     env: TOXENV=pypy3
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ deploy:
       repo: oauthlib/oauthlib
   - provider: releases
     api_key:
-      secure: LEzTaeQt4+Sp21t7usmwaEYLThKIGWDNNj04JADMLgfquTeyz5nDu9P8JNlT//G9RNN20oR8w7jZo97Y+JAylq6Hh/I+p/MEzZi8+NwIpObk3n3zJO4witZQQSTEw/6B7qf1/NQQxjQzlYTJjsGXxBps7srviWZmbH6Tz+epA3A=
+      secure: "eqEWOzKWZCuvd1a77CA03OX/HCrsYlsu1/Sz/RhXQIEhKz6tKp10KGw9zr57bHAIl0OfJFK9k63lI2HOctAmwkKeeQ4HdNqw4pHFa8Gk3liGp31KSmshVtHX8Rtn0DuFA028Wm7w5n+fOVc8tJVU/UsKjsfsAzRHnQjMamckoXU="
     skip_cleanup: true
     on:
       tags: true

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ OAuthLib - Python Framework for OAuth1 & OAuth2
 ===============================================
 
 *A generic, spec-compliant, thorough implementation of the OAuth request-signing
-logic for Python 3.6+.
+logic for Python 3.6+.*
 
 .. image:: https://travis-ci.org/oauthlib/oauthlib.svg?branch=master
   :target: https://travis-ci.org/oauthlib/oauthlib

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ basepython=python3.8
 deps=twine>=1.12.0
 whitelist_externals=echo
 commands=
-        twine check dist/*
+        twine check .tox/dist/*
 
 [testenv:bandit]
 basepython=python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,pypy,pypy3,docs,readme,bandit,isort
+envlist = py36,py37,py38,pypy3,docs,readme,bandit,isort
 
 [testenv]
 deps=


### PR DESCRIPTION
`docs,readme,bandit` tox environments have been added to Travis.
`readme` is important because it validates the `README.rst` format before submitting the package to pypi. I also fixed the format (missing `*` character regression uncaught because of the missing tox environment).
Note the error from pypi when the format is wrong https://travis-ci.org/github/oauthlib/oauthlib/jobs/773071394 :

```
NOTE: Try --verbose to see response content.
HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
The description failed to render for 'text/x-rst'. See https://pypi.org/help/#description-content-type for more information.
```