### PR TITLE
Prepare 3.2.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+3.2.0 (TBD)
+------------------
+
+In Progress
+
+
 3.1.1 (2021-05-31)
 ------------------
 OAuth2.0 Provider - Bugfixes

--- a/oauthlib/__init__.py
+++ b/oauthlib/__init__.py
@@ -12,7 +12,7 @@ import logging
 from logging import NullHandler
 
 __author__ = 'The OAuthlib Community'
-__version__ = '3.1.1'
+__version__ = '3.2.0-dev'
 
 logging.getLogger('oauthlib').addHandler(NullHandler())
 


### PR DESCRIPTION
The PR is mainly to test travis-ci.com migration.
GitHub webhook has https://notify.travis-ci.org renamed into https://notify.travis-ci.com