### PR TITLE
parameters.py - Expanding Error Code Catching

### DIFF
--- a/oauthlib/oauth2/rfc6749/parameters.py
+++ b/oauthlib/oauth2/rfc6749/parameters.py
@@ -261,8 +261,9 @@ def parse_authorization_code_response(uri, state=None):
     if state and params.get('state', None) != state:
         raise MismatchingStateError()
 
-    if 'error' in params:
-        raise_from_error(params.get('error'), params)
+    for key in params.keys():
+        if 'error' in key.lower():
+            raise_from_error(params.get(key), params)
 
     if not 'code' in params:
         raise MissingCodeError("Missing code parameter in response.")
@@ -428,8 +429,9 @@ def parse_token_response(body, scope=None):
 
 def validate_token_parameters(params):
     """Ensures token presence, token type, expiration and scope in params."""
-    if 'error' in params:
-        raise_from_error(params.get('error'), params)
+    for key in params.keys():
+        if 'error' in key.lower():
+            raise_from_error(params.get(key), params)
 
     if not 'access_token' in params:
         raise MissingTokenError(description="Missing access token parameter.")


### PR DESCRIPTION
One public API I use returns errorCode: <error>. This should now catch a wider variety of errors.
