### PR TITLE
fix #755: ensure save_token is called for hybrid code flow

### DIFF
--- a/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
@@ -272,6 +272,8 @@ class AuthorizationCodeGrant(GrantTypeBase):
         grant = self.create_authorization_code(request)
         for modifier in self._code_modifiers:
             grant = modifier(grant, token_handler, request)
+        if 'access_token' in grant:
+            self.request_validator.save_token(grant, request)
         log.debug('Saving grant %r for %r.', grant, request)
         self.request_validator.save_authorization_code(
             request.client_id, grant, request)

--- a/tests/oauth2/rfc6749/grant_types/test_authorization_code.py
+++ b/tests/oauth2/rfc6749/grant_types/test_authorization_code.py
@@ -324,3 +324,18 @@ class AuthorizationCodeGrantTest(TestCase):
             authorization_code.code_challenge_method_s256("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
                                                           "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
         )
+
+    def test_code_modifier_called(self):
+        bearer = BearerToken(self.mock_validator)
+        code_modifier = mock.MagicMock(wraps=lambda grant, *a: grant)
+        self.auth.register_code_modifier(code_modifier)
+        self.auth.create_authorization_response(self.request, bearer)
+        code_modifier.assert_called_once()
+
+    def test_hybrid_token_save(self):
+        bearer = BearerToken(self.mock_validator)
+        self.auth.register_code_modifier(
+            lambda grant, *a: dict(list(grant.items()) + [('access_token', 1)])
+        )
+        self.auth.create_authorization_response(self.request, bearer)
+        self.mock_validator.save_token.assert_called_once()


### PR DESCRIPTION
This closes #755 

It ensures that when a hybrid request such as:

```
GET /authorize/?response_type=code+token&client_id=AppClientID&redirect_url=http://localhost/&scope=openid+profile HTTP/1.1
```

The returned token is persisted via a call to `save_token`.