### PR TITLE
Replace deprecated unittest aliases

### DIFF
--- a/tests/oauth2/rfc6749/endpoints/test_error_responses.py
+++ b/tests/oauth2/rfc6749/endpoints/test_error_responses.py
@@ -178,21 +178,21 @@ class ErrorResponseTest(TestCase):
         description = 'Duplicate client_id parameter.'
 
         # Authorization code
-        self.assertRaisesRegexp(errors.InvalidRequestFatalError,
+        self.assertRaisesRegex(errors.InvalidRequestFatalError,
                               description,
                               self.web.validate_authorization_request,
                               uri.format('code'))
-        self.assertRaisesRegexp(errors.InvalidRequestFatalError,
+        self.assertRaisesRegex(errors.InvalidRequestFatalError,
                               description,
                               self.web.create_authorization_response,
                               uri.format('code'), scopes=['foo'])
 
         # Implicit grant
-        self.assertRaisesRegexp(errors.InvalidRequestFatalError,
+        self.assertRaisesRegex(errors.InvalidRequestFatalError,
                               description,
                               self.mobile.validate_authorization_request,
                               uri.format('token'))
-        self.assertRaisesRegexp(errors.InvalidRequestFatalError,
+        self.assertRaisesRegex(errors.InvalidRequestFatalError,
                               description,
                               self.mobile.create_authorization_response,
                               uri.format('token'), scopes=['foo'])


### PR DESCRIPTION
> *Deprecated since version 3.2:* `assertRegexpMatches` and `assertRaisesRegexp` have been renamed to `assertRegex()` and `assertRaisesRegex()`.

https://docs.python.org/3/library/unittest.html#deprecated-aliases
