### PR TITLE
Remove upper bound on cryptography version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyjwt>=2.0.0,<3
 blinker==1.4
-cryptography>=3.0.0,<4
+cryptography>=3.0.0

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ def fread(fn):
         return f.read()
 
 
-rsa_require = ['cryptography>=3.0.0,<4']
-signedtoken_require = ['cryptography>=3.0.0,<4', 'pyjwt>=2.0.0,<3']
+rsa_require = ['cryptography>=3.0.0']
+signedtoken_require = ['cryptography>=3.0.0', 'pyjwt>=2.0.0,<3']
 signals_require = ['blinker>=1.4.0']
 
 setup(


### PR DESCRIPTION
Cryptography has adopted a firefox-style versioning system where new
feature releases always have new major versions even if they don't have
backwards incompatible changes. This means that an upper bound on the
dependency does not make sense.