### PR TITLE
Remove unneccessary setting of scope=["openid"].

### DIFF
--- a/oauthlib/openid/connect/core/endpoints/userinfo.py
+++ b/oauthlib/openid/connect/core/endpoints/userinfo.py
@@ -36,7 +36,6 @@ class UserInfoEndpoint(BaseEndpoint):
         using UTF-8.
         """
         request = Request(uri, http_method, body, headers)
-        request.scopes = ["openid"]
         self.validate_userinfo_request(request)
 
         claims = self.request_validator.get_userinfo_claims(request)


### PR DESCRIPTION
Remove unused line per https://github.com/oauthlib/oauthlib/issues/799#issuecomment-1025101396

It lead to downstream DOT's failure to set the request.scope properly to not notice the error:-)