### PR TITLE
Allow non-HTTPS issuer when OAUTHLIB_INSECURE_TRANSPORT.

### DIFF
--- a/oauthlib/oauth2/rfc6749/endpoints/metadata.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/metadata.py
@@ -10,13 +10,12 @@ import copy
 import json
 import logging
 
-from .. import grant_types
+from .. import grant_types, utils
 from .authorization import AuthorizationEndpoint
 from .base import BaseEndpoint, catch_errors_and_unavailability
 from .introspect import IntrospectEndpoint
 from .revocation import RevocationEndpoint
 from .token import TokenEndpoint
-from .utils import is_secure_transport
 
 log = logging.getLogger(__name__)
 
@@ -69,7 +68,7 @@ class MetadataEndpoint(BaseEndpoint):
                 raise ValueError("key {} is a mandatory metadata.".format(key))
 
         elif is_issuer:
-            if not is_secure_transport(array[key]):
+            if not utils.is_secure_transport(array[key]):
                 raise ValueError("key {}: {} must be an HTTPS URL".format(key, array[key]))
             if "?" in array[key] or "&" in array[key] or "#" in array[key]:
                 raise ValueError("key {}: {} must not contain query or fragment components".format(key, array[key]))

--- a/oauthlib/oauth2/rfc6749/endpoints/metadata.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/metadata.py
@@ -16,6 +16,7 @@ from .base import BaseEndpoint, catch_errors_and_unavailability
 from .introspect import IntrospectEndpoint
 from .revocation import RevocationEndpoint
 from .token import TokenEndpoint
+from .utils import is_secure_transport
 
 log = logging.getLogger(__name__)
 
@@ -68,7 +69,7 @@ class MetadataEndpoint(BaseEndpoint):
                 raise ValueError("key {} is a mandatory metadata.".format(key))
 
         elif is_issuer:
-            if not array[key].startswith("https"):
+            if not is_secure_transport(array[key]):
                 raise ValueError("key {}: {} must be an HTTPS URL".format(key, array[key]))
             if "?" in array[key] or "&" in array[key] or "#" in array[key]:
                 raise ValueError("key {}: {} must not contain query or fragment components".format(key, array[key]))

--- a/tests/oauth2/rfc6749/endpoints/test_metadata.py
+++ b/tests/oauth2/rfc6749/endpoints/test_metadata.py
@@ -135,3 +135,13 @@ class MetadataEndpointTest(TestCase):
         sort_list(metadata.claims)
         sort_list(expected_claims)
         self.assertEqual(sorted(metadata.claims.items()), sorted(expected_claims.items()))
+
+    def test_metadata_validate_issuer(self):
+        with self.assertRaises(ValueError):
+            endpoint = TokenEndpoint(
+                None, None, grant_types={"password": None},
+            )
+            metadata = MetadataEndpoint([endpoint], {
+                "issuer": 'http://foo.bar',
+                "token_endpoint": "https://foo.bar/token",
+            })


### PR DESCRIPTION
Use `utils.is_secure_transport` to validate issuer, that way `OAUTHLIB_INSECURE_TRANSPORT` is taken into account.