### PR TITLE
add missing slots to TokenBase

### DIFF
--- a/oauthlib/oauth2/rfc6749/tokens.py
+++ b/oauthlib/oauth2/rfc6749/tokens.py
@@ -257,6 +257,7 @@ def get_token_from_header(request):
 
 
 class TokenBase:
+    __slots__ = ()
 
     def __call__(self, request, refresh_token=False):
         raise NotImplementedError('Subclasses must implement this method.')


### PR DESCRIPTION
`TokenBase` doesn't define `__slots__`, but it's subclasses `BearerToken` and `JWTToken` do. This means the memory savings are reduced, and `__dict__` is still present.

Solution: add `__slots__ = ()` to `TokenBase`. This will ensure slots on its base classes are effective.

I discovered the slots issues with [slotscheck](https://github.com/ariebovenberg/slotscheck), a tool I maintain. Of course, If you like, I can add it to CI as I've done for [instagram/LibCST](https://github.com/Instagram/LibCST/pull/615), [sqlalchemy/sqlalchemy](https://github.com/sqlalchemy/sqlalchemy/pull/7670), and [aio-libs/aiohttp](https://github.com/aio-libs/aiohttp/pull/6547).
