### PR TITLE
Rename MetadataEndpoint._grant_types -> _grant_types_supported

### DIFF
--- a/oauthlib/oauth2/rfc6749/endpoints/metadata.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/metadata.py
@@ -91,7 +91,7 @@ class MetadataEndpoint(BaseEndpoint):
         parameter passed to the token endpoint defined in the grant type
         definition.
         """
-        self._grant_types.extend(endpoint._grant_types.keys())
+        self._grant_types_supported.extend(endpoint._grant_types.keys())
         claims.setdefault("token_endpoint_auth_methods_supported", ["client_secret_post", "client_secret_basic"])
 
         self.validate_metadata(claims, "token_endpoint_auth_methods_supported", is_list=True)
@@ -107,7 +107,7 @@ class MetadataEndpoint(BaseEndpoint):
         # using the "token" endpoint, as such, we have to add it explicitly to
         # the list of "grant_types_supported" when enabled.
         if "token" in claims["response_types_supported"]:
-            self._grant_types.append("implicit")
+            self._grant_types_supported.append("implicit")
 
         self.validate_metadata(claims, "response_types_supported", is_required=True, is_list=True)
         self.validate_metadata(claims, "response_modes_supported", is_list=True)
@@ -220,7 +220,7 @@ class MetadataEndpoint(BaseEndpoint):
         self.validate_metadata(claims, "op_policy_uri", is_url=True)
         self.validate_metadata(claims, "op_tos_uri", is_url=True)
 
-        self._grant_types = []
+        self._grant_types_supported = []
         for endpoint in self.endpoints:
             if isinstance(endpoint, TokenEndpoint):
                 self.validate_metadata_token(claims, endpoint)
@@ -233,6 +233,6 @@ class MetadataEndpoint(BaseEndpoint):
 
         # "grant_types_supported" is a combination of all OAuth2 grant types
         # allowed in the current provider implementation.
-        claims.setdefault("grant_types_supported", self._grant_types)
+        claims.setdefault("grant_types_supported", self._grant_types_supported)
         self.validate_metadata(claims, "grant_types_supported", is_list=True)
         return claims


### PR DESCRIPTION
Hello,

this PR renames the `_grant_types` attribute of the `MetadataEndpoint` to `_grant_types_supported`.
Initially introduced in https://github.com/oauthlib/oauthlib/pull/624/commits/6bd865b36dc64caaa8aab9788742c9d54ce81c4d, the `_grant_types` attribute (type `list`)  collides with the  `_grant_types ` attribute (type `dict`) of the `TokenEndpoint` when inheriting from both classes.

This caused a problem: If  I want to create an `Server`-like combined endpoint inheriting from both the `Server` and `MetadataEndpoint` classes and pass a reference to an instance of this class to the constructor of the `MetadataEndpoint`, initializing the `MetadataEndpoint` will fail due to it setting `self._grant_types` to a list but expecting each of the endpoint working on (which, in my case, includes the metadata endpoint itself) to be of type `dict`.

For example, the following code would fail:

```python
from oauthlib import oauth2


class ServerWithMetadata(oauth2.Server, oauth2.MetadataEndpoint):
    """
    An extension of L{oauth2.Server} featuring the L{oauth2.MetaDataEndpoint}.
    """
    def __init__(
        self,
        request_validator,
        token_expires_in=None,
        token_generator=None,
        refresh_token_generator=None,
        claims={},
        *args,
        **kwargs,
    ):
        oauth2.Server.__init__(
            self,
            request_validator,
            token_expires_in=token_expires_in,
            token_generator=token_generator,
            refresh_token_generator=refresh_token_generator,
            *args,
            **kwargs,
        )
        oauth2.MetadataEndpoint.__init__(
            self,
            [self],
            claims=claims,
            raise_errors=True,
        )
```

A possible solution is renaming one of the `_grant_types` attributes. This PR does this.