### PR TITLE
Tests for warning behavior on oauth scope change

### DIFF
--- a/oauthlib/oauth2/rfc6749/parameters.py
+++ b/oauthlib/oauth2/rfc6749/parameters.py
@@ -442,6 +442,13 @@ def parse_token_response(body, scope=None):
     return params
 
 
+class TokenScopeChangedWarning(Warning):
+    token: dict
+    old_scope: List[str]
+    new_scope: List[str]
+
+
+
 def validate_token_parameters(params):
     """Ensures token presence, token type, expiration and scope in params."""
     if 'error' in params:
@@ -464,7 +471,7 @@ def validate_token_parameters(params):
         )
         scope_changed.send(message=message, old=params.old_scopes, new=params.scopes)
         if not os.environ.get('OAUTHLIB_RELAX_TOKEN_SCOPE', None):
-            w = Warning(message)
+            w = TokenScopeChangedWarning(message)
             w.token = params
             w.old_scope = params.old_scopes
             w.new_scope = params.scopes

--- a/tests/oauth2/rfc6749/test_parameters.py
+++ b/tests/oauth2/rfc6749/test_parameters.py
@@ -302,3 +302,14 @@ class ParameterTests(TestCase):
         finally:
             signals.scope_changed.disconnect(record_scope_change)
         del os.environ['OAUTHLIB_RELAX_TOKEN_SCOPE']
+
+    def test_validate_token_parameters_special_warning(self):
+        """When OAUTHLIB_RELAX_TOKEN_SCOPE is unset, the warning raised has
+        special attributes, ``token``, ``old_scope``, and ``new_scope``."""
+        try:
+            parse_token_response(self.url_encoded_response, scope='aaa')
+        except Warning as w:
+            assert isinstance(w, TokenScopeChangedWarning)
+            assert all(hasattr(w, attr) for attr in ('token', 'old_scope', 'new_scope'))
+            assert w.old_scope == ['aaa']
+            assert w.new_scope == ['def', 'abc']


### PR DESCRIPTION
When Oauth scope changes, oauthlib raises a Warning with special attributes (
`token`, `old_scope`, and `new_scope`). This behavior was documented in the
original commit message from ca4811b3087f9d34754d3debf839e247593b8a39, but
there are no tests to check for this behavior. I started working on #809 and
while reading the code, I thought the extra attributes tacked onto the warning
were strange. I thought it was even more strange that this behavior wasn't
documented anywhere or tested for.

I decided not to add any documentation because there is no existing
documentation about scope changes already, and this is a very specific
situation, however I think that having the test case, and the
`TokenScopeChangedWarning` class makes it much clearer to anyone taking a
glance at the source code what the behavior is.

Plus, I didn't want to break anything while working on #809, and I became a
little suspicious when I deleted those lines (`w.token = params; w.old_scope = ...`),
and all the unit tests still passed!
