### PR TITLE
Show draft for changed scope

### DIFF
--- a/oauthlib/oauth2/rfc6749/parameters.py
+++ b/oauthlib/oauth2/rfc6749/parameters.py
@@ -6,6 +6,7 @@ This module contains methods related to `Section 4`_ of the OAuth 2 RFC.
 
 .. _`Section 4`: https://tools.ietf.org/html/rfc6749#section-4
 """
+import difflib
 import json
 import os
 import time
@@ -459,9 +460,16 @@ def validate_token_parameters(params):
     # parameter to inform the client of the actual scope granted.
     # https://tools.ietf.org/html/rfc6749#section-3.3
     if params.scope_changed:
-        message = 'Scope has changed from "{old}" to "{new}".'.format(
-            old=params.old_scope, new=params.scope,
-        )
+        message = 'Scope has changed. Difference:\n{diff}'.format(
+            old=params.old_scope,
+            new=params.scope,
+            diff="\n".join(
+                difflib.ndiff(
+                    sorted(params.old_scope.split(" ")),
+                    sorted(params.scope.split(" ")),
+                )
+            )
+         )
         scope_changed.send(message=message, old=params.old_scopes, new=params.scopes)
         if not os.environ.get('OAUTHLIB_RELAX_TOKEN_SCOPE', None):
             w = Warning(message)

--- a/tests/oauth2/rfc6749/clients/test_backend_application.py
+++ b/tests/oauth2/rfc6749/clients/test_backend_application.py
@@ -78,7 +78,7 @@ class BackendApplicationClientTest(TestCase):
             client.parse_request_body_response(self.token_json, scope="invalid")
             self.assertEqual(len(scope_changes_recorded), 1)
             message, old, new = scope_changes_recorded[0]
-            self.assertEqual(message, 'Scope has changed from "invalid" to "/profile".')
+            self.assertEqual(message, 'Scope has changed. Difference:\n- invalid\n+ /profile')
             self.assertEqual(old, ['invalid'])
             self.assertEqual(new, ['/profile'])
         finally:

--- a/tests/oauth2/rfc6749/clients/test_legacy_application.py
+++ b/tests/oauth2/rfc6749/clients/test_legacy_application.py
@@ -81,7 +81,7 @@ class LegacyApplicationClientTest(TestCase):
             client.parse_request_body_response(self.token_json, scope="invalid")
             self.assertEqual(len(scope_changes_recorded), 1)
             message, old, new = scope_changes_recorded[0]
-            self.assertEqual(message, 'Scope has changed from "invalid" to "/profile".')
+            self.assertEqual(message, 'Scope has changed. Difference:\n- invalid\n+ /profile')
             self.assertEqual(old, ['invalid'])
             self.assertEqual(new, ['/profile'])
         finally:

--- a/tests/oauth2/rfc6749/clients/test_mobile_application.py
+++ b/tests/oauth2/rfc6749/clients/test_mobile_application.py
@@ -103,7 +103,7 @@ class MobileApplicationClientTest(TestCase):
             client.parse_request_uri_response(self.response_uri, scope="invalid")
             self.assertEqual(len(scope_changes_recorded), 1)
             message, old, new = scope_changes_recorded[0]
-            self.assertEqual(message, 'Scope has changed from "invalid" to "/profile".')
+            self.assertEqual(message, 'Scope has changed. Difference:\n- invalid\n+ /profile')
             self.assertEqual(old, ['invalid'])
             self.assertEqual(new, ['/profile'])
         finally:

--- a/tests/oauth2/rfc6749/clients/test_web_application.py
+++ b/tests/oauth2/rfc6749/clients/test_web_application.py
@@ -179,7 +179,7 @@ class WebApplicationClientTest(TestCase):
             client.parse_request_body_response(self.token_json, scope="invalid")
             self.assertEqual(len(scope_changes_recorded), 1)
             message, old, new = scope_changes_recorded[0]
-            self.assertEqual(message, 'Scope has changed from "invalid" to "/profile".')
+            self.assertEqual(message, 'Scope has changed. Difference:\n- invalid\n+ /profile')
             self.assertEqual(old, ['invalid'])
             self.assertEqual(new, ['/profile'])
         finally:


### PR DESCRIPTION
This is a draft PR to show a clean diff instead of a "splat" of text when a scope
change occurs. According to (my understanding of) RFC 6749 Section A.4, the only
allowed delimiter for oauth scopes is a space character:

```
A.4.  "scope" Syntax

   The "scope" element is defined in Section 3.3:

     scope       = scope-token *( SP scope-token )
     scope-token = 1*NQCHAR
```

Therefore, this implementation should be good to go. I updated tests so that
they pass with the change. Looking forward to feedback.

Please note that there could be a possible merge conflict with pr#810, so please
review and merge that less-controversial PR first so that I can resolve those
changes into this draft.

Thanks!
