### PR TITLE
OAuth2Error: Allow falsy values as state

### DIFF
--- a/oauthlib/oauth2/rfc6749/errors.py
+++ b/oauthlib/oauth2/rfc6749/errors.py
@@ -60,7 +60,7 @@ class OAuth2Error(Exception):
             self.response_type = request.response_type
             self.response_mode = request.response_mode
             self.grant_type = request.grant_type
-            if not state:
+            if state is None:
                 self.state = request.state
         else:
             self.redirect_uri = None


### PR DESCRIPTION
The idea is to allow values like `0` to be used a state.
The current implementation only checks for truthiness.