### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/oauth1/security.rst
+++ b/docs/oauth1/security.rst
@@ -20,7 +20,7 @@ A few important facts regarding OAuth security
         for Python 3.6 and later. The ``secrets`` module is designed for
         generating cryptographically strong random numbers. For earlier versions
         of Python, use ``random.SystemRandom`` which is based on ``os.urandom``
-        rather than the default ``random`` based on the effecient but not truly
+        rather than the default ``random`` based on the efficient but not truly
         random Mersenne Twister. Predictable tokens allow attackers to bypass
         virtually all defences OAuth provides.
 

--- a/docs/oauth2/grants/custom_grant.rst
+++ b/docs/oauth2/grants/custom_grant.rst
@@ -37,7 +37,7 @@ existing ones.
 
 3. Associate it with Endpoints
 ------------------------------
-Then, once implemented, you have to instanciate the grant object and
+Then, once implemented, you have to instantiate the grant object and
 bind it to your endpoint. Either :py:class:`AuthorizationEndpoint`,
 :py:class:`TokenEndpoint` or both.
 
@@ -48,7 +48,7 @@ This example shows how to add a simple extension to the `Token endpoint`:
 * creation of a new class ``MyCustomGrant``, and implement ``create_token_response``.
 * do basics and custom request validations, then call a custom method
   of `Request Validator` to extend the interface for the implementor.
-* instanciate the new grant, and bind it with an existing ``Server``.
+* instantiate the new grant, and bind it with an existing ``Server``.
 
 .. code-block:: python
 

--- a/oauthlib/oauth2/rfc6749/clients/backend_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/backend_application.py
@@ -39,7 +39,7 @@ class BackendApplicationClient(Client):
         format per `Appendix B`_ in the HTTP request entity-body:
 
         :param body: Existing request body (URL encoded string) to embed parameters
-                     into. This may contain extra paramters. Default ''.
+                     into. This may contain extra parameters. Default ''.
         :param scope:   The scope of the access request as described by
                         `Section 3.3`_.
 

--- a/oauthlib/oauth2/rfc6749/clients/base.py
+++ b/oauthlib/oauth2/rfc6749/clients/base.py
@@ -274,7 +274,7 @@ class Client:
             request (if there was one).
         :param state:
         :param body: Existing request body (URL encoded string) to embed parameters
-                     into. This may contain extra paramters. Default ''.
+                     into. This may contain extra parameters. Default ''.
         :param kwargs: Additional parameters to included in the request.
         :returns: The prepared request tuple with (url, headers, body).
         """
@@ -303,7 +303,7 @@ class Client:
         :param token_url: Provider token refresh endpoint URL.
         :param refresh_token: Refresh token string.
         :param body: Existing request body (URL encoded string) to embed parameters
-            into. This may contain extra paramters. Default ''.
+            into. This may contain extra parameters. Default ''.
         :param scope: List of scopes to request. Must be equal to
             or a subset of the scopes granted when obtaining the refresh
             token. If none is provided, the ones provided in the constructor are

--- a/oauthlib/oauth2/rfc6749/clients/legacy_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/legacy_application.py
@@ -49,7 +49,7 @@ class LegacyApplicationClient(Client):
         :param username:    The resource owner username.
         :param password:    The resource owner password.
         :param body: Existing request body (URL encoded string) to embed parameters
-                     into. This may contain extra paramters. Default ''.
+                     into. This may contain extra parameters. Default ''.
         :param scope:   The scope of the access request as described by
                         `Section 3.3`_.
         :param include_client_id: `True` to send the `client_id` in the

--- a/oauthlib/oauth2/rfc6749/clients/service_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/service_application.py
@@ -99,7 +99,7 @@ class ServiceApplicationClient(Client):
         :param extra_claims: A dict of additional claims to include in the JWT.
 
         :param body: Existing request body (URL encoded string) to embed parameters
-                     into. This may contain extra paramters. Default ''.
+                     into. This may contain extra parameters. Default ''.
 
         :param scope: The scope of the access request.
 

--- a/oauthlib/oauth2/rfc6749/clients/web_application.py
+++ b/oauthlib/oauth2/rfc6749/clients/web_application.py
@@ -117,7 +117,7 @@ class WebApplicationClient(Client):
                                 values MUST be identical.
 
         :param body: Existing request body (URL encoded string) to embed parameters
-                     into. This may contain extra paramters. Default ''.
+                     into. This may contain extra parameters. Default ''.
 
         :param include_client_id: `True` (default) to send the `client_id` in the
                                   body of the upstream request. This is required

--- a/oauthlib/oauth2/rfc6749/endpoints/revocation.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/revocation.py
@@ -42,7 +42,7 @@ class RevocationEndpoint(BaseEndpoint):
 
 
         The authorization server responds with HTTP status code 200 if the
-        token has been revoked sucessfully or if the client submitted an
+        token has been revoked successfully or if the client submitted an
         invalid token.
 
         Note: invalid tokens do not cause an error response since the client

--- a/oauthlib/oauth2/rfc6749/parameters.py
+++ b/oauthlib/oauth2/rfc6749/parameters.py
@@ -45,7 +45,7 @@ def prepare_grant_uri(uri, client_id, response_type, redirect_uri=None,
                   back to the client.  The parameter SHOULD be used for
                   preventing cross-site request forgery as described in
                   `Section 10.12`_.
-    :param code_challenge: PKCE paramater. A challenge derived from the 
+    :param code_challenge: PKCE parameter. A challenge derived from the 
                            code_verifier that is sent in the authorization 
                            request, to be verified against later.
     :param code_challenge_method: PKCE parameter. A method that was used to derive the 

--- a/oauthlib/openid/connect/core/grant_types/dispatchers.py
+++ b/oauthlib/openid/connect/core/grant_types/dispatchers.py
@@ -84,7 +84,7 @@ class AuthorizationTokenGrantDispatcher(Dispatcher):
         code = parameters.get('code', None)
         redirect_uri = parameters.get('redirect_uri', None)
 
-        # If code is not pressent fallback to `default_grant` which will
+        # If code is not present fallback to `default_grant` which will
         # raise an error for the missing `code` in `create_token_response` step.
         if code:
             scopes = self.request_validator.get_authorization_code_scopes(client_id, code, redirect_uri, request)


### PR DESCRIPTION
There are small typos in:
- docs/oauth1/security.rst
- docs/oauth2/grants/custom_grant.rst
- oauthlib/oauth2/rfc6749/clients/backend_application.py
- oauthlib/oauth2/rfc6749/clients/base.py
- oauthlib/oauth2/rfc6749/clients/legacy_application.py
- oauthlib/oauth2/rfc6749/clients/service_application.py
- oauthlib/oauth2/rfc6749/clients/web_application.py
- oauthlib/oauth2/rfc6749/endpoints/revocation.py
- oauthlib/oauth2/rfc6749/parameters.py
- oauthlib/openid/connect/core/grant_types/dispatchers.py

Fixes:
- Should read `parameters` rather than `paramters`.
- Should read `instantiate` rather than `instanciate`.
- Should read `successfully` rather than `sucessfully`.
- Should read `present` rather than `pressent`.
- Should read `parameter` rather than `paramater`.
- Should read `efficient` rather than `effecient`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md