### PR TITLE
Update pre-configured OIDC server to use OIDC flavor of Refresh Token grant type

### DIFF
--- a/oauthlib/openid/connect/core/endpoints/pre_configured.py
+++ b/oauthlib/openid/connect/core/endpoints/pre_configured.py
@@ -12,11 +12,13 @@ from oauthlib.oauth2.rfc6749.endpoints import (
 from oauthlib.oauth2.rfc6749.grant_types import (
     AuthorizationCodeGrant as OAuth2AuthorizationCodeGrant,
     ClientCredentialsGrant, ImplicitGrant as OAuth2ImplicitGrant,
-    RefreshTokenGrant, ResourceOwnerPasswordCredentialsGrant,
+    ResourceOwnerPasswordCredentialsGrant,
 )
 from oauthlib.oauth2.rfc6749.tokens import BearerToken
 
-from ..grant_types import AuthorizationCodeGrant, HybridGrant, ImplicitGrant
+from ..grant_types import (
+    AuthorizationCodeGrant, HybridGrant, ImplicitGrant, RefreshTokenGrant
+)
 from ..grant_types.dispatchers import (
     AuthorizationCodeGrantDispatcher, AuthorizationTokenGrantDispatcher,
     ImplicitTokenGrantDispatcher,

--- a/tests/openid/connect/core/endpoints/test_refresh_token.py
+++ b/tests/openid/connect/core/endpoints/test_refresh_token.py
@@ -1,0 +1,32 @@
+"""Ensure that the server correctly uses the OIDC flavor of
+the Refresh token grant type when appropriate.
+
+When the OpenID scope is provided, the refresh token response
+should include a fresh ID token.
+"""
+import json
+from unittest import mock
+
+from oauthlib.openid import RequestValidator
+from oauthlib.openid.connect.core.endpoints.pre_configured import Server
+
+from tests.unittest import TestCase
+
+
+class TestRefreshToken(TestCase):
+
+    def setUp(self):
+        self.validator = mock.MagicMock(spec=RequestValidator)
+        self.validator.get_id_token.return_value='id_token'
+
+        self.server = Server(self.validator)
+
+    def test_refresh_token_with_openid(self):
+        body = 'scope=openid+test_scope&grant_type=refresh_token&refresh_token=abc'
+        h, b, s = self.server.create_token_response('', body=body)
+        self.assertIn('id_token', json.loads(b))
+
+    def test_refresh_token_no_openid(self):
+        body = 'scope=test_scope&grant_type=refresh_token&refresh_token=abc'
+        h, b, s = self.server.create_token_response('', body=body)
+        self.assertNotIn('id_token', json.loads(b))

--- a/tests/openid/connect/core/endpoints/test_refresh_token.py
+++ b/tests/openid/connect/core/endpoints/test_refresh_token.py
@@ -22,11 +22,11 @@ class TestRefreshToken(TestCase):
         self.server = Server(self.validator)
 
     def test_refresh_token_with_openid(self):
-        body = 'scope=openid+test_scope&grant_type=refresh_token&refresh_token=abc'
-        h, b, s = self.server.create_token_response('', body=body)
-        self.assertIn('id_token', json.loads(b))
+        request_body = 'scope=openid+test_scope&grant_type=refresh_token&refresh_token=abc'
+        headers, body, status = self.server.create_token_response('', body=request_body)
+        self.assertIn('id_token', json.loads(body))
 
     def test_refresh_token_no_openid(self):
-        body = 'scope=test_scope&grant_type=refresh_token&refresh_token=abc'
-        h, b, s = self.server.create_token_response('', body=body)
-        self.assertNotIn('id_token', json.loads(b))
+        request_body = 'scope=test_scope&grant_type=refresh_token&refresh_token=abc'
+        headers, body, status = self.server.create_token_response('', body=request_body)
+        self.assertNotIn('id_token', json.loads(body))


### PR DESCRIPTION

#752 Added an OIDC variant of the Refresh Token grant type. This pull request updates the pre-configured OIDC server to use this grant type, rather than the RFC6749 version. Practically, this means that OIDC refresh token responses now include ID tokens when the `openid` scope is provided.

See #827 for more context.