### PR TITLE
Update setup.cfg to use license_files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-license_file = LICENSE
+license_files = LICENSE
 
 [isort]
 combine_as_imports = true


### PR DESCRIPTION
Fixes the following warning:

> The license_file parameter is deprecated, use license_files instead.