### PR TITLE
Add classifier for Python 3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: Implementation',
         'Programming Language :: Python :: Implementation :: CPython',


### PR DESCRIPTION
Some tools or services like https://pyreadiness.org/ use classifiers to check for compatibility with a particular Python version. It would be nice to have classifiers for all Python versions tested with tox in `setup.py`.