### PR TITLE
Ensure that `request.client_id` is set during Refresh Token Grant.

### DIFF
--- a/oauthlib/oauth2/rfc6749/grant_types/refresh_token.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/refresh_token.py
@@ -101,6 +101,9 @@ class RefreshTokenGrant(GrantTypeBase):
             if not self.request_validator.authenticate_client(request):
                 log.debug('Invalid client (%r), denying access.', request)
                 raise errors.InvalidClientError(request=request)
+            # Ensure that request.client_id is set.
+            if request.client_id is None and request.client is not None:
+                request.client_id = request.client.client_id
         elif not self.request_validator.authenticate_client_id(request.client_id, request):
             log.debug('Client authentication failed, %r.', request)
             raise errors.InvalidClientError(request=request)

--- a/tests/oauth2/rfc6749/grant_types/test_refresh_token.py
+++ b/tests/oauth2/rfc6749/grant_types/test_refresh_token.py
@@ -130,6 +130,22 @@ class RefreshTokenGrantTest(TestCase):
                           self.request)
         self.mock_validator.client_authentication_required.assert_called_once_with(self.request)
 
+
+    def test_authentication_required_populate_client_id(self):
+        """
+        Make sure that request.client_id is populated from
+        request.client.client_id if None.
+
+        """
+        self.mock_validator.client_authentication_required.return_value = True
+        self.mock_validator.authenticate_client.return_value = True
+        # self.mock_validator.authenticate_client_id.return_value = False
+        # self.request.code = 'waffles'
+        self.request.client_id = None
+        self.request.client.client_id = 'foobar'
+        self.auth.validate_token_request(self.request)
+        self.request.client_id = 'foobar'
+
     def test_invalid_grant_type(self):
         self.request.grant_type = 'wrong_type'
         self.assertRaises(errors.UnsupportedGrantTypeError,


### PR DESCRIPTION
If a confidential client authenticates via Authorization header, `request.client_id` will be `null`.  This change ensures that `request.client_id` is always set.

Authorization Code Grant has similar behavior, see 335d9e8b427163bc64c18cb7ad54e609fcd84b23