### PR TITLE
CI: Only attempt upload for upstream

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   pypi-publish:
     if: |
+      github.repository_owner == 'oauthlib' &&
       ${{ github.event.workflow_run.conclusion == 'success' }} &&
       ${{ github.ref_type == 'tag' }}
     name: Upload release to PyPI


### PR DESCRIPTION
Add an extra conditional because there's no point attempting upload from forks because they'll fail as they don't have the credentials.

# Before

<img width="752" alt="image" src="https://github.com/oauthlib/oauthlib/assets/1324225/38fd493b-471a-49f2-8035-4e6fe0414cf4">

> Notice: Attempting to perform trusted publishing exchange to retrieve a temporary short-lived API token for authentication against https://upload.pypi.org/legacy/ due to __token__ username with no supplied password field

https://github.com/hugovk/oauthlib/actions/runs/5984901609

Also remove the double curly brackets, they prevent the `if` statement from being evaluated properly.

# After

<img width="692" alt="image" src="https://github.com/oauthlib/oauthlib/assets/1324225/2ba450dc-693f-4796-9f6d-3783d2fcaad7">

https://github.com/hugovk/oauthlib/actions/runs/5985055507
