### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -1,6 +1,6 @@
 name: Python Tests
 run-name: Run Tests by ${{ github.actor }}
-on: [push]
+on: [push, pull_request, workflow_dispatch]
 jobs:
   tests:
     env:

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -4,6 +4,7 @@ on: [push]
 jobs:
   tests:
     env:
+      FORCE_COLOR: 1
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -7,13 +7,14 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
       - name: Check out repository code
         uses: actions/checkout@v3
       - name: Install prereq

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -152,7 +152,7 @@ request that fails this test suite will be **rejected**.
 Testing multiple versions of Python
 -----------------------------------
 
-OAuthLib supports Python 3.5, 3.6, 3.7 and PyPy 2.7 & PyPy 3. Testing
+OAuthLib supports Python 3.6+ and PyPy3. Testing
 all versions conveniently can be done using `Tox`_.
 
 .. sourcecode:: bash

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: Implementation',
         'Programming Language :: Python :: Implementation :: CPython',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # require tox>=4
 [tox]
-envlist = py38,py39,py310,py311,pypy3,docs,readme,bandit,isort
+envlist = py38,py39,py310,py311,py312,pypy3,docs,readme,bandit,isort
 
 [testenv]
 deps=


### PR DESCRIPTION
The [Python 3.12 release candidate is out!](https://discuss.python.org/t/python-3-12-0-release-candidate-1-released/31137?u=hugovk) :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.