### PR TITLE
Make UtilsTests.test_filter_params Python 3.13+ compatible

### DIFF
--- a/tests/oauth1/rfc5849/test_utils.py
+++ b/tests/oauth1/rfc5849/test_utils.py
@@ -53,11 +53,11 @@ class UtilsTests(TestCase):
         # The following is an isolated test function used to test the filter_params decorator.
         @filter_params
         def special_test_function(params, realm=None):
-            """ I am a special test function """
+            """I am a special test function"""
             return 'OAuth ' + ','.join(['='.join([k, v]) for k, v in params])
 
         # check that the docstring got through
-        self.assertEqual(special_test_function.__doc__, " I am a special test function ")
+        self.assertEqual(special_test_function.__doc__, "I am a special test function")
 
         # Check that the decorator filtering works as per design.
         #   Any param that does not start with 'oauth'


### PR DESCRIPTION
Since Python 3.13.0a1, docstrings are automatically dedented. See https://github.com/python/cpython/issues/81283 and https://docs.python.org/3.13/whatsnew/3.13.html#other-language-changes

As a result, using a docstring with leading space as a test case breaks the test assumption.

The initial commit which introduced this test a decade ago (6c0c7914f3a57823834b1be492b307992f943629)
does not specify why testing the spaces is important.