### PR TITLE
initial idea for clarifying names of token -> token_dict and token_str

### DIFF
--- a/docs/oauth2/grants/custom_grant.rst
+++ b/docs/oauth2/grants/custom_grant.rst
@@ -63,8 +63,8 @@ This example shows how to add a simple extension to the `Token endpoint`:
             # ..
             self.request_validator.your_custom_check(request)
 
-            token = token_handler.create_token(request)
-            return self._get_default_headers(), json.dumps(token), 200
+            token_dict = token_handler.create_token(request)
+            return self._get_default_headers(), json.dumps(token_dict), 200
 
     def setup_oauthlib():
         my_custom_grant = MyCustomGrant()

--- a/docs/oauth2/oidc/id_tokens.rst
+++ b/docs/oauth2/oidc/id_tokens.rst
@@ -39,7 +39,7 @@ You can switch to jwcrypto library if you want to return JWE instead.
 
         super().__init__(self, **kwargs)
 
-    def finalize_id_token(self, id_token, token, token_handler, request):
+    def finalize_id_token(self, id_token, token_dict, token_handler, request):
         import jwt
 
         id_token["iss"] = "https://my.cool.app.com"

--- a/docs/oauth2/tokens/bearer.rst
+++ b/docs/oauth2/tokens/bearer.rst
@@ -92,13 +92,13 @@ See the example below:
             self.issuer = issuer
 
         def generate_access_token(self, request):
-            token = jwt.encode({
+            token_str = jwt.encode({
                 "ref": str(libuuid.uuid4()),
                 "aud": request.client_id,
                 "iss": self.issuer,
                 "exp": now + datetime.timedelta(seconds=request.expires_in)
             }, self.secret, algorithm='HS256').decode()
-            return token
+            return token_str
 
 
 Then associate it to your `Server`:

--- a/examples/skeleton_oauth2_web_application_server.py
+++ b/examples/skeleton_oauth2_web_application_server.py
@@ -81,7 +81,7 @@ class SkeletonValidator(RequestValidator):
         # In this case, it must be "authorization_code" or "refresh_token"
         pass
 
-    def save_bearer_token(self, token, request, *args, **kwargs):
+    def save_bearer_token(self, token_dict, request, *args, **kwargs):
         # Remember to associate it with request.scopes, request.user and
         # request.client. The two former will be set when you validate
         # the authorization code. Don't forget to save both the
@@ -96,13 +96,13 @@ class SkeletonValidator(RequestValidator):
 
     # Protected resource request
 
-    def validate_bearer_token(self, token, scopes, request):
+    def validate_bearer_token(self, token_str, scopes, request):
         # Remember to check expiration and scope membership
         pass
 
     # Token refresh request
 
-    def get_original_scopes(self, refresh_token, request, *args, **kwargs):
+    def get_original_scopes(self, refresh_token_str, request, *args, **kwargs):
         # Obtain the token associated with the given refresh_token and
         # return its scopes, these will be passed on to the refreshed
         # access token if the client did not specify a scope during the

--- a/oauthlib/oauth1/rfc5849/endpoints/access_token.py
+++ b/oauthlib/oauth1/rfc5849/endpoints/access_token.py
@@ -29,7 +29,7 @@ class AccessTokenEndpoint(BaseEndpoint):
     validator methods to implement for this endpoint.
     """
 
-    def create_access_token(self, request, credentials):
+    def create_access_token(self, request, credentials) -> str:
         """Create and save a new access token.
 
         Similar to OAuth 2, indication of granted scopes will be included as a
@@ -41,15 +41,15 @@ class AccessTokenEndpoint(BaseEndpoint):
         """
         request.realms = self.request_validator.get_realms(
             request.resource_owner_key, request)
-        token = {
+        token_data = {
             'oauth_token': self.token_generator(),
             'oauth_token_secret': self.token_generator(),
             # Backport the authorized scopes indication used in OAuth2
             'oauth_authorized_realms': ' '.join(request.realms)
         }
-        token.update(credentials)
-        self.request_validator.save_access_token(token, request)
-        return urlencode(token.items())
+        token_data.update(credentials)
+        self.request_validator.save_access_token(token_data, request)
+        return urlencode(token_data.items())
 
     def create_access_token_response(self, uri, http_method='GET', body=None,
                                      headers=None, credentials=None):
@@ -105,12 +105,12 @@ class AccessTokenEndpoint(BaseEndpoint):
             valid, processed_request = self.validate_access_token_request(
                 request)
             if valid:
-                token = self.create_access_token(request, credentials or {})
+                token_str = self.create_access_token(request, credentials or {})
                 self.request_validator.invalidate_request_token(
                     request.client_key,
                     request.resource_owner_key,
                     request)
-                return resp_headers, token, 200
+                return resp_headers, token_str, 200
             else:
                 return {}, None, 401
         except errors.OAuth1Error as e:

--- a/oauthlib/oauth1/rfc5849/endpoints/request_token.py
+++ b/oauthlib/oauth1/rfc5849/endpoints/request_token.py
@@ -29,7 +29,7 @@ class RequestTokenEndpoint(BaseEndpoint):
     validator methods to implement for this endpoint.
     """
 
-    def create_request_token(self, request, credentials):
+    def create_request_token(self, request, credentials) -> str:
         """Create and save a new request token.
 
         :param request: OAuthlib request.
@@ -37,14 +37,14 @@ class RequestTokenEndpoint(BaseEndpoint):
         :param credentials: A dict of extra token credentials.
         :returns: The token as an urlencoded string.
         """
-        token = {
+        token_data = {
             'oauth_token': self.token_generator(),
             'oauth_token_secret': self.token_generator(),
             'oauth_callback_confirmed': 'true'
         }
-        token.update(credentials)
-        self.request_validator.save_request_token(token, request)
-        return urlencode(token.items())
+        token_data.update(credentials)
+        self.request_validator.save_request_token(token_data, request)
+        return urlencode(token_data.items())
 
     def create_request_token_response(self, uri, http_method='GET', body=None,
                                       headers=None, credentials=None):
@@ -100,8 +100,8 @@ class RequestTokenEndpoint(BaseEndpoint):
             valid, processed_request = self.validate_request_token_request(
                 request)
             if valid:
-                token = self.create_request_token(request, credentials or {})
-                return resp_headers, token, 200
+                token_str = self.create_request_token(request, credentials or {})
+                return resp_headers, token_str, 200
             else:
                 return {}, None, 401
         except errors.OAuth1Error as e:

--- a/oauthlib/oauth1/rfc5849/request_validator.py
+++ b/oauthlib/oauth1/rfc5849/request_validator.py
@@ -158,23 +158,23 @@ class RequestValidator:
         return (set(client_key) <= self.safe_characters and
                 lower <= len(client_key) <= upper)
 
-    def check_request_token(self, request_token):
+    def check_request_token(self, token_str:str):
         """Checks that the request token contains only safe characters
         and is no shorter than lower and no longer than upper.
         """
         lower, upper = self.request_token_length
-        return (set(request_token) <= self.safe_characters and
-                lower <= len(request_token) <= upper)
+        return (set(token_str) <= self.safe_characters and
+                lower <= len(token_str) <= upper)
 
-    def check_access_token(self, request_token):
+    def check_access_token(self, token_str:str):
         """Checks that the token contains only safe characters
         and is no shorter than lower and no longer than upper.
         """
         lower, upper = self.access_token_length
-        return (set(request_token) <= self.safe_characters and
-                lower <= len(request_token) <= upper)
+        return (set(token_str) <= self.safe_characters and
+                lower <= len(token_str) <= upper)
 
-    def check_nonce(self, nonce):
+    def check_nonce(self, nonce:str):
         """Checks that the nonce only contains only safe characters
         and is no shorter than lower and no longer than upper.
         """
@@ -182,13 +182,13 @@ class RequestValidator:
         return (set(nonce) <= self.safe_characters and
                 lower <= len(nonce) <= upper)
 
-    def check_verifier(self, verifier):
+    def check_verifier(self, verifier_str:str):
         """Checks that the verifier contains only safe characters
         and is no shorter than lower and no longer than upper.
         """
         lower, upper = self.verifier_length
-        return (set(verifier) <= self.safe_characters and
-                lower <= len(verifier) <= upper)
+        return (set(verifier_str) <= self.safe_characters and
+                lower <= len(verifier_str) <= upper)
 
     def check_realms(self, realms):
         """Check that the realm is one of a set allowed realms."""
@@ -294,11 +294,11 @@ class RequestValidator:
         """
         raise self._subclass_must_implement('get_client_secret')
 
-    def get_request_token_secret(self, client_key, token, request):
+    def get_request_token_secret(self, client_key, token_str, request):
         """Retrieves the shared secret associated with the request token.
 
         :param client_key: The client/consumer key.
-        :param token: The request token string.
+        :param token_str: The request token string.
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
         :returns: The token secret as a string.
@@ -327,11 +327,11 @@ class RequestValidator:
         """
         raise self._subclass_must_implement('get_request_token_secret')
 
-    def get_access_token_secret(self, client_key, token, request):
+    def get_access_token_secret(self, client_key, token_str, request):
         """Retrieves the shared secret associated with the access token.
 
         :param client_key: The client/consumer key.
-        :param token: The access token string.
+        :param token_str: The access token string.
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
         :returns: The token secret as a string.
@@ -377,10 +377,10 @@ class RequestValidator:
         """
         raise self._subclass_must_implement("get_default_realms")
 
-    def get_realms(self, token, request):
+    def get_realms(self, token_str, request):
         """Get realms associated with a request token.
 
-        :param token: The request token string.
+        :param token_str: The request token string.
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
         :returns: The list of realms associated with the request token.
@@ -392,10 +392,10 @@ class RequestValidator:
         """
         raise self._subclass_must_implement("get_realms")
 
-    def get_redirect_uri(self, token, request):
+    def get_redirect_uri(self, token_str, request):
         """Get the redirect URI associated with a request token.
 
-        :param token: The request token string.
+        :param token_str: The request token string.
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
         :returns: The redirect URI associated with the request token.
@@ -434,11 +434,11 @@ class RequestValidator:
         """
         raise self._subclass_must_implement("get_rsa_key")
 
-    def invalidate_request_token(self, client_key, request_token, request):
+    def invalidate_request_token(self, client_key, token_str, request):
         """Invalidates a used request token.
 
         :param client_key: The client/consumer key.
-        :param request_token: The request token string.
+        :param token_str: The request token string.
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
         :returns: None
@@ -498,11 +498,11 @@ class RequestValidator:
         """
         raise self._subclass_must_implement("validate_client_key")
 
-    def validate_request_token(self, client_key, token, request):
+    def validate_request_token(self, client_key, token_str, request):
         """Validates that supplied request token is registered and valid.
 
         :param client_key: The client/consumer key.
-        :param token: The request token string.
+        :param token_str: The request token string.
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
         :returns: True or False
@@ -533,11 +533,11 @@ class RequestValidator:
         """
         raise self._subclass_must_implement("validate_request_token")
 
-    def validate_access_token(self, client_key, token, request):
+    def validate_access_token(self, client_key, token_str, request):
         """Validates that supplied access token is registered and valid.
 
         :param client_key: The client/consumer key.
-        :param token: The access token string.
+        :param token_str: The access token string.
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
         :returns: True or False
@@ -569,14 +569,15 @@ class RequestValidator:
         raise self._subclass_must_implement("validate_access_token")
 
     def validate_timestamp_and_nonce(self, client_key, timestamp, nonce,
-                                     request, request_token=None, access_token=None):
+                                     request, request_token_str=None,
+                                     access_token_str=None):
         """Validates that the nonce has not been used before.
 
         :param client_key: The client/consumer key.
         :param timestamp: The ``oauth_timestamp`` parameter.
         :param nonce: The ``oauth_nonce`` parameter.
-        :param request_token: Request token string, if any.
-        :param access_token: Access token string, if any.
+        :param request_token_str: Request token string, if any.
+        :param access_token_str: Access token string, if any.
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
         :returns: True or False
@@ -605,9 +606,9 @@ class RequestValidator:
            ]
 
            def validate_timestamp_and_nonce(self, client_key, timestamp, nonce,
-              request_token=None, access_token=None):
+              request_token_str=None, access_token_str=None):
 
-              return ((client_key, timestamp, nonce, request_token or access_token)
+              return ((client_key, timestamp, nonce, request_token_str or access_token_str)
                        not in self.nonces_and_timestamps_database)
 
         This method is used by
@@ -672,12 +673,12 @@ class RequestValidator:
         """
         raise self._subclass_must_implement("validate_requested_realms")
 
-    def validate_realms(self, client_key, token, request, uri=None,
+    def validate_realms(self, client_key, token_str, request, uri=None,
                         realms=None):
         """Validates access to the request realm.
 
         :param client_key: The client/consumer key.
-        :param token: A request token string.
+        :param token_str: A request token string.
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
         :param uri: The URI the realms is protecting.
@@ -695,7 +696,7 @@ class RequestValidator:
         Can be as simple as::
 
             from your_datastore import RequestToken
-            request_token = RequestToken.get(token, None)
+            request_token = RequestToken.get(token_str, None)
 
             if not request_token:
                 return False
@@ -707,11 +708,11 @@ class RequestValidator:
         """
         raise self._subclass_must_implement("validate_realms")
 
-    def validate_verifier(self, client_key, token, verifier, request):
+    def validate_verifier(self, client_key, token_str, verifier, request):
         """Validates a verification code.
 
         :param client_key: The client/consumer key.
-        :param token: A request token string.
+        :param token_str: A request token string.
         :param verifier: The authorization verifier string.
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
@@ -739,10 +740,10 @@ class RequestValidator:
         """
         raise self._subclass_must_implement("validate_verifier")
 
-    def verify_request_token(self, token, request):
+    def verify_request_token(self, token_str, request):
         """Verify that the given OAuth1 request token is valid.
 
-        :param token: A request token string.
+        :param token_str: A request token string.
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
         :returns: True or False
@@ -758,10 +759,10 @@ class RequestValidator:
         """
         raise self._subclass_must_implement("verify_request_token")
 
-    def verify_realms(self, token, realms, request):
+    def verify_realms(self, token_str, realms, request):
         """Verify authorized realms to see if they match those given to token.
 
-        :param token: An access token string.
+        :param token_str: An access token string.
         :param realms: A list of realms the client attempts to access.
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
@@ -782,10 +783,10 @@ class RequestValidator:
         """
         raise self._subclass_must_implement("verify_realms")
 
-    def save_access_token(self, token, request):
+    def save_access_token(self, token_dict, request):
         """Save an OAuth1 access token.
 
-        :param token: A dict with token credentials.
+        :param token_dict: A dict with token credentials.
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
 
@@ -806,10 +807,10 @@ class RequestValidator:
         """
         raise self._subclass_must_implement("save_access_token")
 
-    def save_request_token(self, token, request):
+    def save_request_token(self, token_dict, request):
         """Save an OAuth1 request token.
 
-        :param token: A dict with token credentials.
+        :param token_dict: A dict with token credentials.
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
 
@@ -827,10 +828,10 @@ class RequestValidator:
         """
         raise self._subclass_must_implement("save_request_token")
 
-    def save_verifier(self, token, verifier, request):
+    def save_verifier(self, token_str, verifier, request):
         """Associate an authorization verifier with a request token.
 
-        :param token: A request token string.
+        :param token_str: A request token string.
         :param verifier: A dictionary containing the oauth_verifier and
                         oauth_token
         :param request: OAuthlib request.

--- a/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
@@ -304,16 +304,16 @@ class AuthorizationCodeGrant(GrantTypeBase):
             headers.update(e.headers)
             return headers, e.json, e.status_code
 
-        token = token_handler.create_token(request, refresh_token=self.refresh_token)
+        token_dict = token_handler.create_token(request, refresh_token=self.refresh_token)
 
         for modifier in self._token_modifiers:
-            token = modifier(token, token_handler, request)
+            token_dict = modifier(token_dict, token_handler, request)
 
-        self.request_validator.save_token(token, request)
+        self.request_validator.save_token(token_dict, request)
         self.request_validator.invalidate_authorization_code(
             request.client_id, request.code, request)
         headers.update(self._create_cors_headers(request))
-        return headers, json.dumps(token), 200
+        return headers, json.dumps(token_dict), 200
 
     def validate_authorization_request(self, request):
         """Check the authorization request for normal and fatal errors.

--- a/oauthlib/oauth2/rfc6749/grant_types/base.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/base.py
@@ -134,9 +134,9 @@ class GrantTypeBase:
         """
         raise NotImplementedError('Subclasses must implement this method.')
 
-    def add_token(self, token, token_handler, request):
+    def add_token(self, token_dict, token_handler, request):
         """
-        :param token:
+        :param token_dict: A token Dict
         :param token_handler: A token handler instance, for example of type
                               oauthlib.oauth2.BearerToken.
         :param request: OAuthlib request.
@@ -144,10 +144,10 @@ class GrantTypeBase:
         """
         # Only add a hybrid access token on auth step if asked for
         if request.response_type not in ["token", "code token", "id_token token", "code id_token token"]:
-            return token
+            return token_dict
 
-        token.update(token_handler.create_token(request, refresh_token=False))
-        return token
+        token_dict.update(token_handler.create_token(request, refresh_token=False))
+        return token_dict
 
     def validate_grant_type(self, request):
         """
@@ -175,7 +175,7 @@ class GrantTypeBase:
                                                       request.scopes, request.client, request):
             raise errors.InvalidScopeError(request=request)
 
-    def prepare_authorization_response(self, request, token, headers, body, status):
+    def prepare_authorization_response(self, request, token_dict, headers, body, status):
         """Place token according to response mode.
 
         Base classes can define a default response mode for their authorization
@@ -183,7 +183,7 @@ class GrantTypeBase:
 
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
-        :param token:
+        :param token_dict:
         :param headers:
         :param body:
         :param status:
@@ -195,10 +195,10 @@ class GrantTypeBase:
                       request.response_mode, self.default_response_mode)
             request.response_mode = self.default_response_mode
 
-        token_items = token.items()
+        token_items = token_dict.items()
 
         if request.response_type == 'none':
-            state = token.get('state', None)
+            state = token_dict.get('state', None)
             token_items = [('state', state)] if state else []
 
         if request.response_mode == 'query':

--- a/oauthlib/oauth2/rfc6749/grant_types/client_credentials.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/client_credentials.py
@@ -72,16 +72,16 @@ class ClientCredentialsGrant(GrantTypeBase):
             headers.update(e.headers)
             return headers, e.json, e.status_code
 
-        token = token_handler.create_token(request, refresh_token=False)
+        token_dict = token_handler.create_token(request, refresh_token=False)
 
         for modifier in self._token_modifiers:
-            token = modifier(token)
+            token_dict = modifier(token_dict)
 
-        self.request_validator.save_token(token, request)
+        self.request_validator.save_token(token_dict, request)
 
         log.debug('Issuing token to client id %r (%r), %r.',
-                  request.client_id, request.client, token)
-        return headers, json.dumps(token), 200
+                  request.client_id, request.client, token_dict)
+        return headers, json.dumps(token_dict), 200
 
     def validate_token_request(self, request):
         """

--- a/oauthlib/oauth2/rfc6749/grant_types/implicit.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/implicit.py
@@ -233,21 +233,21 @@ class ImplicitGrant(GrantTypeBase):
         # In OIDC implicit flow it is possible to have a request_type that does not include the access_token!
         # "id_token token" - return the access token and the id token
         # "id_token" - don't return the access token
-        token = token_handler.create_token(request, refresh_token=False) if 'token' in request.response_type.split() else {}
+        token_dict = token_handler.create_token(request, refresh_token=False) if 'token' in request.response_type.split() else {}
 
         if request.state is not None:
-            token['state'] = request.state
+            token_dict['state'] = request.state
 
         for modifier in self._token_modifiers:
-            token = modifier(token, token_handler, request)
+            token_dict = modifier(token_dict, token_handler, request)
 
         # In OIDC implicit flow it is possible to have a request_type that does
         # not include the access_token! In this case there is no need to save a token.
         if "token" in request.response_type.split():
-            self.request_validator.save_token(token, request)
+            self.request_validator.save_token(token_dict, request)
 
         return self.prepare_authorization_response(
-            request, token, {}, None, 302)
+            request, token_dict, {}, None, 302)
 
     def validate_authorization_request(self, request):
         """

--- a/oauthlib/oauth2/rfc6749/grant_types/refresh_token.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/refresh_token.py
@@ -59,18 +59,18 @@ class RefreshTokenGrant(GrantTypeBase):
             headers.update(e.headers)
             return headers, e.json, e.status_code
 
-        token = token_handler.create_token(request,
+        token_dict = token_handler.create_token(request,
                                            refresh_token=self.issue_new_refresh_tokens)
 
         for modifier in self._token_modifiers:
-            token = modifier(token, token_handler, request)
+            token_dict = modifier(token_dict, token_handler, request)
 
-        self.request_validator.save_token(token, request)
+        self.request_validator.save_token(token_dict, request)
 
         log.debug('Issuing new token to client id %r (%r), %r.',
-                  request.client_id, request.client, token)
+                  request.client_id, request.client, token_dict)
         headers.update(self._create_cors_headers(request))
-        return headers, json.dumps(token), 200
+        return headers, json.dumps(token_dict), 200
 
     def validate_token_request(self, request):
         """

--- a/oauthlib/oauth2/rfc6749/grant_types/resource_owner_password_credentials.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/resource_owner_password_credentials.py
@@ -100,16 +100,16 @@ class ResourceOwnerPasswordCredentialsGrant(GrantTypeBase):
             headers.update(e.headers)
             return headers, e.json, e.status_code
 
-        token = token_handler.create_token(request, self.refresh_token)
+        token_dict = token_handler.create_token(request, self.refresh_token)
 
         for modifier in self._token_modifiers:
-            token = modifier(token)
+            token_dict = modifier(token_dict)
 
-        self.request_validator.save_token(token, request)
+        self.request_validator.save_token(token_dict, request)
 
         log.debug('Issuing token %r to client id %r (%r) and username %s.',
-                  token, request.client_id, request.client, request.username)
-        return headers, json.dumps(token), 200
+                  token_dict, request.client_id, request.client, request.username)
+        return headers, json.dumps(token_dict), 200
 
     def validate_token_request(self, request):
         """

--- a/oauthlib/oauth2/rfc6749/parameters.py
+++ b/oauthlib/oauth2/rfc6749/parameters.py
@@ -9,6 +9,8 @@ This module contains methods related to `Section 4`_ of the OAuth 2 RFC.
 import json
 import os
 import time
+from typing import Dict
+from typing import Optional
 import urllib.parse as urlparse
 
 from oauthlib.common import add_params_to_qs, add_params_to_uri
@@ -23,7 +25,8 @@ from .utils import is_secure_transport, list_to_scope, scope_to_list
 
 
 def prepare_grant_uri(uri, client_id, response_type, redirect_uri=None,
-                      scope=None, state=None, code_challenge=None, code_challenge_method='plain', **kwargs):
+                      scope=None, state=None, code_challenge=None,
+                      code_challenge_method='plain', **kwargs):
     """Prepare the authorization grant request URI.
 
     The client constructs the request URI by adding the following
@@ -171,15 +174,15 @@ def prepare_token_request(grant_type, body='', include_client_id=True, code_veri
     return add_params_to_qs(body, params)
 
 
-def prepare_token_revocation_request(url, token, token_type_hint="access_token",
-        callback=None, body='', **kwargs):
+def prepare_token_revocation_request(url, token_str,
+    token_type_hint="access_token", callback=None, body='', **kwargs):
     """Prepare a token revocation request.
 
     The client constructs the request by including the following parameters
     using the ``application/x-www-form-urlencoded`` format in the HTTP request
     entity-body:
 
-    :param token: REQUIRED.  The token that the client wants to get revoked.
+    :param token_str: REQUIRED.  The token that the client wants to get revoked.
 
     :param token_type_hint: OPTIONAL.  A hint about the type of the token
                             submitted for revocation. Clients MAY pass this
@@ -211,7 +214,7 @@ def prepare_token_revocation_request(url, token, token_type_hint="access_token",
     if not is_secure_transport(url):
         raise InsecureTransportError()
 
-    params = [('token', token)]
+    params = [('token', token_str)]
 
     if token_type_hint:
         params.append(('token_type_hint', token_type_hint))
@@ -354,7 +357,7 @@ def parse_implicit_response(uri, state=None, scope=None):
     return params
 
 
-def parse_token_response(body, scope=None):
+def parse_token_response(body:str, scope:Optional[str]=None) -> Dict:
     """Parse the JSON token response body into a dict.
 
     The authorization server issues an access token and optional refresh

--- a/oauthlib/oauth2/rfc6749/request_validator.py
+++ b/oauthlib/oauth2/rfc6749/request_validator.py
@@ -148,10 +148,10 @@ class RequestValidator:
         """
         raise NotImplementedError('Subclasses must implement this method.')
 
-    def get_original_scopes(self, refresh_token, request, *args, **kwargs):
+    def get_original_scopes(self, refresh_token_str, request, *args, **kwargs):
         """Get the list of scopes associated with the refresh token.
 
-        :param refresh_token: Unicode refresh token.
+        :param refresh_token_str: Unicode refresh token.
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
         :rtype: List of scopes.
@@ -161,7 +161,7 @@ class RequestValidator:
         """
         raise NotImplementedError('Subclasses must implement this method.')
 
-    def is_within_original_scope(self, request_scopes, refresh_token, request, *args, **kwargs):
+    def is_within_original_scope(self, request_scopes, refresh_token_str, request, *args, **kwargs):
         """Check if requested scopes are within a scope of the refresh token.
 
         When access tokens are refreshed the scope of the new token
@@ -173,7 +173,7 @@ class RequestValidator:
         get_original_scopes is not practical.
 
         :param request_scopes: A list of scopes that were requested by client.
-        :param refresh_token: Unicode refresh_token.
+        :param refresh_token_str: Unicode refresh_token.
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
         :rtype: True or False
@@ -183,7 +183,7 @@ class RequestValidator:
         """
         return False
 
-    def introspect_token(self, token, token_type_hint, request, *args, **kwargs):
+    def introspect_token(self, token_str, token_type_hint, request, *args, **kwargs):
         """Introspect an access or refresh token.
 
         Called once the introspect request is validated. This method should
@@ -212,7 +212,7 @@ class RequestValidator:
 
         The dict of claims is added to request.token after this method.
 
-        :param token: The token string.
+        :param token_str: The token string.
         :param token_type_hint: access_token or refresh_token.
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
@@ -238,10 +238,10 @@ class RequestValidator:
         """
         raise NotImplementedError('Subclasses must implement this method.')
 
-    def revoke_token(self, token, token_type_hint, request, *args, **kwargs):
+    def revoke_token(self, token_str, token_type_hint, request, *args, **kwargs):
         """Revoke an access or refresh token.
 
-        :param token: The token string.
+        :param token_str: The token string.
         :param token_type_hint: access_token or refresh_token.
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
@@ -303,18 +303,18 @@ class RequestValidator:
         """
         raise NotImplementedError('Subclasses must implement this method.')
 
-    def save_token(self, token, request, *args, **kwargs):
+    def save_token(self, token_dict, request, *args, **kwargs):
         """Persist the token with a token type specific method.
 
         Currently, only save_bearer_token is supported.
 
-        :param token: A (Bearer) token dict.
+        :param token_dict: A (Bearer) token dict.
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
         """
-        return self.save_bearer_token(token, request, *args, **kwargs)
+        return self.save_bearer_token(token_dict, request, *args, **kwargs)
 
-    def save_bearer_token(self, token, request, *args, **kwargs):
+    def save_bearer_token(self, token_dict, request, *args, **kwargs):
         """Persist the Bearer token.
 
         The Bearer token should at minimum be associated with:
@@ -351,7 +351,7 @@ class RequestValidator:
         the claims dict, which should be saved for later use when generating the
         id_token and/or UserInfo response content.
 
-        :param token: A Bearer token dict.
+        :param token_dict: A Bearer token dict.
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
         :rtype: The default redirect URI for the client
@@ -364,10 +364,10 @@ class RequestValidator:
         """
         raise NotImplementedError('Subclasses must implement this method.')
 
-    def validate_bearer_token(self, token, scopes, request):
+    def validate_bearer_token(self, token_str, scopes, request):
         """Ensure the Bearer token is valid and authorized access to scopes.
 
-        :param token: A string of random characters.
+        :param token_str: A string of random characters.
         :param scopes: A list of scopes associated with the protected resource.
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
@@ -402,7 +402,7 @@ class RequestValidator:
         one provided for django these attributes will be made available
         in all protected views as keyword arguments.
 
-        :param token: Unicode Bearer token
+        :param token_str: Unicode Bearer token
         :param scopes: List of scopes (defined by you)
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
@@ -505,13 +505,13 @@ class RequestValidator:
         """
         raise NotImplementedError('Subclasses must implement this method.')
 
-    def validate_refresh_token(self, refresh_token, client, request, *args, **kwargs):
+    def validate_refresh_token(self, refresh_token_str, client, request, *args, **kwargs):
         """Ensure the Bearer token is valid and authorized access to scopes.
 
         OBS! The request.user attribute should be set to the resource owner
         associated with this refresh token.
 
-        :param refresh_token: Unicode refresh token.
+        :param refresh_token_str: Unicode refresh token.
         :param client: Client object set by you, see ``.authenticate_client``.
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request

--- a/oauthlib/oauth2/rfc6749/tokens.py
+++ b/oauthlib/oauth2/rfc6749/tokens.py
@@ -64,7 +64,7 @@ class OAuth2Token(dict):
         return list(self._new_scope - self._old_scope)
 
 
-def prepare_mac_header(token, uri, key, http_method,
+def prepare_mac_header(token_str, uri, key, http_method,
                        nonce=None,
                        headers=None,
                        body=None,
@@ -91,7 +91,7 @@ def prepare_mac_header(token, uri, key, http_method,
     .. _`MAC Access Authentication`: https://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-01
     .. _`extension algorithms`: https://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-01#section-7.1
 
-    :param token:
+    :param token_str: Token as string.
     :param uri: Request URI.
     :param key: MAC given provided by token endpoint.
     :param http_method: HTTP Request method.
@@ -155,7 +155,7 @@ def prepare_mac_header(token, uri, key, http_method,
     sign = b2a_base64(sign.digest())[:-1].decode('utf-8')
 
     header = []
-    header.append('MAC id="%s"' % token)
+    header.append('MAC id="%s"' % token_str)
     if draft != 0:
         header.append('ts="%s"' % ts)
     header.append('nonce="%s"' % nonce)
@@ -170,7 +170,7 @@ def prepare_mac_header(token, uri, key, http_method,
     return headers
 
 
-def prepare_bearer_uri(token, uri):
+def prepare_bearer_uri(token_str, uri):
     """Add a `Bearer Token`_ to the request URI.
     Not recommended, use only if client can't use authorization header or body.
 
@@ -178,13 +178,13 @@ def prepare_bearer_uri(token, uri):
 
     .. _`Bearer Token`: https://tools.ietf.org/html/rfc6750
 
-    :param token:
+    :param token_str:
     :param uri:
     """
-    return add_params_to_uri(uri, [(('access_token', token))])
+    return add_params_to_uri(uri, [(('access_token', token_str))])
 
 
-def prepare_bearer_headers(token, headers=None):
+def prepare_bearer_headers(token_str, headers=None):
     """Add a `Bearer Token`_ to the request URI.
     Recommended method of passing bearer tokens.
 
@@ -192,25 +192,25 @@ def prepare_bearer_headers(token, headers=None):
 
     .. _`Bearer Token`: https://tools.ietf.org/html/rfc6750
 
-    :param token:
+    :param token_str:
     :param headers:
     """
     headers = headers or {}
-    headers['Authorization'] = 'Bearer %s' % token
+    headers['Authorization'] = 'Bearer %s' % token_str
     return headers
 
 
-def prepare_bearer_body(token, body=''):
+def prepare_bearer_body(token_str, body=''):
     """Add a `Bearer Token`_ to the request body.
 
     access_token=h480djs93hd8
 
     .. _`Bearer Token`: https://tools.ietf.org/html/rfc6750
 
-    :param token:
+    :param token_str:
     :param body:
     """
-    return add_params_to_qs(body, [(('access_token', token))])
+    return add_params_to_qs(body, [(('access_token', token_str))])
 
 
 def random_token_generator(request, refresh_token=False):
@@ -241,16 +241,16 @@ def get_token_from_header(request):
     :type request: oauthlib.common.Request
     :return: Return the token or None if the Authorization header is malformed.
     """
-    token = None
+    token_str = None
 
     if 'Authorization' in request.headers:
         split_header = request.headers.get('Authorization').split()
         if len(split_header) == 2 and split_header[0].lower() == 'bearer':
-            token = split_header[1]
+            token_str = split_header[1]
     else:
-        token = request.access_token
+        token_str = request.access_token
 
-    return token
+    return token_str
 
 
 class TokenBase:
@@ -333,9 +333,9 @@ class BearerToken(TokenBase):
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
         """
-        token = get_token_from_header(request)
+        token_str = get_token_from_header(request)
         return self.request_validator.validate_bearer_token(
-            token, request.scopes, request)
+            token_str, request.scopes, request)
 
     def estimate_type(self, request):
         """

--- a/oauthlib/openid/connect/core/grant_types/authorization_code.py
+++ b/oauthlib/openid/connect/core/grant_types/authorization_code.py
@@ -22,7 +22,7 @@ class AuthorizationCodeGrant(GrantTypeBase):
             self.openid_authorization_validator)
         self.register_token_modifier(self.add_id_token)
 
-    def add_id_token(self, token, token_handler, request):
+    def add_id_token(self, token_dict, token_handler, request):
         """
         Construct an initial version of id_token, and let the
         request_validator sign or encrypt it.
@@ -32,7 +32,7 @@ class AuthorizationCodeGrant(GrantTypeBase):
         """
         # Treat it as normal OAuth 2 auth code request if openid is not present
         if not request.scopes or 'openid' not in request.scopes:
-            return token
+            return token_dict
 
         nonce = self.request_validator.get_authorization_code_nonce(
             request.client_id,
@@ -40,4 +40,4 @@ class AuthorizationCodeGrant(GrantTypeBase):
             request.redirect_uri,
             request
         )
-        return super().add_id_token(token, token_handler, request, nonce=nonce)
+        return super().add_id_token(token_dict, token_handler, request, nonce=nonce)

--- a/oauthlib/openid/connect/core/grant_types/hybrid.py
+++ b/oauthlib/openid/connect/core/grant_types/hybrid.py
@@ -35,8 +35,8 @@ class HybridGrant(GrantTypeBase):
         self.register_code_modifier(self.add_id_token)
         self.register_token_modifier(self.add_id_token)
 
-    def add_id_token(self, token, token_handler, request):
-        return super().add_id_token(token, token_handler, request, nonce=request.nonce)
+    def add_id_token(self, token_dict, token_handler, request):
+        return super().add_id_token(token_dict, token_handler, request, nonce=request.nonce)
 
     def openid_authorization_validator(self, request):
         """Additional validation when following the Authorization Code flow.

--- a/oauthlib/openid/connect/core/grant_types/implicit.py
+++ b/oauthlib/openid/connect/core/grant_types/implicit.py
@@ -25,10 +25,10 @@ class ImplicitGrant(GrantTypeBase):
             self.openid_authorization_validator)
         self.register_token_modifier(self.add_id_token)
 
-    def add_id_token(self, token, token_handler, request):
-        if 'state' not in token and request.state:
-            token['state'] = request.state
-        return super().add_id_token(token, token_handler, request, nonce=request.nonce)
+    def add_id_token(self, token_dict, token_handler, request):
+        if 'state' not in token_dict and request.state:
+            token_dict['state'] = request.state
+        return super().add_id_token(token_dict, token_handler, request, nonce=request.nonce)
 
     def openid_authorization_validator(self, request):
         """Additional validation when following the implicit flow.

--- a/oauthlib/openid/connect/core/grant_types/refresh_token.py
+++ b/oauthlib/openid/connect/core/grant_types/refresh_token.py
@@ -20,7 +20,7 @@ class RefreshTokenGrant(GrantTypeBase):
             request_validator=request_validator, **kwargs)
         self.register_token_modifier(self.add_id_token)
 
-    def add_id_token(self, token, token_handler, request):
+    def add_id_token(self, token_dict, token_handler, request):
         """
         Construct an initial version of id_token, and let the
         request_validator sign or encrypt it.
@@ -31,4 +31,4 @@ class RefreshTokenGrant(GrantTypeBase):
         if not self.request_validator.refresh_id_token(request):
             return token
 
-        return super().add_id_token(token, token_handler, request)
+        return super().add_id_token(token_dict, token_handler, request)

--- a/oauthlib/openid/connect/core/request_validator.py
+++ b/oauthlib/openid/connect/core/request_validator.py
@@ -61,12 +61,12 @@ class RequestValidator(OAuth2RequestValidator):
         """
         raise NotImplementedError('Subclasses must implement this method.')
 
-    def get_jwt_bearer_token(self, token, token_handler, request):
+    def get_jwt_bearer_token(self, token_dict, token_handler, request):
         """Get JWT Bearer token or OpenID Connect ID token
 
         If using OpenID Connect this SHOULD call `oauthlib.oauth2.RequestValidator.get_id_token`
 
-        :param token: A Bearer token dict
+        :param token_dict: A Bearer token dict
         :param token_handler: the token handler (BearerToken class)
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
@@ -77,7 +77,7 @@ class RequestValidator(OAuth2RequestValidator):
         """
         raise NotImplementedError('Subclasses must implement this method.')
 
-    def get_id_token(self, token, token_handler, request):
+    def get_id_token(self, token_dict, token_handler, request):
         """Get OpenID Connect ID token
 
         This method is OPTIONAL and is NOT RECOMMENDED.
@@ -108,7 +108,7 @@ class RequestValidator(OAuth2RequestValidator):
         .. _`3.2.2.10`: http://openid.net/specs/openid-connect-core-1_0.html#ImplicitIDToken
         .. _`3.3.2.11`: http://openid.net/specs/openid-connect-core-1_0.html#HybridIDToken
 
-        :param token: A Bearer token dict
+        :param token_dict: A Bearer token dict
         :param token_handler: the token handler (BearerToken class)
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
@@ -116,7 +116,7 @@ class RequestValidator(OAuth2RequestValidator):
         """
         return None
 
-    def finalize_id_token(self, id_token, token, token_handler, request):
+    def finalize_id_token(self, id_token_dict, token_dict, token_handler, request):
         """Finalize OpenID Connect ID token & Sign or Encrypt.
 
         In the OpenID Connect workflows when an ID Token is requested
@@ -124,7 +124,7 @@ class RequestValidator(OAuth2RequestValidator):
         construction, signing and optional encryption of the ID Token
         as described in the OpenID Connect spec.
 
-        The `id_token` parameter is a dict containing a couple of OIDC
+        The `id_token_dict` parameter is a dict containing a couple of OIDC
         technical fields related to the specification. Prepopulated
         attributes are:
 
@@ -150,8 +150,8 @@ class RequestValidator(OAuth2RequestValidator):
 
         .. _`OpenID Connect Core#Claims`: https://openid.net/specs/openid-connect-core-1_0.html#Claims
 
-        :param id_token: A dict containing technical fields of id_token
-        :param token: A Bearer token dict
+        :param id_token_dict: A dict containing technical fields of id_token
+        :param token_dict: A Bearer token dict
         :param token_handler: the token handler (BearerToken class)
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
@@ -159,7 +159,7 @@ class RequestValidator(OAuth2RequestValidator):
         """
         raise NotImplementedError('Subclasses must implement this method.')
 
-    def validate_jwt_bearer_token(self, token, scopes, request):
+    def validate_jwt_bearer_token(self, token_str, scopes, request):
         """Ensure the JWT Bearer token or OpenID Connect ID token are valids and authorized access to scopes.
 
         If using OpenID Connect this SHOULD call `oauthlib.oauth2.RequestValidator.get_id_token`
@@ -172,7 +172,7 @@ class RequestValidator(OAuth2RequestValidator):
             - http://openid.net/specs/openid-connect-core-1_0.html#HybridIDTValidation
             - http://openid.net/specs/openid-connect-core-1_0.html#HybridIDTValidation2
 
-        :param token: Unicode Bearer token
+        :param token_str: Unicode Bearer token
         :param scopes: List of scopes (defined by you)
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
@@ -185,7 +185,7 @@ class RequestValidator(OAuth2RequestValidator):
         """
         raise NotImplementedError('Subclasses must implement this method.')
 
-    def validate_id_token(self, token, scopes, request):
+    def validate_id_token(self, token_str, scopes, request):
         """Ensure the id token is valid and authorized access to scopes.
 
         OpenID connect core 1.0 describe how to validate an id_token:
@@ -194,7 +194,7 @@ class RequestValidator(OAuth2RequestValidator):
             - http://openid.net/specs/openid-connect-core-1_0.html#HybridIDTValidation
             - http://openid.net/specs/openid-connect-core-1_0.html#HybridIDTValidation2
 
-        :param token: Unicode Bearer token
+        :param token_str: Unicode Bearer token
         :param scopes: List of scopes (defined by you)
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request

--- a/oauthlib/openid/connect/core/tokens.py
+++ b/oauthlib/openid/connect/core/tokens.py
@@ -34,9 +34,9 @@ class JWTToken(TokenBase):
         return self.request_validator.get_jwt_bearer_token(None, None, request)
 
     def validate_request(self, request):
-        token = get_token_from_header(request)
+        token_str = get_token_from_header(request)
         return self.request_validator.validate_jwt_bearer_token(
-            token, request.scopes, request)
+            token_str, request.scopes, request)
 
     def estimate_type(self, request):
         token = get_token_from_header(request)


### PR DESCRIPTION
Here is an initial idea to start addressing #856

Various functions accept a parameter with a name like "token", but the parameter might either be a String or a Dict depending on the function.  Sometimes two similar functions will require different input types - for example `save_bearer_token` operates on a Dict, but `validate_bearer_token` operates on a string.  To better clarify this, and aid in future typing, the names of these functions were updated to have a `_str` or `_dict` suffix.  On several functions, the type of input was not identified in the docstring and a code audit was needed to determine. 

This does not change the various attributes on `oauthlib.common.Request` - which do need to be better listed and typed.

This quick PR was done for initial feedback.  I did not run this through any tests yet.