### PR TITLE
lint_python.yml: ruff --output-format=github .

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -11,7 +11,7 @@ jobs:
           check-latest: true
       - run: pip install --upgrade pip setuptools wheel
       - run: pip install black codespell mypy pytest ruff safety
-      - run: ruff --format=github .
+      - run: ruff --output-format=github .
       - run: black --check . || true
       - run: codespell  # --ignore-words-list="" --skip="*.css,*.js,*.lock"
       - run: pip install -r requirements-test.txt


### PR DESCRIPTION
Ruff renamed this option when they added a code formatted similar to black.