### PR TITLE
fix: redirect URI should be the last parameter

### DIFF
--- a/oauthlib/oauth2/rfc6749/parameters.py
+++ b/oauthlib/oauth2/rfc6749/parameters.py
@@ -73,8 +73,6 @@ def prepare_grant_uri(uri, client_id, response_type, redirect_uri=None,
     params = [(('response_type', response_type)),
               (('client_id', client_id))]
 
-    if redirect_uri:
-        params.append(('redirect_uri', redirect_uri))
     if scope:
         params.append(('scope', list_to_scope(scope)))
     if state:
@@ -86,6 +84,9 @@ def prepare_grant_uri(uri, client_id, response_type, redirect_uri=None,
     for k in kwargs:
         if kwargs[k]:
             params.append((str(k), kwargs[k]))
+
+    if redirect_uri:
+        params.append(('redirect_uri', redirect_uri))
 
     return add_params_to_uri(uri, params)
 

--- a/tests/oauth2/rfc6749/test_parameters.py
+++ b/tests/oauth2/rfc6749/test_parameters.py
@@ -37,13 +37,12 @@ class ParameterTests(TestCase):
         self.auth_implicit_list_scope['scope'] = self.list_scope
 
     auth_base_uri = ('https://server.example.com/authorize?response_type={0}'
-                     '&client_id=s6BhdRkqt3&redirect_uri=https%3A%2F%2F'
-                     'client.example.com%2Fcb&scope={1}&state={2}{3}')
+                     '&client_id=s6BhdRkqt3&scope={1}&state={2}{3}'
+                     '&redirect_uri=https%3A%2F%2Fclient.example.com%2Fcb')
 
     auth_base_uri_pkce = ('https://server.example.com/authorize?response_type={0}'
-                     '&client_id=s6BhdRkqt3&redirect_uri=https%3A%2F%2F'
-                     'client.example.com%2Fcb&scope={1}&state={2}{3}&code_challenge={4}'
-                     '&code_challenge_method={5}')
+                         '&client_id=s6BhdRkqt3&scope={1}&state={2}{3}&code_challenge={4}'
+                         '&code_challenge_method={5}&redirect_uri=https%3A%2F%2Fclient.example.com%2Fcb')
 
     auth_grant_uri = auth_base_uri.format('code', 'photos', state, '')
     auth_grant_uri_pkce = auth_base_uri_pkce.format('code', 'photos', state, '', 'code_challenge',
@@ -192,7 +191,6 @@ class ParameterTests(TestCase):
                            '&refresh_token=tGzv3JOkF0XG5Qx2TlKWIA'
                            '&example_parameter=example_value')
 
-
     def test_prepare_grant_uri(self):
         """Verify correct authorization URI construction."""
         self.assertURLEqual(prepare_grant_uri(**self.auth_grant), self.auth_grant_uri)
@@ -268,7 +266,6 @@ class ParameterTests(TestCase):
         finally:
             signals.scope_changed.disconnect(record_scope_change)
         del os.environ['OAUTHLIB_RELAX_TOKEN_SCOPE']
-
 
     def test_json_token_notype(self):
         """Verify strict token type parsing only when configured. """


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.2 says:

> The endpoint URI MAY include an "application/x-www-form-urlencoded" formatted (per [Appendix B](https://datatracker.ietf.org/doc/html/rfc6749#appendix-B)) query component ([[RFC3986] Section 3.4](https://datatracker.ietf.org/doc/html/rfc3986#section-3.4)), which MUST be retained when adding additional query parameters.

Query parameters added after the redirect URI may be interpreted as part of the redirect URI, resulting in an "Invalid Redirect URI" error from the authorization server. Adding `redirect_uri` as the last query parameter seems to be an easy way to avoid this.

Example:

```python
oauth = OAuth2Session(
	client_id="my-client-id",
	redirect_uri="https://example.org/oauth/callback/abc",
	scope=["my-scope"],
)
authorization_url, state = oauth.authorization_url(self.authorization_uri, access_type=offline)
authorization_url == "https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=my-client-id&redirect_uri=https://example.org/oauth/callback/abc&scope=my-scope&state=my-state&access_type=offline"
```

Now the authorization server might think that the redirect URI is `"https://example.org/oauth/callback/abc&scope=my-scope&state=my-state&access_type=offline"`, which does not match the registered URI `"https://example.org/oauth/callback/abc"`.

After this PR, the resulting authorization_url would be `"https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=my-client-id&scope=my-scope&state=my-state&access_type=offline&redirect_uri=https://example.org/oauth/callback/abc"`, so the `redirect_uri` cannot be interpreted in a wrong way.