### PR TITLE
Update create_code_verifier to output the proper length

### DIFF
--- a/oauthlib/oauth2/rfc6749/clients/base.py
+++ b/oauthlib/oauth2/rfc6749/clients/base.py
@@ -490,7 +490,7 @@ class Client:
         if not length <= 128:
             raise ValueError("Length must be less than or equal to 128")
 
-        allowed_characters = re.compile('^[A-Zaa-z0-9-._~]')
+        allowed_characters = re.compile('^[A-Za-z0-9-._~]')
         code_verifier = generate_token(length, UNICODE_ASCII_CHARACTER_SET + "-._~")
 
         if not re.search(allowed_characters, code_verifier):

--- a/oauthlib/oauth2/rfc6749/clients/base.py
+++ b/oauthlib/oauth2/rfc6749/clients/base.py
@@ -9,7 +9,6 @@ for consuming OAuth 2.0 RFC6749.
 import base64
 import hashlib
 import re
-import secrets
 import time
 import warnings
 

--- a/oauthlib/oauth2/rfc6749/clients/base.py
+++ b/oauthlib/oauth2/rfc6749/clients/base.py
@@ -13,7 +13,7 @@ import secrets
 import time
 import warnings
 
-from oauthlib.common import generate_token
+from oauthlib.common import UNICODE_ASCII_CHARACTER_SET, generate_token
 from oauthlib.oauth2.rfc6749 import tokens
 from oauthlib.oauth2.rfc6749.errors import (
     InsecureTransportError, TokenExpiredError,
@@ -492,7 +492,7 @@ class Client:
             raise ValueError("Length must be less than or equal to 128")
 
         allowed_characters = re.compile('^[A-Zaa-z0-9-._~]')
-        code_verifier = secrets.token_urlsafe(length)
+        code_verifier = generate_token(length, UNICODE_ASCII_CHARACTER_SET + "-._~")
 
         if not re.search(allowed_characters, code_verifier):
             raise ValueError("code_verifier contains invalid characters")

--- a/tests/oauth2/rfc6749/clients/test_base.py
+++ b/tests/oauth2/rfc6749/clients/test_base.py
@@ -340,6 +340,12 @@ class ClientTest(TestCase):
         code_verifier = client.create_code_verifier(length=length)
         self.assertEqual(client.code_verifier, code_verifier)
 
+    def test_create_code_verifier_length(self):
+        client = Client(self.client_id)
+        length = 96
+        code_verifier = client.create_code_verifier(length=length)
+        self.assertEqual(len(code_verifier), 96)
+
     def test_create_code_challenge_plain(self):
         client = Client(self.client_id)
         code_verifier = client.create_code_verifier(length=128)

--- a/tests/oauth2/rfc6749/clients/test_base.py
+++ b/tests/oauth2/rfc6749/clients/test_base.py
@@ -344,7 +344,7 @@ class ClientTest(TestCase):
         client = Client(self.client_id)
         length = 96
         code_verifier = client.create_code_verifier(length=length)
-        self.assertEqual(len(code_verifier), 96)
+        self.assertEqual(len(code_verifier), length)
 
     def test_create_code_challenge_plain(self):
         client = Client(self.client_id)


### PR DESCRIPTION
Previously, `create_code_verifier` would call `secrets.token_urlsafe(nbytes=length)` to produce the code verifier, but this leads to incorrect behaviour because the string returned by `token_urlsafe` doesn't have length `nbytes`. Instead it has length `nbytes * (4/3)` since the output is base64-encoded.

This means that, for example, you could call `create_code_verifier(length=128)` and you would get a result with length 171, which exceeds the 128-character maximum length of the code verifier allowed by the spec. But this wouldn't be caught by the checks in the code, since they only check the input length parameter and not the actual output length.

This PR fixes the issue by using the `generate_token` utility function instead, which does output strings of the exact length you specify. It also adds a test to make sure the length of the outputted string is equal to the specified length.