### PR TITLE
Fix CI Errors

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -13,7 +13,7 @@ jobs:
       - run: pip install black codespell mypy pytest ruff safety
       - run: ruff check --output-format=github .
       - run: black --check . || true
-      - run: codespell --ignore-words-list="implementor,mimiced,provicers,re-use"  # --skip="*.css,*.js,*.lock"
+      - run: codespell --ignore-words-list="implementor,mimiced,provicers,re-use,THIRDPARTY,assertIn"  # --skip="*.css,*.js,*.lock"
       - run: pip install -r requirements-test.txt
       - run: pip install --editable .
       - run: mkdir --parents --verbose .mypy_cache

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -11,7 +11,7 @@ jobs:
           check-latest: true
       - run: pip install --upgrade pip setuptools wheel
       - run: pip install black codespell mypy pytest ruff safety
-      - run: ruff --output-format=github .
+      - run: ruff check --output-format=github .
       - run: black --check . || true
       - run: codespell --ignore-words-list="implementor,mimiced,provicers,re-use"  # --skip="*.css,*.js,*.lock"
       - run: pip install -r requirements-test.txt

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ format fmt black:
 	black .
 
 lint ruff:
-	ruff .
+	ruff check .
 
 test:
 	tox

--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -316,7 +316,7 @@ class CaseInsensitiveDict(dict):
         return super().__getitem__(key)
 
     def get(self, k, default=None):
-        return self[k] if k in self else default
+        return self[k] if k in self else default  # noqa: SIM401
 
     def __setitem__(self, k, v):
         super().__setitem__(k, v)

--- a/oauthlib/oauth2/rfc6749/parameters.py
+++ b/oauthlib/oauth2/rfc6749/parameters.py
@@ -273,7 +273,7 @@ def parse_authorization_code_response(uri, state=None):
     query = urlparse.urlparse(uri).query
     params = dict(urlparse.parse_qsl(query))
 
-    if state and params.get('state', None) != state:
+    if state and params.get('state') != state:
         raise MismatchingStateError()
 
     if 'error' in params:
@@ -346,7 +346,7 @@ def parse_implicit_response(uri, state=None, scope=None):
     if 'expires_in' in params:
         params['expires_at'] = round(time.time()) + int(params['expires_in'])
 
-    if state and params.get('state', None) != state:
+    if state and params.get('state') != state:
         raise ValueError("Mismatching or missing state in params.")
 
     params = OAuth2Token(params, old_scope=scope)

--- a/oauthlib/oauth2/rfc6749/tokens.py
+++ b/oauthlib/oauth2/rfc6749/tokens.py
@@ -24,7 +24,7 @@ class OAuth2Token(dict):
     def __init__(self, params, old_scope=None):
         super().__init__(params)
         self._new_scope = None
-        if 'scope' in params and params['scope']:
+        if params.get('scope'):
             self._new_scope = set(utils.scope_to_list(params['scope']))
         if old_scope is not None:
             self._old_scope = set(utils.scope_to_list(old_scope))

--- a/oauthlib/openid/connect/core/grant_types/dispatchers.py
+++ b/oauthlib/openid/connect/core/grant_types/dispatchers.py
@@ -80,9 +80,9 @@ class AuthorizationTokenGrantDispatcher(Dispatcher):
         handler = self.default_grant
         scopes = ()
         parameters = dict(request.decoded_body)
-        client_id = parameters.get('client_id', None)
-        code = parameters.get('code', None)
-        redirect_uri = parameters.get('redirect_uri', None)
+        client_id = parameters.get('client_id')
+        code = parameters.get('code')
+        redirect_uri = parameters.get('redirect_uri')
 
         # If code is not present fallback to `default_grant` which will
         # raise an error for the missing `code` in `create_token_response` step.

--- a/tests/oauth1/rfc5849/test_signatures.py
+++ b/tests/oauth1/rfc5849/test_signatures.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from jwt import InvalidKeyError
 from oauthlib.oauth1.rfc5849.signature import (
     base_string_uri, collect_parameters, normalize_parameters,
     sign_hmac_sha1_with_client, sign_hmac_sha256_with_client,
@@ -765,11 +766,16 @@ MmgDHR2tt8KeYTSgfU+BAkBcaVF91EQ7VXhvyABNYjeYP7lU7orOgdWMa/zbLXSU
 
         # Signing needs a private key
 
-        for bad_value in [None, '', 'foobar']:
+        for bad_value in [None, '']:
             self.assertRaises(ValueError,
                               sign_rsa_sha1_with_client,
                               self.eg_signature_base_string,
                               MockClient(rsa_key=bad_value))
+
+        self.assertRaises(InvalidKeyError,
+                            sign_rsa_sha1_with_client,
+                            self.eg_signature_base_string,
+                            MockClient(rsa_key='foobar'))
 
         self.assertRaises(AttributeError,
                           sign_rsa_sha1_with_client,

--- a/tests/oauth2/rfc6749/clients/test_web_application.py
+++ b/tests/oauth2/rfc6749/clients/test_web_application.py
@@ -252,18 +252,13 @@ class WebApplicationClientTest(TestCase):
         self.assertEqual(r4b_params['client_id'], self.client_id)
 
         # scenario Warnings
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")  # catch all
-
-            # warning1 - raise a DeprecationWarning if a `client_id` is submitted
-            rWarnings1 = client.prepare_request_body(client_id=self.client_id)
-            self.assertEqual(len(w), 1)
-            self.assertIsInstance(w[0].message, DeprecationWarning)
-
+        # warning1 - raise a DeprecationWarning if a `client_id` is submitted
+        with self.assertWarns(DeprecationWarning):
+            client.prepare_request_body(client_id=self.client_id)
             # testing the exact warning message in Python2&Python3 is a pain
 
         # scenario Exceptions
         # exception1 - raise a ValueError if the a different `client_id` is submitted
-        with self.assertRaises(ValueError) as cm:
+        with self.assertWarns(DeprecationWarning), self.assertRaises(ValueError):
             client.prepare_request_body(client_id='different_client_id')
             # testing the exact exception message in Python2&Python3 is a pain

--- a/tests/oauth2/rfc6749/test_tokens.py
+++ b/tests/oauth2/rfc6749/test_tokens.py
@@ -76,7 +76,7 @@ class TokenTest(TestCase):
     bearer_uri = 'http://server.example.com/resource?access_token=vF9dft4qmT'
 
     def _mocked_validate_bearer_token(self, token, scopes, request):
-        if not token:
+        if not token:  # noqa: SIM103
             return False
         return True
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,4 +31,4 @@ commands=
 deps=ruff
 allowlist_externals=ruff
 skip_install=true
-commands=ruff .
+commands=ruff check .


### PR DESCRIPTION
This fixes the CI errors that are currently causing my other PR #876 to fail.

There were a few issues:

- Ruff now requires an explicit `check` command in the command line
- PyJWT now raises an InvalidKeyError in a situation where it previously raised a ValueError
- Several Ruff linting rules were being violated, most of which I fixed with ruff check --fix, and the remaining I marked as ignored

I also cleaned up some warning detection code in one of the tests and silenced one of the expected DeprecationWarnings which was previously leaking through to the output