### PR TITLE
Guard ui_locales.split()

### DIFF
--- a/oauthlib/openid/connect/core/grant_types/base.py
+++ b/oauthlib/openid/connect/core/grant_types/base.py
@@ -310,11 +310,15 @@ class GrantTypeBase:
             msg = "Session user does not match client supplied user."
             raise LoginRequired(request=request, description=msg)
 
+        ui_locales = request.ui_locales if request.ui_locales else []
+        if hasattr(ui_locales, 'split'):
+            ui_locales = ui_locales.strip().split()
+
         request_info = {
             'display': request.display,
             'nonce': request.nonce,
             'prompt': prompt,
-            'ui_locales': request.ui_locales.split() if request.ui_locales else [],
+            'ui_locales': ui_locales,
             'id_token_hint': request.id_token_hint,
             'login_hint': request.login_hint,
             'claims': request.claims


### PR DESCRIPTION
`request.ui_locales` might already be a list, only split the value if the `split` method is available.

I'm creating this PR because I ran into an issue with `django-oauth-toolkit`, I've added a workaround there:

https://github.com/jazzband/django-oauth-toolkit/pull/1469

Since I'm unsure if this is a bug in `oauthlib`, or is caused by unexpected use by `django-oauth-toolkit` I'm suggesting this change here as well.