### PR TITLE
Add the device authorization endpoint (RFC8628 section 3.1 & 3.2)

### DIFF
--- a/oauthlib/oauth2/__init__.py
+++ b/oauthlib/oauth2/__init__.py
@@ -34,3 +34,4 @@ from .rfc6749.request_validator import RequestValidator
 from .rfc6749.tokens import BearerToken, OAuth2Token
 from .rfc6749.utils import is_secure_transport
 from .rfc8628.clients import DeviceClient
+from .rfc8628.endpoints import DeviceAuthorizationEndpoint

--- a/oauthlib/oauth2/rfc8628/endpoints/__init__.py
+++ b/oauthlib/oauth2/rfc8628/endpoints/__init__.py
@@ -1,0 +1,8 @@
+"""
+oauthlib.oauth2.rfc8628
+~~~~~~~~~~~~~~~~~~~~~~~
+
+This module is an implementation of various logic needed
+for consuming and providing OAuth 2.0 Device Authorization RFC8628.
+"""
+from .device_authorization import DeviceAuthorizationEndpoint

--- a/oauthlib/oauth2/rfc8628/endpoints/device_authorization.py
+++ b/oauthlib/oauth2/rfc8628/endpoints/device_authorization.py
@@ -1,0 +1,156 @@
+"""
+oauthlib.oauth2.rfc6749
+~~~~~~~~~~~~~~~~~~~~~~~
+
+This module is an implementation of various logic needed
+for consuming and providing OAuth 2.0 RFC6749.
+"""
+import json
+
+from oauthlib.common import generate_token
+
+from oauthlib.oauth2.rfc6749.endpoints.base import (
+    BaseEndpoint,
+    catch_errors_and_unavailability,
+)
+
+
+class DeviceAuthorizationEndpoint(BaseEndpoint):
+
+    """DeviceAuthorization endpoint - used by the client to initiate
+    the authorization flow by requesting a set of verification codes
+    from the authorization server by making an HTTP "POST" request to
+    the device authorization endpoint.
+
+    The client authentication requirements of Section 3.2.1 of [RFC6749]
+    apply to requests on this endpoint, which means that confidential
+    clients (those that have established client credentials) authenticate
+    in the same manner as when making requests to the token endpoint, and
+    public clients provide the "client_id" parameter to identify
+    themselves.
+    """
+
+    def __init__(
+        self,
+        verification_uri,
+        expires_in=1800,
+        interval=None,
+        verification_uri_complete=None,
+    ):
+        """
+        :param verification_uri: a string containing the URL that can be polled by the client application
+        :param expires_in: a number that represents the lifetime of the `user_code` and `device_code`
+        :param interval: an option number that represents the number of seconds between each poll requests
+        :param verification_uri_complete: a string of a function that can be called with `user_data` as parameter
+        """
+        self._expires_in = expires_in
+        self._interval = interval
+        self._verification_uri = verification_uri
+        self._verification_uri_complete = verification_uri_complete
+        self._interval = interval
+
+        BaseEndpoint.__init__(self)
+
+    @property
+    def interval(self):
+        """The minimum amount of time in seconds that the client
+        SHOULD wait between polling requests to the token endpoint.  If no
+        value is provided, clients MUST use 5 as the default.
+        """
+        return self._interval
+
+    @property
+    def expires_in(self):
+        """The lifetime in seconds of the "device_code" and "user_code"."""
+        return self._expires_in
+
+    @property
+    def verification_uri(self):
+        """The end-user verification URI on the authorization
+        server.  The URI should be short and easy to remember as end users
+        will be asked to manually type it into their user agent.
+        """
+        return self._verification_uri
+
+    def verification_uri_complete(self, user_code):
+        if not self._verification_uri_complete:
+            return None
+        if isinstance(self._verification_uri_complete, str):
+            return self._verification_uri_complete.format(user_code=user_code)
+        if callable(self._verification_uri_complete):
+            return self._verification_uri_complete(user_code)
+        return None
+
+    @catch_errors_and_unavailability
+    def create_device_authorization_response(self, uri):
+        """create_device_authorization_response - generates a unique device
+        verification code and an end-user code that are valid for a limited
+        time and includes them in the HTTP response body using the
+        "application/json" format [RFC8259] with a 200 (OK) status code, as
+        described in `Section-3.2`_.
+
+        :param uri: a string representing the current parameter.
+        :return: the response payload as a JSON string.
+
+        The response contains the following parameters:
+
+        device_code
+           REQUIRED.  The device verification code.
+
+        user_code
+           REQUIRED.  The end-user verification code.
+
+        verification_uri
+           REQUIRED.  The end-user verification URI on the authorization
+           server.  The URI should be short and easy to remember as end users
+           will be asked to manually type it into their user agent.
+
+        verification_uri_complete
+           OPTIONAL.  A verification URI that includes the "user_code" (or
+           other information with the same function as the "user_code"),
+           which is designed for non-textual transmission.
+
+        expires_in
+           REQUIRED.  The lifetime in seconds of the "device_code" and
+           "user_code".
+
+        interval
+           OPTIONAL.  The minimum amount of time in seconds that the client
+           SHOULD wait between polling requests to the token endpoint.  If no
+           value is provided, clients MUST use 5 as the default.
+
+        For example:
+
+           HTTP/1.1 200 OK
+           Content-Type: application/json
+           Cache-Control: no-store
+
+           {
+             "device_code": "GmRhmhcxhwAzkoEqiMEg_DnyEysNkuNhszIySk9eS",
+             "user_code": "WDJB-MJHT",
+             "verification_uri": "https://example.com/device",
+             "verification_uri_complete":
+                 "https://example.com/device?user_code=WDJB-MJHT",
+             "expires_in": 1800,
+             "interval": 5
+           }
+
+        .. _`Section-3.2`: https://www.rfc-editor.org/rfc/rfc8628#section-3.2
+        """
+        headers = {}
+        user_code = generate_token()
+        data = {
+            "verification_uri": self.verification_uri,
+            "expires_in": self.expires_in,
+            "user_code": user_code,
+            "device_code": generate_token(),
+        }
+        if self.interval is not None:
+            data["interval"] = self.interval
+
+        verification_uri_complete = self.verification_uri_complete(user_code)
+        if verification_uri_complete:
+            data["verification_uri_complete"] = verification_uri_complete
+
+        body = json.dumps(data)
+        return headers, body, 200

--- a/oauthlib/oauth2/rfc8628/endpoints/device_authorization.py
+++ b/oauthlib/oauth2/rfc8628/endpoints/device_authorization.py
@@ -10,10 +10,8 @@ import logging
 
 from oauthlib.common import Request, generate_token
 from oauthlib.oauth2.rfc6749 import errors
-
 from oauthlib.oauth2.rfc6749.endpoints.base import (
-    BaseEndpoint,
-    catch_errors_and_unavailability,
+    BaseEndpoint, catch_errors_and_unavailability,
 )
 
 log = logging.getLogger(__name__)

--- a/oauthlib/oauth2/rfc8628/endpoints/device_authorization.py
+++ b/oauthlib/oauth2/rfc8628/endpoints/device_authorization.py
@@ -1,5 +1,5 @@
 """
-oauthlib.oauth2.rfc6749
+oauthlib.oauth2.rfc8628
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 This module is an implementation of various logic needed

--- a/oauthlib/oauth2/rfc8628/endpoints/device_authorization.py
+++ b/oauthlib/oauth2/rfc8628/endpoints/device_authorization.py
@@ -3,7 +3,7 @@ oauthlib.oauth2.rfc6749
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 This module is an implementation of various logic needed
-for consuming and providing OAuth 2.0 RFC6749.
+for consuming and providing OAuth 2.0 RFC8628.
 """
 import json
 import logging

--- a/oauthlib/oauth2/rfc8628/pre_configured.py
+++ b/oauthlib/oauth2/rfc8628/pre_configured.py
@@ -1,0 +1,19 @@
+from oauthlib.oauth2.rfc8628.endpoints.device_authorization import (
+    DeviceAuthorizationEndpoint,
+)
+
+
+class DeviceApplicationServer(DeviceAuthorizationEndpoint):
+
+    """An all-in-one endpoint featuring Authorization code grant and Bearer tokens."""
+
+    def __init__(self, request_validator, verification_uri, **kwargs):
+        """Construct a new web application server.
+
+        :param request_validator: An implementation of
+                                  oauthlib.oauth2.rfc8626.RequestValidator.
+        :param verification_uri: the verification_uri to be send back.
+        """
+        DeviceAuthorizationEndpoint.__init__(
+            self, request_validator, verification_uri=verification_uri
+        )

--- a/oauthlib/oauth2/rfc8628/request_validator.py
+++ b/oauthlib/oauth2/rfc8628/request_validator.py
@@ -1,0 +1,25 @@
+from oauthlib.oauth2 import RequestValidator as OAuth2RequestValidator
+
+
+class RequestValidator(OAuth2RequestValidator):
+    def client_authentication_required(self, request, *args, **kwargs):
+        """Determine if client authentication is required for current request.
+
+        According to the rfc8628, client authentication is required in the following cases:
+            - Device Authorization Request follows the, the client authentication requirements
+              of Section 3.2.1 of [RFC6749] apply to requests on this endpoint, which means that
+              confidential clients (those that have established client credentials) authenticate
+              in the same manner as when making requests to the token endpoint, and
+              public clients provide the "client_id" parameter to identify themselves,
+              see `Section 3.1`_.
+
+        :param request: OAuthlib request.
+        :type request: oauthlib.common.Request
+        :rtype: True or False
+
+        Method is used by:
+            - Device Authorization Request
+
+        .. _`Section 3.1`: https://www.rfc-editor.org/rfc/rfc8628#section-3.1
+        """
+        return True

--- a/oauthlib/openid/connect/core/endpoints/pre_configured.py
+++ b/oauthlib/openid/connect/core/endpoints/pre_configured.py
@@ -17,7 +17,7 @@ from oauthlib.oauth2.rfc6749.grant_types import (
 from oauthlib.oauth2.rfc6749.tokens import BearerToken
 
 from ..grant_types import (
-    AuthorizationCodeGrant, HybridGrant, ImplicitGrant, RefreshTokenGrant
+    AuthorizationCodeGrant, HybridGrant, ImplicitGrant, RefreshTokenGrant,
 )
 from ..grant_types.dispatchers import (
     AuthorizationCodeGrantDispatcher, AuthorizationTokenGrantDispatcher,

--- a/tests/oauth2/rfc8628/endpoints/test_error_responses.py
+++ b/tests/oauth2/rfc8628/endpoints/test_error_responses.py
@@ -26,7 +26,7 @@ class ErrorResponseTest(TestCase):
             headers={"Content-Type": "application/x-www-form-urlencoded"},
         )
 
-    def assertRequestRaises(self, error, request):
+    def assert_request_raises(self, error, request):
         """Test that the request fails similarly on the validation and response endpoint."""
         self.assertRaises(
             error,
@@ -53,7 +53,7 @@ class ErrorResponseTest(TestCase):
     def test_missing_client_id(self):
         # Device code grant
         request = self.build_request(client_id=None)
-        self.assertRequestRaises(errors.MissingClientIdError, request)
+        self.assert_request_raises(errors.MissingClientIdError, request)
 
     def test_empty_client_id(self):
         # Device code grant
@@ -70,30 +70,30 @@ class ErrorResponseTest(TestCase):
         request = self.build_request(client_id="foo")
         # Device code grant
         self.validator.validate_client_id.return_value = False
-        self.assertRequestRaises(errors.InvalidClientIdError, request)
+        self.assert_request_raises(errors.InvalidClientIdError, request)
 
     def test_duplicate_client_id(self):
         request = self.build_request()
         request.body = "client_id=foo&client_id=bar"
         # Device code grant
         self.validator.validate_client_id.return_value = False
-        self.assertRequestRaises(errors.InvalidRequestFatalError, request)
+        self.assert_request_raises(errors.InvalidRequestFatalError, request)
 
     def test_unauthenticated_confidential_client(self):
         self.validator.client_authentication_required.return_value = True
         self.validator.authenticate_client.return_value = False
         request = self.build_request()
-        self.assertRequestRaises(errors.InvalidClientError, request)
+        self.assert_request_raises(errors.InvalidClientError, request)
 
     def test_unauthenticated_public_client(self):
         self.validator.client_authentication_required.return_value = False
         self.validator.authenticate_client_id.return_value = False
         request = self.build_request()
-        self.assertRequestRaises(errors.InvalidClientError, request)
+        self.assert_request_raises(errors.InvalidClientError, request)
 
     def test_duplicate_scope_parameter(self):
         request = self.build_request()
         request.body = "client_id=foo&scope=foo&scope=bar"
         # Device code grant
         self.validator.validate_client_id.return_value = False
-        self.assertRequestRaises(errors.InvalidRequestFatalError, request)
+        self.assert_request_raises(errors.InvalidRequestFatalError, request)

--- a/tests/oauth2/rfc8628/endpoints/test_error_responses.py
+++ b/tests/oauth2/rfc8628/endpoints/test_error_responses.py
@@ -1,0 +1,99 @@
+import json
+from unittest import TestCase, mock
+from oauthlib.common import Request, urlencode
+from oauthlib.oauth2.rfc6749 import errors
+
+from oauthlib.oauth2.rfc8628.request_validator import RequestValidator
+from oauthlib.oauth2.rfc8628.pre_configured import DeviceApplicationServer
+
+
+class ErrorResponseTest(TestCase):
+    def set_client(self, request):
+        request.client = mock.MagicMock()
+        request.client.client_id = "mocked"
+        return True
+
+    def build_request(
+        self, uri="https://example.com/device_authorize", client_id="foo"
+    ):
+        body = ""
+        if client_id:
+            body = f"client_id={client_id}"
+        return Request(
+            uri,
+            http_method="POST",
+            body=body,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+
+    def assertRequestRaises(self, error, request):
+        """Test that the request fails similarly on the validation and response endpoint."""
+        self.assertRaises(
+            error,
+            self.device.validate_device_authorization_request,
+            request,
+        )
+        self.assertRaises(
+            error,
+            self.device.create_device_authorization_response,
+            uri=request.uri,
+            http_method=request.http_method,
+            body=request.body,
+            headers=request.headers,
+        )
+
+    def setUp(self):
+        self.validator = mock.MagicMock(spec=RequestValidator)
+        self.validator.get_default_redirect_uri.return_value = None
+        self.validator.get_code_challenge.return_value = None
+        self.device = DeviceApplicationServer(
+            self.validator, "https://example.com/verify"
+        )
+
+    def test_missing_client_id(self):
+        # Device code grant
+        request = self.build_request(client_id=None)
+        self.assertRequestRaises(errors.MissingClientIdError, request)
+
+    def test_empty_client_id(self):
+        # Device code grant
+        self.assertRaises(
+            errors.MissingClientIdError,
+            self.device.create_device_authorization_response,
+            "https://i.l/",
+            "POST",
+            "client_id=",
+            {"Content-Type": "application/x-www-form-urlencoded"},
+        )
+
+    def test_invalid_client_id(self):
+        request = self.build_request(client_id="foo")
+        # Device code grant
+        self.validator.validate_client_id.return_value = False
+        self.assertRequestRaises(errors.InvalidClientIdError, request)
+
+    def test_duplicate_client_id(self):
+        request = self.build_request()
+        request.body = "client_id=foo&client_id=bar"
+        # Device code grant
+        self.validator.validate_client_id.return_value = False
+        self.assertRequestRaises(errors.InvalidRequestFatalError, request)
+
+    def test_unauthenticated_confidential_client(self):
+        self.validator.client_authentication_required.return_value = True
+        self.validator.authenticate_client.return_value = False
+        request = self.build_request()
+        self.assertRequestRaises(errors.InvalidClientError, request)
+
+    def test_unauthenticated_public_client(self):
+        self.validator.client_authentication_required.return_value = False
+        self.validator.authenticate_client_id.return_value = False
+        request = self.build_request()
+        self.assertRequestRaises(errors.InvalidClientError, request)
+
+    def test_duplicate_scope_parameter(self):
+        request = self.build_request()
+        request.body = "client_id=foo&scope=foo&scope=bar"
+        # Device code grant
+        self.validator.validate_client_id.return_value = False
+        self.assertRequestRaises(errors.InvalidRequestFatalError, request)

--- a/tests/oauth2/rfc8628/endpoints/test_error_responses.py
+++ b/tests/oauth2/rfc8628/endpoints/test_error_responses.py
@@ -1,10 +1,10 @@
 import json
 from unittest import TestCase, mock
+
 from oauthlib.common import Request, urlencode
 from oauthlib.oauth2.rfc6749 import errors
-
-from oauthlib.oauth2.rfc8628.request_validator import RequestValidator
 from oauthlib.oauth2.rfc8628.pre_configured import DeviceApplicationServer
+from oauthlib.oauth2.rfc8628.request_validator import RequestValidator
 
 
 class ErrorResponseTest(TestCase):

--- a/tests/oauth2/rfc8628/test_server.py
+++ b/tests/oauth2/rfc8628/test_server.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 from unittest import mock
 

--- a/tests/oauth2/rfc8628/test_server.py
+++ b/tests/oauth2/rfc8628/test_server.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+import json
+from unittest import mock
+
+from oauthlib.oauth2.rfc8628.endpoints import DeviceAuthorizationEndpoint
+
+from tests.unittest import TestCase
+
+
+class DeviceAuthorizationEndpointTest(TestCase):
+    def setUp(self):
+        self.verification_uri = "http://i.b/l/verify"
+        self.uri = "http://i.b/l"
+
+    @mock.patch("oauthlib.oauth2.rfc8628.endpoints.device_authorization.generate_token")
+    def test_device_authorization_grant(self, generate_token):
+        generate_token.side_effect = ["abc", "def"]
+        endpoint = DeviceAuthorizationEndpoint(verification_uri=self.verification_uri)
+        _, body, status_code = endpoint.create_device_authorization_response(self.uri)
+        expected_payload = {
+            "verification_uri": "http://i.b/l/verify",
+            "user_code": "abc",
+            "device_code": "def",
+            "expires_in": 1800,
+        }
+        self.assertEqual(200, status_code)
+        self.assertEqual(json.loads(body), expected_payload)
+
+    @mock.patch(
+        "oauthlib.oauth2.rfc8628.endpoints.device_authorization.generate_token",
+        lambda: "abc",
+    )
+    def test_device_authorization_grant_interval(self):
+        endpoint = DeviceAuthorizationEndpoint(
+            verification_uri=self.verification_uri, interval=5
+        )
+        _, body, _ = endpoint.create_device_authorization_response(self.uri)
+        self.assertEqual(5, json.loads(body)["interval"])
+
+    @mock.patch(
+        "oauthlib.oauth2.rfc8628.endpoints.device_authorization.generate_token",
+        lambda: "abc",
+    )
+    def test_device_authorization_grant_interval_with_zero(self):
+        endpoint = DeviceAuthorizationEndpoint(
+            verification_uri=self.verification_uri, interval=0
+        )
+        _, body, _ = endpoint.create_device_authorization_response(self.uri)
+        self.assertEqual(0, json.loads(body)["interval"])
+
+    @mock.patch(
+        "oauthlib.oauth2.rfc8628.endpoints.device_authorization.generate_token",
+        lambda: "abc",
+    )
+    def test_device_authorization_grant_verify_url_complete_string(self):
+        endpoint = DeviceAuthorizationEndpoint(
+            verification_uri=self.verification_uri,
+            verification_uri_complete="http://i.l/v?user_code={user_code}",
+        )
+        _, body, _ = endpoint.create_device_authorization_response(self.uri)
+        self.assertEqual(
+            "http://i.l/v?user_code=abc",
+            json.loads(body)["verification_uri_complete"],
+        )
+
+    @mock.patch(
+        "oauthlib.oauth2.rfc8628.endpoints.device_authorization.generate_token",
+        lambda: "abc",
+    )
+    def test_device_authorization_grant_verify_url_complete_callable(self):
+        endpoint = DeviceAuthorizationEndpoint(
+            verification_uri=self.verification_uri,
+            verification_uri_complete=lambda u: f"http://i.l/v?user_code={u}",
+        )
+        _, body, _ = endpoint.create_device_authorization_response(self.uri)
+        self.assertEqual(
+            "http://i.l/v?user_code=abc",
+            json.loads(body)["verification_uri_complete"],
+        )

--- a/tests/oauth2/rfc8628/test_server.py
+++ b/tests/oauth2/rfc8628/test_server.py
@@ -3,20 +3,38 @@ import json
 from unittest import mock
 
 from oauthlib.oauth2.rfc8628.endpoints import DeviceAuthorizationEndpoint
+from oauthlib.oauth2.rfc8628.request_validator import RequestValidator
 
 from tests.unittest import TestCase
 
 
 class DeviceAuthorizationEndpointTest(TestCase):
+    def _configure_endpoint(self, interval=None, verification_uri_complete=None):
+        self.endpoint = DeviceAuthorizationEndpoint(
+            request_validator=mock.MagicMock(spec=RequestValidator),
+            verification_uri=self.verification_uri,
+            interval=interval,
+            verification_uri_complete=verification_uri_complete,
+        )
+
     def setUp(self):
+        self.request_validator = mock.MagicMock(spec=RequestValidator)
         self.verification_uri = "http://i.b/l/verify"
         self.uri = "http://i.b/l"
+        self.http_method = "POST"
+        self.body = "client_id=abc"
+        self.headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        self._configure_endpoint()
+
+    def response_payload(self):
+        return self.uri, self.http_method, self.body, self.headers
 
     @mock.patch("oauthlib.oauth2.rfc8628.endpoints.device_authorization.generate_token")
     def test_device_authorization_grant(self, generate_token):
         generate_token.side_effect = ["abc", "def"]
-        endpoint = DeviceAuthorizationEndpoint(verification_uri=self.verification_uri)
-        _, body, status_code = endpoint.create_device_authorization_response(self.uri)
+        _, body, status_code = self.endpoint.create_device_authorization_response(
+            *self.response_payload()
+        )
         expected_payload = {
             "verification_uri": "http://i.b/l/verify",
             "user_code": "abc",
@@ -31,10 +49,10 @@ class DeviceAuthorizationEndpointTest(TestCase):
         lambda: "abc",
     )
     def test_device_authorization_grant_interval(self):
-        endpoint = DeviceAuthorizationEndpoint(
-            verification_uri=self.verification_uri, interval=5
+        self._configure_endpoint(interval=5)
+        _, body, _ = self.endpoint.create_device_authorization_response(
+            *self.response_payload()
         )
-        _, body, _ = endpoint.create_device_authorization_response(self.uri)
         self.assertEqual(5, json.loads(body)["interval"])
 
     @mock.patch(
@@ -42,10 +60,10 @@ class DeviceAuthorizationEndpointTest(TestCase):
         lambda: "abc",
     )
     def test_device_authorization_grant_interval_with_zero(self):
-        endpoint = DeviceAuthorizationEndpoint(
-            verification_uri=self.verification_uri, interval=0
+        self._configure_endpoint(interval=0)
+        _, body, _ = self.endpoint.create_device_authorization_response(
+            *self.response_payload()
         )
-        _, body, _ = endpoint.create_device_authorization_response(self.uri)
         self.assertEqual(0, json.loads(body)["interval"])
 
     @mock.patch(
@@ -53,11 +71,12 @@ class DeviceAuthorizationEndpointTest(TestCase):
         lambda: "abc",
     )
     def test_device_authorization_grant_verify_url_complete_string(self):
-        endpoint = DeviceAuthorizationEndpoint(
-            verification_uri=self.verification_uri,
-            verification_uri_complete="http://i.l/v?user_code={user_code}",
+        self._configure_endpoint(
+            verification_uri_complete="http://i.l/v?user_code={user_code}"
         )
-        _, body, _ = endpoint.create_device_authorization_response(self.uri)
+        _, body, _ = self.endpoint.create_device_authorization_response(
+            *self.response_payload()
+        )
         self.assertEqual(
             "http://i.l/v?user_code=abc",
             json.loads(body)["verification_uri_complete"],
@@ -68,11 +87,12 @@ class DeviceAuthorizationEndpointTest(TestCase):
         lambda: "abc",
     )
     def test_device_authorization_grant_verify_url_complete_callable(self):
-        endpoint = DeviceAuthorizationEndpoint(
-            verification_uri=self.verification_uri,
-            verification_uri_complete=lambda u: f"http://i.l/v?user_code={u}",
+        self._configure_endpoint(
+            verification_uri_complete=lambda u: f"http://i.l/v?user_code={u}"
         )
-        _, body, _ = endpoint.create_device_authorization_response(self.uri)
+        _, body, _ = self.endpoint.create_device_authorization_response(
+            *self.response_payload()
+        )
         self.assertEqual(
             "http://i.l/v?user_code=abc",
             json.loads(body)["verification_uri_complete"],

--- a/tests/test_uri_validate.py
+++ b/tests/test_uri_validate.py
@@ -1,4 +1,5 @@
 import unittest
+
 from oauthlib.uri_validate import is_absolute_uri
 
 from tests.unittest import TestCase


### PR DESCRIPTION
Implements Section 3.1 and Section 3.2 of [RFC8628](https://www.rfc-editor.org/rfc/rfc8628#section-3.1)


(Cherry picked from https://github.com/oauthlib/oauthlib/pull/844 and rebased against upstream master
To fix lint issue to get it merged)