### PR TITLE
TT-4334: Support accessToken parameter in OAuth2 response for CBA

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,12 @@
 Changelog
 =========
+3.2.2.post1 (2024-10-03)
+------------------
+OAuth2.0 Provider:
+
+* Took a fork of oauthlib to fix a use case where token is not coming in `access_token` but in `accessToken` variable.
+
+* TT-4334: Update token response validation to allow tokens in `accessToken` variable.
 
 3.2.2 (2022-10-17)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+Fork from https://github.com/oauthlib/oauthlib repo on 10/03/2024
+
+===============================================
 OAuthLib - Python Framework for OAuth1 & OAuth2
 ===============================================
 

--- a/oauthlib/__init__.py
+++ b/oauthlib/__init__.py
@@ -12,7 +12,7 @@ import logging
 from logging import NullHandler
 
 __author__ = 'The OAuthlib Community'
-__version__ = '3.2.2'
+__version__ = '3.2.2.post1'
 
 logging.getLogger('oauthlib').addHandler(NullHandler())
 

--- a/oauthlib/oauth2/rfc6749/parameters.py
+++ b/oauthlib/oauth2/rfc6749/parameters.py
@@ -450,7 +450,10 @@ def validate_token_parameters(params):
         raise_from_error(params.get('error'), params)
 
     if 'access_token' not in params:
-        raise MissingTokenError(description="Missing access token parameter.")
+        if 'accessToken' in params:
+            params['access_token'] = params['accessToken']
+        else:
+            raise MissingTokenError(description="Missing access token parameter.")
 
     if 'token_type' not in params and os.environ.get('OAUTHLIB_STRICT_TOKEN_TYPE'):
         raise MissingTokenTypeError()

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ signedtoken_require = ['cryptography>=3.0.0', 'pyjwt>=2.0.0,<3']
 signals_require = ['blinker>=1.4.0']
 
 setup(
-    name='oauthlib',
+    name='runscope-oauthlib',
     version=oauthlib.__version__,
     description='A generic, spec-compliant, thorough implementation of the OAuth request-signing logic',
     long_description=fread('README.rst'),


### PR DESCRIPTION
Create a new package `runscope-oauthlib` by forking the original `oauthlib` package. Going forward, we will use this package for OAuth related functions.

Why did we need to fork it out?
CBA is using a 3rd party server which is sending token in accessToken parameter rather than in access_token which is RFC standard. This library is strictly follow the RFC standards due to which CBA gets `Missing Access Token` error. Since this is working on Postman (they do show the warning that this is against the standard) , we also have to provide the support for it. Also, I tried to fix by overriding the Class and Functions but it involves a lot of code changes.