### PR TITLE
Device flow: Pass verification_uri_complete to endpoint + pass Server kwargs to DeviceCodeGrant to allow validators to be setup with more flexibility

### DIFF
--- a/docs/oauth2/endpoints/device.rst
+++ b/docs/oauth2/endpoints/device.rst
@@ -22,12 +22,21 @@ the device authorization endpoint.
     from your_validator import your_validator
     verification_uri = "https://example.com/device"
 
+    # verification_uri_complete can either be a callable that receives user code as an arg
+    # or a string (e.g verification_uri_complete = "https://example.com/device=1234")
+    verification_uri_complete = lambda user_code: f"https://example.com/device={user_code}"
+
     def user_code():
        # some logic to generate a random string...
        return "123-456"
 
     # user code is optional
-    server = DeviceApplicationServer(your_validator, verification_uri, user_code)
+    server = DeviceApplicationServer(
+        request_validator=your_validator,
+        verification_uri=verification_uri,
+        verification_uri_complete=verification_uri_complete,
+        user_code=user_code
+    )
 
     headers, data, status = server.create_device_authorization_response(request)
 

--- a/oauthlib/oauth2/rfc6749/endpoints/pre_configured.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/pre_configured.py
@@ -57,7 +57,7 @@ class Server(
         self.password_grant = ResourceOwnerPasswordCredentialsGrant(request_validator)
         self.credentials_grant = ClientCredentialsGrant(request_validator)
         self.refresh_grant = RefreshTokenGrant(request_validator)
-        self.device_code_grant = DeviceCodeGrant(request_validator)
+        self.device_code_grant = DeviceCodeGrant(request_validator, **kwargs)
 
         self.bearer = BearerToken(
             request_validator, token_generator, token_expires_in, refresh_token_generator

--- a/oauthlib/oauth2/rfc8628/clients/device.py
+++ b/oauthlib/oauth2/rfc8628/clients/device.py
@@ -45,9 +45,9 @@ class DeviceClient(Client):
         if scope:
             params.append(('scope', list_to_scope(scope)))
 
-        for k in kwargs:
-            if kwargs[k]:
-                params.append((str(k), kwargs[k]))
+        for k,v in kwargs.items():
+            if v:
+                params.append((str(k), v))
 
         return add_params_to_uri(uri, params)
 

--- a/oauthlib/oauth2/rfc8628/endpoints/device_authorization.py
+++ b/oauthlib/oauth2/rfc8628/endpoints/device_authorization.py
@@ -224,6 +224,7 @@ class DeviceAuthorizationEndpoint(BaseEndpoint):
         if self.interval is not None:
             data["interval"] = self.interval
 
+
         verification_uri_complete = self.verification_uri_complete(user_code)
         if verification_uri_complete:
             data["verification_uri_complete"] = verification_uri_complete

--- a/oauthlib/oauth2/rfc8628/endpoints/pre_configured.py
+++ b/oauthlib/oauth2/rfc8628/endpoints/pre_configured.py
@@ -1,7 +1,8 @@
 from oauthlib.oauth2.rfc8628.endpoints.device_authorization import (
     DeviceAuthorizationEndpoint,
 )
-from typing import Callable
+
+from typing import Callable, Optional
 from oauthlib.openid.connect.core.request_validator import RequestValidator
 
 
@@ -13,6 +14,7 @@ class DeviceApplicationServer(DeviceAuthorizationEndpoint):
         request_validator: RequestValidator,
         verification_uri: str,
         interval: int = 5,
+        verification_uri_complete: Optional[str] = None,  # noqa: FA100
         user_code_generator: Callable[[None], str] = None,
         **kwargs,
     ):
@@ -30,4 +32,5 @@ class DeviceApplicationServer(DeviceAuthorizationEndpoint):
             interval=interval,
             verification_uri=verification_uri,
             user_code_generator=user_code_generator,
+            verification_uri_complete=verification_uri_complete,
         )

--- a/oauthlib/oauth2/rfc8628/grant_types/device_code.py
+++ b/oauthlib/oauth2/rfc8628/grant_types/device_code.py
@@ -3,7 +3,7 @@ import json
 
 from typing import Callable
 
-from oauthlib import common # noqa: TCH001
+from oauthlib import common # noqa: TC001
 
 from oauthlib.oauth2.rfc6749 import errors as rfc6749_errors
 from oauthlib.oauth2.rfc6749.grant_types.base import GrantTypeBase

--- a/oauthlib/openid/connect/core/endpoints/pre_configured.py
+++ b/oauthlib/openid/connect/core/endpoints/pre_configured.py
@@ -80,7 +80,7 @@ class Server(
         self.openid_connect_auth = AuthorizationCodeGrant(request_validator)
         self.openid_connect_implicit = ImplicitGrant(request_validator)
         self.openid_connect_hybrid = HybridGrant(request_validator)
-        self.device_code_grant = DeviceCodeGrant(request_validator)
+        self.device_code_grant = DeviceCodeGrant(request_validator, **kwargs)
 
         self.bearer = BearerToken(
             request_validator, token_generator, token_expires_in, refresh_token_generator

--- a/ruff.toml
+++ b/ruff.toml
@@ -98,6 +98,12 @@ max-complexity = 24  # default is 10
 "oauthlib/oauth2/rfc6749/endpoints/base.py" = ["BLE001"]
 "oauthlib/openid/connect/core/grant_types/base.py" = ["BLE001"]
 "tests/*" = ["PT009", "PT027", "S101"]
+"oauthlib/oauth1/rfc5849/endpoints/resource.py" = ["A005"]
+"oauthlib/oauth2/rfc6749/endpoints/resource.py" = ["A005"]
+"oauthlib/oauth2/rfc6749/endpoints/token.py" = ["A005"]
+"oauthlib/oauth2/rfc6749/parameters.py" = ["PLC0206"]
+"oauthlib/oauth2/rfc6749/tokens.py" = ["RUF023"]
+"oauthlib/openid/connect/core/tokens.py" = ["RUF023"]
 
 # [tool.ruff.pylint]
 [pylint]

--- a/tests/oauth2/rfc8628/endpoints/test_device_application_server.py
+++ b/tests/oauth2/rfc8628/endpoints/test_device_application_server.py
@@ -1,0 +1,26 @@
+import json
+from unittest import TestCase, mock
+
+from oauthlib.common import Request, urlencode
+from oauthlib.oauth2.rfc6749 import errors
+from oauthlib.oauth2.rfc8628.endpoints.pre_configured import DeviceApplicationServer
+from oauthlib.oauth2.rfc8628.request_validator import RequestValidator
+
+
+def test_server_set_up_device_endpoint_instance_attributes_correctly():
+    """
+    Simple test that just instantiates DeviceApplicationServer
+    and asserts the important attributes are present
+    """
+    validator = mock.MagicMock(spec=RequestValidator)
+    validator.get_default_redirect_uri.return_value = None
+    validator.get_code_challenge.return_value = None
+
+    verification_uri = "test.com/device"
+    verification_uri_complete = "test.com/device?user_code=123"
+    device = DeviceApplicationServer(validator,  verification_uri=verification_uri, verification_uri_complete=verification_uri_complete)
+    device_vars = vars(device)
+    assert device_vars["_verification_uri_complete"] == "test.com/device?user_code=123"
+    assert device_vars["_verification_uri"] == "test.com/device"
+    assert device_vars["_expires_in"] == 1800
+    assert device_vars["_interval"] == 5


### PR DESCRIPTION
Note to reviewer: pr is best reviewed commit by commit

While implementing [this](https://github.com/jazzband/django-oauth-toolkit)
I realised two things are missing

1. `verification_uri_complete` isn't being passed to the endpoint
2. The server kwargs aren't being passed to the device code grant

### Explanation of 2:
oauthlib assumes code like so for adding custom validators (or rather, examples in the code base do this but the constructor of a grant allows for generic kwargs to be passed in to set it up)

```
auth = DeviceCodeGrant(validator)

auth.custom_validators.pre_token.append(pre_token_validator)
auth.custom_validators.post_token.append(post_token_validator)
```

However there are cases where one would want more flexibility. What do I mean flexibility? All grant's inherit from `GrantTypeBase` and have a [constructor](https://github.com/duzumaki/oauthlib/blob/a4af43e35ba98ad84e7f6df09d541a6d1e0c2135/oauthlib/oauth2/rfc6749/grant_types/base.py#L82) like:

```
    def __init__(self, request_validator=None, **kwargs):
        self.request_validator = request_validator or RequestValidator()
        self._setup_custom_validators(kwargs)

    def _setup_custom_validators(self, kwargs):
        post_auth = kwargs.get('post_auth', [])
        post_token = kwargs.get('post_token', [])
        pre_auth = kwargs.get('pre_auth', [])
        pre_token = kwargs.get('pre_token', [])
        self.custom_validators = ValidatorsContainer(post_auth, post_token,
                                                     pre_auth, pre_token)
```

One might want to pass in any combination of the custom validators to the `Server` that uses the Grant object as a generic dict of [server kwargs ](https://github.com/duzumaki/django-oauth-toolkit/blob/af5d436e16802c48b4c37910c450640f02a7b6e1/build/lib/oauth2_provider/views/mixins.py#L77)(like is done in [django-oauth-toolkit](https://github.com/jazzband/django-oauth-toolkit) in order to abstract oauthlib away)


By allowing this it makes it easier to set up the validator checks


#### But what were you even trying to do in the first place?
For the device code this means being able to pass in a validation callable in a more flexible manner to assign `oauthlib.common.Request's` user attribute before the access token is made and saved allowing to associate the device user with the access token user 


Screenshot showing access tokens having users set from the device flow and `verification_uri_complete`(https://datatracker.ietf.org/doc/html/rfc8628#section-3.2) coming back from the authorization stage
![image](https://github.com/user-attachments/assets/9975f222-9ae4-4985-b1e1-8138e4f957f7)
![image](https://github.com/user-attachments/assets/d0259067-8196-44cf-a3b5-023b0bb70295)



