### PR TITLE
Remove code verifier regex

### DIFF
--- a/oauthlib/oauth2/rfc6749/clients/base.py
+++ b/oauthlib/oauth2/rfc6749/clients/base.py
@@ -490,11 +490,7 @@ class Client:
         if not length <= 128:
             raise ValueError("Length must be less than or equal to 128")
 
-        allowed_characters = re.compile('^[A-Za-z0-9-._~]')
         code_verifier = generate_token(length, UNICODE_ASCII_CHARACTER_SET + "-._~")
-
-        if not re.search(allowed_characters, code_verifier):
-            raise ValueError("code_verifier contains invalid characters")
 
         self.code_verifier = code_verifier
 

--- a/oauthlib/oauth2/rfc6749/clients/base.py
+++ b/oauthlib/oauth2/rfc6749/clients/base.py
@@ -8,7 +8,6 @@ for consuming OAuth 2.0 RFC6749.
 """
 import base64
 import hashlib
-import re
 import time
 import warnings
 


### PR DESCRIPTION
Fixes #884

This removes a check which is not effective due to an incorrect regex syntax and theoretically shouldn't be necessary anyway.