### PR TITLE
Remove generic classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
-        'License :: OSI Approved',
         'License :: OSI Approved :: BSD License',
         'Operating System :: MacOS',
         'Operating System :: POSIX',


### PR DESCRIPTION
On CLM scan tools such as Sonartype, indexing of license setup takes into consideration the current status of the license on Pypi.org. Currently, two classifiers are added:

![image](https://github.com/user-attachments/assets/36ae4f28-29ec-4e97-b77e-d78a2951b1ca)

That leads the scan tools to index this package as non compliant as it's using a very generic classifier. 

Sonartype response to this package:

```
• oauthlib: The Non-Standard is populated for the PyPI component oauthlib-3.2.2, which contains the following string in the associated `PKG-INFO`_ file under the _License Classifier section:
 
Classifier: License :: OSI Approved

The said string "OSI Approved" is mapped to an UNKNOWN as it is highly generic and can't be mapped to a specific license.
```

This PR makes sure that oauthlib is promptly returning only "License :: OSI Approved :: BSD License" and allow scan tools to make sure this lib is safe in regards to licensing.

Other repos for reference:

https://github.com/ets-labs/python-dependency-injector/blob/6e4794bab18fef3ffbc6a11bee526fe24688286f/pyproject.toml#L30
https://github.com/lepture/authlib/blob/4eafdc21891e78361f478479efe109ff0fb2f661/pyproject.toml#L21
https://github.com/gweis/isodate/blob/17cb25eb7bc3556a68f3f7b241313e9bb8b23760/pyproject.toml#L11
