### PR TITLE
Add mandatory RTD configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: true
+# the requirements.txt override some RTD defaults.
+# ideally it has to be updated from time to time
+# with latest libraries versions.
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+sphinx_rtd_theme
+readthedocs-sphinx-ext


### PR DESCRIPTION
Currently documentation is broken because ReadTheDocs now requires to have a configuration file.

Error at RTD output:

```
Config file not found at default path

The required .readthedocs.yaml configuration file was not found at repository's root. Learn how to use this file in our [configuration file tutorial](https://docs.readthedocs.io/en/stable/config-file/index.html).
```

This MR is an attempt to fix documentation generation.