### PR TITLE
Replace pyenv with uv in documentation and tooling

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -10,9 +10,8 @@ jobs:
           python-version: 3.x
           check-latest: true
       - run: pip install --upgrade pip setuptools wheel
-      - run: pip install black codespell mypy pytest ruff safety
+      - run: pip install codespell mypy pytest ruff safety
       - run: ruff check --output-format=github .
-      - run: black --check . || true
       - run: codespell --ignore-words-list="implementor,mimiced,provicers,re-use,THIRDPARTY,assertIn"  # --skip="*.css,*.js,*.lock"
       - run: pip install -r requirements-test.txt
       - run: pip install --editable .

--- a/Makefile
+++ b/Makefile
@@ -35,36 +35,35 @@ clean-build:
 	@rm -fr *.egg-info
 
 test:
-	tox
+	uvx --with tox-uv tox
 
 bottle:
 	#---------------------------
 	# Library refinitiv/bottle-oauthlib
 	# Contacts: Jonathan.Huot
 	cd bottle-oauthlib 2>/dev/null || git clone https://github.com/refinitiv/bottle-oauthlib.git
-	cd bottle-oauthlib && sed -i.old 's,deps =,deps= --editable=file://{toxinidir}/../,' tox.ini && sed -i.old '/oauthlib/d' requirements.txt && tox
+	cd bottle-oauthlib && sed -i.old 's,deps =,deps= --editable=file://{toxinidir}/../,' tox.ini && sed -i.old '/oauthlib/d' requirements.txt && uvx --with tox-uv tox
 
 django:
 	#---------------------------
 	# Library: evonove/django-oauth-toolkit
 	# Contacts: evonove,masci
-	# (note: has tox.ini already)
 	cd django-oauth-toolkit 2>/dev/null || git clone https://github.com/evonove/django-oauth-toolkit.git
-	cd django-oauth-toolkit && sed -i.old 's,deps =,deps= --editable=file://{toxinidir}/../,' tox.ini && tox
+	cd django-oauth-toolkit && sed -i.old 's,deps =,deps= --editable=file://{toxinidir}/../,' tox.ini && uvx --with tox-uv tox
 
 requests:
 	#---------------------------
 	# Library requests/requests-oauthlib
 	# Contacts: ib-lundgren,lukasa
 	cd requests-oauthlib 2>/dev/null || git clone https://github.com/requests/requests-oauthlib.git
-	cd requests-oauthlib && sed -i.old 's,deps=,deps = --editable=file://{toxinidir}/../[signedtoken],' tox.ini && sed -i.old '/oauthlib/d' requirements.txt && tox
+	cd requests-oauthlib && sed -i.old 's,oauthlib.*,--editable=file://{toxinidir}/../../[signedtoken],' requirements.txt && uvx --with tox-uv tox
 
 dance:
 	#---------------------------
 	# Library singingwolfboy/flask-dance
 	# Contacts: singingwolfboy
 	cd flask-dance 2>/dev/null || git clone https://github.com/singingwolfboy/flask-dance.git
-	cd flask-dance && sed -i.old 's,deps=,deps = --editable=file://{toxinidir}/../,' tox.ini && sed -i.old '/oauthlib/d' requirements.txt && tox 
+	cd flask-dance && sed -i.old 's;"oauthlib.*";"oauthlib @ file://'`pwd`'/../";' pyproject.toml && uv venv && uv pip install -e '.[test]' && ./.venv/bin/coverage run -m pytest
 
 .DEFAULT_GOAL := all
 .PHONY: clean test bottle dance django flask requests

--- a/Makefile
+++ b/Makefile
@@ -34,12 +34,6 @@ clean-build:
 	@rm -fr dist/
 	@rm -fr *.egg-info
 
-format fmt black:
-	black .
-
-lint ruff:
-	ruff check .
-
 test:
 	tox
 
@@ -74,4 +68,4 @@ dance:
 
 .DEFAULT_GOAL := all
 .PHONY: clean test bottle dance django flask requests
-all: lint test bottle dance django flask requests
+all: test bottle dance django flask requests

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -159,24 +159,22 @@ all versions conveniently at once can be done using `Tox`_.
 
    $ tox
 
-Tox requires you to have `virtualenv`_ installed as well as respective python
-version. We recommend using `pyenv`_ to install those Python versions.
+Tox requires you to have respective python versions. We recommend using `uv`_ to install those Python versions.
 
-We recommend using the latest patch version for each Python version we support and the latest PyPy versions.
-The versions beloew may not be up to date.
 
 .. sourcecode:: bash
 
-   $ pyenv install -l # check which versions you want to use
-   $ pyenv install 3.8.18
-   $ pyenv install 3.11.7
-   $ pyenv install pypy3.10-7.3.13
+   $ uv tool install tox --with tox-uv
+   $ uv python list # check which versions you want to use
+   $ uv python install 3.8 3.9 3.10 3.11 3.12 3.13
+   $ uv python install pypy3
+   $ uvx --with tox-uv tox # that run all tests with all python versions
+
 
 .. _`Tox`: https://tox.readthedocs.io/en/latest/install.html
-.. _`virtualenv`: https://virtualenv.pypa.io/en/latest/installation/
-.. _`pyenv`: https://github.com/pyenv/pyenv
+.. _`uv`: https://docs.astral.sh/uv/#python-versions
 
-Test upstream applications
+Test downstream applications
 -----------------------------------
 
 Remember, OAuthLib is used by several 3rd party projects. If you think you
@@ -185,6 +183,14 @@ submit a breaking change, confirm that other projects builds are not affected.
 .. sourcecode:: bash
 
    $ make
+
+Note be sure you are using ``uv`` as explained before with all python versions, including those from downstream libraries, to have all test cases running.
+
+As of 2025, additional downstreams python versions are as below:
+
+.. sourcecode:: bash
+
+   $ uv python install pypy3.10
 
 
 If you add code, add tests!

--- a/ruff.toml
+++ b/ruff.toml
@@ -5,6 +5,7 @@
 
 # When switching from ruff.toml to pyproject.toml, use the section names that
 # start with [tool.ruff
+exclude = ["flask-dance", "requests-oauthlib", "bottle-oauthlib", "django-oauth-toolkit"]
 
 # [tool.ruff]
 lint.select = [


### PR DESCRIPTION
pyenv has never been easy to use IMHO

uv is a game changer and suggest to use it to test all python versions at once.