### PR TITLE
Improve github action to publish package

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -19,6 +19,8 @@ jobs:
           allow-prereleases: true
       - name: Check out repository code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install prereq
         run: pip install tox coveralls
       - name: Run python tests
@@ -58,16 +60,47 @@ jobs:
           python-version: "3.11"
       - name: Check out repository code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install prereq
         run: pip install tox
       - name: Run python tests
         run: tox -e ${{ matrix.toxenv }}
-  pypi-publish:
+  build:
+    name: Build oauthlib distribution
     needs:
       - tests
       - docs
       - coveralls
-    if: ${{ success() }} && github.repository == 'oauthlib/oauthlib' && startsWith(github.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install pypa/build
+        run: >-
+          python3 -m
+          pip install
+          build
+          --user
+      - name: Build wheel and tarball
+        run: python3 -m build
+      - name: Store the package's artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+  pypi-publish:
+    if: success() && github.repository == 'oauthlib/oauthlib' && startsWith(github.ref, 'refs/tags/')
+    needs:
+      - build
     name: Upload release to PyPI
     runs-on: ubuntu-latest
     environment:
@@ -76,16 +109,10 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-    - name: Check out repository code
-      uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
       with:
-        python-version: '3.10'
-    - name: Install prereq
-      run: pip install build twine
-    - name: Build python package
-      run: python -m build
-    - name: Check python package
-      run: twine check dist/*
+        name: python-package-distributions
+        path: dist/
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -98,7 +98,7 @@ jobs:
           name: python-package-distributions
           path: dist/
   pypi-publish:
-    if: success() && github.repository == 'oauthlib/oauthlib' && github.ref_type = 'tag'
+    if: success() && github.repository == 'oauthlib/oauthlib' && github.ref_type == 'tag'
     needs:
       - build
     name: Upload release to PyPI

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -98,7 +98,7 @@ jobs:
           name: python-package-distributions
           path: dist/
   pypi-publish:
-    if: success() && github.repository == 'oauthlib/oauthlib' && startsWith(github.ref, 'refs/tags/')
+    if: success() && github.repository == 'oauthlib/oauthlib' && github.ref_type = 'tag'
     needs:
       - build
     name: Upload release to PyPI


### PR DESCRIPTION
No longer attempt to publish package for each commit due to a broken if statement.
Added build/upload artifact job.
Removed build from publish job.
Migrated from twine to python build

Fix #913 based on https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/