### PR TITLE
Fix client authentication for DeviceCodeGrant when getting a token

### DIFF
--- a/docs/oauth2/server.rst
+++ b/docs/oauth2/server.rst
@@ -300,7 +300,8 @@ can be seen below.
 
         def validate_client_id(self, client_id, request):
             try:
-                Client.objects.get(client_id=client_id)
+                client = Client.objects.get(client_id=client_id)
+                request.client = client
                 return True
             except Client.DoesNotExist:
                 return False

--- a/oauthlib/oauth2/__init__.py
+++ b/oauthlib/oauth2/__init__.py
@@ -66,5 +66,6 @@ from .rfc6749.request_validator import RequestValidator
 from .rfc6749.tokens import BearerToken, OAuth2Token
 from .rfc6749.utils import is_secure_transport
 from .rfc8628.clients import DeviceClient
-from oauthlib.oauth2.rfc8628.endpoints import DeviceAuthorizationEndpoint, DeviceApplicationServer
-from oauthlib.oauth2.rfc8628.grant_types import DeviceCodeGrant
+from .rfc8628.endpoints import DeviceAuthorizationEndpoint, DeviceApplicationServer
+from .rfc8628.errors import AuthorizationPendingError, SlowDownError, ExpiredTokenError, AccessDenied
+from .rfc8628.grant_types import DeviceCodeGrant

--- a/oauthlib/oauth2/__init__.py
+++ b/oauthlib/oauth2/__init__.py
@@ -66,6 +66,6 @@ from .rfc6749.request_validator import RequestValidator
 from .rfc6749.tokens import BearerToken, OAuth2Token
 from .rfc6749.utils import is_secure_transport
 from .rfc8628.clients import DeviceClient
-from .rfc8628.endpoints import DeviceAuthorizationEndpoint, DeviceApplicationServer
-from .rfc8628.errors import AuthorizationPendingError, SlowDownError, ExpiredTokenError, AccessDenied
+from .rfc8628.endpoints import DeviceApplicationServer, DeviceAuthorizationEndpoint
+from .rfc8628.errors import AccessDenied, AuthorizationPendingError, ExpiredTokenError, SlowDownError
 from .rfc8628.grant_types import DeviceCodeGrant

--- a/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
@@ -452,21 +452,7 @@ class AuthorizationCodeGrant(GrantTypeBase):
                 raise errors.InvalidRequestError(description='Duplicate %s parameter.' % param,
                                                  request=request)
 
-        if self.request_validator.client_authentication_required(request):
-            # If the client type is confidential or the client was issued client
-            # credentials (or assigned other authentication requirements), the
-            # client MUST authenticate with the authorization server as described
-            # in Section 3.2.1.
-            # https://tools.ietf.org/html/rfc6749#section-3.2.1
-            if not self.request_validator.authenticate_client(request):
-                log.debug('Client authentication failed, %r.', request)
-                raise errors.InvalidClientError(request=request)
-        elif not self.request_validator.authenticate_client_id(request.client_id, request):
-            # REQUIRED, if the client is not authenticating with the
-            # authorization server as described in Section 3.2.1.
-            # https://tools.ietf.org/html/rfc6749#section-3.2.1
-            log.debug('Client authentication failed, %r.', request)
-            raise errors.InvalidClientError(request=request)
+        self.validate_client_authentication(request)
 
         if not hasattr(request.client, 'client_id'):
             raise NotImplementedError('Authenticate client must set the '

--- a/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/authorization_code.py
@@ -454,13 +454,6 @@ class AuthorizationCodeGrant(GrantTypeBase):
 
         self.validate_client_authentication(request)
 
-        if not hasattr(request.client, 'client_id'):
-            raise NotImplementedError('Authenticate client must set the '
-                                      'request.client.client_id attribute '
-                                      'in authenticate_client.')
-
-        request.client_id = request.client_id or request.client.client_id
-
         # Ensure client is authorized use of this grant type
         self.validate_grant_type(request)
 

--- a/oauthlib/oauth2/rfc6749/grant_types/base.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/base.py
@@ -175,6 +175,27 @@ class GrantTypeBase:
                                                       request.scopes, request.client, request):
             raise errors.InvalidScopeError(request=request)
 
+    def validate_client_authentication(self, request):
+        """Raise on failed client authentication."""
+        # Handles confidential clients
+        if self.request_validator.client_authentication_required(request):
+            # If the client type is confidential or the client was issued client
+            # credentials (or assigned other authentication requirements), the
+            # client MUST authenticate with the authorization server as described
+            # in Section 3.2.1.
+            # https://tools.ietf.org/html/rfc6749#section-3.2.1
+            if not self.request_validator.authenticate_client(request):
+                log.debug('Client authentication failed, %r.', request)
+                raise errors.InvalidClientError(request=request)
+
+        # Handles public clients
+        elif not self.request_validator.authenticate_client_id(request.client_id, request):
+            # REQUIRED, if the client is not authenticating with the
+            # authorization server as described in Section 3.2.1.
+            # https://tools.ietf.org/html/rfc6749#section-3.2.1
+            log.debug('Client authentication failed, %r.', request)
+            raise errors.InvalidClientError(request=request)
+
     def prepare_authorization_response(self, request, token, headers, body, status):
         """Place token according to response mode.
 

--- a/oauthlib/oauth2/rfc6749/grant_types/base.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/base.py
@@ -175,26 +175,56 @@ class GrantTypeBase:
                                                       request.scopes, request.client, request):
             raise errors.InvalidScopeError(request=request)
 
+    def validate_client_confidential(self, request):
+        # If the client type is confidential or the client was issued client
+        # credentials (or assigned other authentication requirements), the
+        # client MUST authenticate with the authorization server as described
+        # in Section 3.2.1.
+        # https://tools.ietf.org/html/rfc6749#section-3.2.1
+        log.debug('Authenticating confidential client, %r.', request)
+        if not self.request_validator.authenticate_client(request):
+            log.debug('Client authentication failed, %r.', request)
+            raise errors.InvalidClientError(request=request)
+
+        if request.client is None or \
+            not hasattr(request.client, 'client_id'):
+            raise NotImplementedError('Authenticate client must set the '
+                                      'request.client.client_id attribute '
+                                      'in authenticate_client.')
+
+        if not request.client_id:
+            request.client_id = request.client.client_id
+        elif request.client_id != request.client.client_id:
+            raise errors.ServerError('Discrepency found between client identifier')
+
+    def validate_client_public(self, request):
+        # REQUIRED, if the client is not authenticating with the
+        # authorization server as described in Section 3.2.1.
+        # https://tools.ietf.org/html/rfc6749#section-3.2.1
+        log.debug('Authenticating public client, %r.', request)
+        if not self.request_validator.authenticate_client_id(request.client_id, request):
+            log.debug('Client authentication failed, %r.', request)
+            raise errors.InvalidClientError(request=request)
+
+        if request.client is None or \
+            not hasattr(request.client, 'client_id'):
+            raise NotImplementedError('Authenticate client must set the '
+                                      'request.client.client_id attribute '
+                                      'in authenticate_client.')
+
+        if not request.client_id:
+            request.client_id = request.client.client_id
+        elif request.client_id != request.client.client_id:
+            raise errors.ServerError('Discrepency found between client identifier')
+
     def validate_client_authentication(self, request):
         """Raise on failed client authentication."""
         # Handles confidential clients
         if self.request_validator.client_authentication_required(request):
-            # If the client type is confidential or the client was issued client
-            # credentials (or assigned other authentication requirements), the
-            # client MUST authenticate with the authorization server as described
-            # in Section 3.2.1.
-            # https://tools.ietf.org/html/rfc6749#section-3.2.1
-            if not self.request_validator.authenticate_client(request):
-                log.debug('Client authentication failed, %r.', request)
-                raise errors.InvalidClientError(request=request)
-
+            self.validate_client_confidential(request)
         # Handles public clients
-        elif not self.request_validator.authenticate_client_id(request.client_id, request):
-            # REQUIRED, if the client is not authenticating with the
-            # authorization server as described in Section 3.2.1.
-            # https://tools.ietf.org/html/rfc6749#section-3.2.1
-            log.debug('Client authentication failed, %r.', request)
-            raise errors.InvalidClientError(request=request)
+        else:
+            self.validate_client_public(request)
 
     def prepare_authorization_response(self, request, token, headers, body, status):
         """Place token according to response mode.

--- a/oauthlib/oauth2/rfc6749/grant_types/client_credentials.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/client_credentials.py
@@ -103,18 +103,11 @@ class ClientCredentialsGrant(GrantTypeBase):
                 raise errors.InvalidRequestError(description='Duplicate %s parameter.' % param,
                                                  request=request)
 
-        log.debug('Authenticating client, %r.', request)
-        if not self.request_validator.authenticate_client(request):
-            log.debug('Client authentication failed, %r.', request)
-            raise errors.InvalidClientError(request=request)
-        elif not hasattr(request.client, 'client_id'):
-            raise NotImplementedError('Authenticate client must set the '
-                                      'request.client.client_id attribute '
-                                      'in authenticate_client.')
+        self.validate_client_confidential(request)
+
         # Ensure client is authorized use of this grant type
         self.validate_grant_type(request)
 
-        request.client_id = request.client_id or request.client.client_id
         log.debug('Authorizing access to client %r.', request.client_id)
         self.validate_scopes(request)
 

--- a/oauthlib/oauth2/rfc6749/grant_types/refresh_token.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/refresh_token.py
@@ -96,17 +96,11 @@ class RefreshTokenGrant(GrantTypeBase):
         # authentication requirements), the client MUST authenticate with the
         # authorization server as described in Section 3.2.1.
         # https://tools.ietf.org/html/rfc6749#section-3.2.1
-        if self.request_validator.client_authentication_required(request):
-            log.debug('Authenticating client, %r.', request)
-            if not self.request_validator.authenticate_client(request):
-                log.debug('Invalid client (%r), denying access.', request)
-                raise errors.InvalidClientError(request=request)
-            # Ensure that request.client_id is set.
-            if request.client_id is None and request.client is not None:
-                request.client_id = request.client.client_id
-        elif not self.request_validator.authenticate_client_id(request.client_id, request):
-            log.debug('Client authentication failed, %r.', request)
-            raise errors.InvalidClientError(request=request)
+        self.validate_client_authentication(request)
+
+        # Ensure that request.client_id is set.
+        if request.client_id is None and request.client is not None:
+            request.client_id = request.client.client_id
 
         # Ensure client is authorized use of this grant type
         self.validate_grant_type(request)

--- a/oauthlib/oauth2/rfc6749/grant_types/refresh_token.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/refresh_token.py
@@ -91,16 +91,8 @@ class RefreshTokenGrant(GrantTypeBase):
 
         # Because refresh tokens are typically long-lasting credentials used to
         # request additional access tokens, the refresh token is bound to the
-        # client to which it was issued.  If the client type is confidential or
-        # the client was issued client credentials (or assigned other
-        # authentication requirements), the client MUST authenticate with the
-        # authorization server as described in Section 3.2.1.
-        # https://tools.ietf.org/html/rfc6749#section-3.2.1
+        # client to which it was issued
         self.validate_client_authentication(request)
-
-        # Ensure that request.client_id is set.
-        if request.client_id is None and request.client is not None:
-            request.client_id = request.client.client_id
 
         # Ensure client is authorized use of this grant type
         self.validate_grant_type(request)

--- a/oauthlib/oauth2/rfc6749/grant_types/resource_owner_password_credentials.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/resource_owner_password_credentials.py
@@ -85,14 +85,7 @@ class ResourceOwnerPasswordCredentialsGrant(GrantTypeBase):
         """
         headers = self._get_default_headers()
         try:
-            if self.request_validator.client_authentication_required(request):
-                log.debug('Authenticating client, %r.', request)
-                if not self.request_validator.authenticate_client(request):
-                    log.debug('Client authentication failed, %r.', request)
-                    raise errors.InvalidClientError(request=request)
-            elif not self.request_validator.authenticate_client_id(request.client_id, request):
-                log.debug('Client authentication failed, %r.', request)
-                raise errors.InvalidClientError(request=request)
+            self.validate_client_authentication(request)
             log.debug('Validating access token request, %r.', request)
             self.validate_token_request(request)
         except errors.OAuth2Error as e:

--- a/oauthlib/oauth2/rfc6749/grant_types/resource_owner_password_credentials.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/resource_owner_password_credentials.py
@@ -85,7 +85,6 @@ class ResourceOwnerPasswordCredentialsGrant(GrantTypeBase):
         """
         headers = self._get_default_headers()
         try:
-            self.validate_client_authentication(request)
             log.debug('Validating access token request, %r.', request)
             self.validate_token_request(request)
         except errors.OAuth2Error as e:
@@ -168,23 +167,18 @@ class ResourceOwnerPasswordCredentialsGrant(GrantTypeBase):
         if not request.grant_type == 'password':
             raise errors.UnsupportedGrantTypeError(request=request)
 
+        self.validate_client_authentication(request)
+
         log.debug('Validating username %s.', request.username)
         if not self.request_validator.validate_user(request.username,
                                                     request.password, request.client, request):
             raise errors.InvalidGrantError(
                 'Invalid credentials given.', request=request)
-        elif not hasattr(request.client, 'client_id'):
-            raise NotImplementedError(
-                'Validate user must set the '
-                'request.client.client_id attribute '
-                'in authenticate_client.')
         log.debug('Authorizing access to user %r.', request.user)
 
         # Ensure client is authorized use of this grant type
         self.validate_grant_type(request)
 
-        if request.client:
-            request.client_id = request.client_id or request.client.client_id
         self.validate_scopes(request)
 
         for validator in self.custom_validators.post_token:

--- a/oauthlib/oauth2/rfc6749/request_validator.py
+++ b/oauthlib/oauth2/rfc6749/request_validator.py
@@ -60,6 +60,11 @@ class RequestValidator:
         class must contain the 'client_id' attribute and the 'client_id' must have
         a value.
 
+        This method MUST NOT be used to authenticate public clients. Public
+        clients do not authenticate through means outside the OAuth 2 spec and
+        are instead validated by :meth:`authenticate_client_id`. If the client
+        is public, this method must return False.
+
         :param request: OAuthlib request.
         :type request: oauthlib.common.Request
         :rtype: True or False
@@ -69,6 +74,7 @@ class RequestValidator:
             - Resource Owner Password Credentials Grant (may be disabled)
             - Client Credentials Grant
             - Refresh Token Grant
+            - Device Code Grant
 
         .. _`HTTP Basic Authentication Scheme`: https://tools.ietf.org/html/rfc1945#section-11.1
         """
@@ -91,6 +97,9 @@ class RequestValidator:
 
         Method is used by:
             - Authorization Code Grant
+            - Resource Owner Password Credentials Grant
+            - Refresh Token Grant
+            - Device Code Grant
         """
         raise NotImplementedError('Subclasses must implement this method.')
 

--- a/oauthlib/oauth2/rfc6749/request_validator.py
+++ b/oauthlib/oauth2/rfc6749/request_validator.py
@@ -86,9 +86,10 @@ class RequestValidator:
         A non-confidential client is one that is not required to authenticate
         through other means, such as using HTTP Basic.
 
-        Note, while not strictly necessary it can often be very convenient
-        to set request.client to the client object associated with the
-        given client_id.
+        After the client identification succeeds, this method needs to set the
+        client on the request, i.e. request.client = client. A client object's
+        class must contain the 'client_id' attribute and the 'client_id' must have
+        a value.
 
         :param client_id: Unicode client identifier.
         :param request: OAuthlib request.
@@ -428,9 +429,10 @@ class RequestValidator:
     def validate_client_id(self, client_id, request, *args, **kwargs):
         """Ensure client_id belong to a valid and active client.
 
-        Note, while not strictly necessary it can often be very convenient
-        to set request.client to the client object associated with the
-        given client_id.
+        After the client identification succeeds, this method needs to set the
+        client on the request, i.e. request.client = client. A client object's
+        class must contain the 'client_id' attribute and the 'client_id' must have
+        a value.
 
         :param client_id: Unicode client identifier.
         :param request: OAuthlib request.

--- a/oauthlib/oauth2/rfc8628/grant_types/device_code.py
+++ b/oauthlib/oauth2/rfc8628/grant_types/device_code.py
@@ -55,14 +55,12 @@ class DeviceCodeGrant(GrantTypeBase):
                     description=f"Duplicate {param} parameter.", request=request
                 )
 
-        if not self.request_validator.authenticate_client(request):
-            raise rfc6749_errors.InvalidClientError(request=request)
-        elif not hasattr(request.client, "client_id"):
-            raise NotImplementedError(
-                "Authenticate client must set the "
-                "request.client.client_id attribute "
-                "in authenticate_client."
-            )
+        self.validate_client_authentication(request)
+
+        if not hasattr(request.client, 'client_id'):
+            raise NotImplementedError('Authenticate client must set the '
+                                      'request.client.client_id attribute '
+                                      'in authenticate_client.')
 
         # Ensure client is authorized use of this grant type
         self.validate_grant_type(request)
@@ -93,13 +91,7 @@ class DeviceCodeGrant(GrantTypeBase):
         """
         headers = self._get_default_headers()
         try:
-            if self.request_validator.client_authentication_required(
-                request
-            ) and not self.request_validator.authenticate_client(request):
-                raise rfc6749_errors.InvalidClientError(request=request)
-
             self.validate_token_request(request)
-
         except rfc6749_errors.OAuth2Error as e:
             headers.update(e.headers)
             return headers, e.json, e.status_code

--- a/oauthlib/oauth2/rfc8628/grant_types/device_code.py
+++ b/oauthlib/oauth2/rfc8628/grant_types/device_code.py
@@ -57,15 +57,9 @@ class DeviceCodeGrant(GrantTypeBase):
 
         self.validate_client_authentication(request)
 
-        if not hasattr(request.client, 'client_id'):
-            raise NotImplementedError('Authenticate client must set the '
-                                      'request.client.client_id attribute '
-                                      'in authenticate_client.')
-
         # Ensure client is authorized use of this grant type
         self.validate_grant_type(request)
 
-        request.client_id = request.client_id or request.client.client_id
         self.validate_scopes(request)
 
         for validator in self.custom_validators.post_token:

--- a/tests/oauth2/rfc6749/endpoints/test_error_responses.py
+++ b/tests/oauth2/rfc6749/endpoints/test_error_responses.py
@@ -400,7 +400,7 @@ class ErrorResponseTest(TestCase):
         self.assertEqual('invalid_client', json.loads(body)['error'])
 
         # Client credentials grant
-        _, body, _ = self.legacy.create_token_response('https://i.b/token',
+        _, body, _ = self.backend.create_token_response('https://i.b/token',
                 body='grant_type=client_credentials')
         self.assertEqual('invalid_client', json.loads(body)['error'])
 

--- a/tests/oauth2/rfc6749/endpoints/test_scope_handling.py
+++ b/tests/oauth2/rfc6749/endpoints/test_scope_handling.py
@@ -30,12 +30,12 @@ class TestScopeHandling(TestCase):
         request.user = 'foo'
         request.client_id = 'bar'
         request.client = mock.MagicMock()
-        request.client.client_id = 'mocked'
+        request.client.client_id = request.client_id
         return True
 
     def set_client(self, request):
         request.client = mock.MagicMock()
-        request.client.client_id = 'mocked'
+        request.client.client_id = request.client_id
         return True
 
     def setUp(self):

--- a/tests/oauth2/rfc6749/grant_types/test_authorization_code.py
+++ b/tests/oauth2/rfc6749/grant_types/test_authorization_code.py
@@ -34,7 +34,7 @@ class AuthorizationCodeGrantTest(TestCase):
 
     def set_client(self, request):
         request.client = mock.MagicMock()
-        request.client.client_id = 'mocked'
+        request.client.client_id = request.client_id
         return True
 
     def setup_validators(self):
@@ -196,6 +196,36 @@ class AuthorizationCodeGrantTest(TestCase):
         self.mock_validator.authenticate_client_id.return_value = False
         self.request.state = 'abc'
         self.assertRaises(errors.InvalidClientError,
+                          self.auth.validate_token_request, self.request)
+
+    def test_client_id_discrepancy(self):
+        """ServerError raised when authenticate_client sets a different client_id."""
+        def set_mismatched_client(request):
+            request.client = mock.MagicMock()
+            request.client.client_id = 'different_from_abcdef'
+            return True
+        self.mock_validator.authenticate_client.side_effect = set_mismatched_client
+        self.assertRaises(errors.ServerError,
+                          self.auth.validate_token_request, self.request)
+
+    def test_public_client_id_missing(self):
+        """NotImplementedError raised when authenticate_client_id does not set request.client."""
+        self.mock_validator.client_authentication_required.return_value = False
+        self.mock_validator.authenticate_client_id.return_value = True
+        self.request.client = mock.MagicMock()
+        del self.request.client.client_id
+        self.assertRaises(NotImplementedError,
+                          self.auth.validate_token_request, self.request)
+
+    def test_public_client_id_discrepancy(self):
+        """ServerError raised when authenticate_client_id sets a different client_id."""
+        def set_mismatched_client(client_id, request):
+            request.client = mock.MagicMock()
+            request.client.client_id = 'different_from_abcdef'
+            return True
+        self.mock_validator.client_authentication_required.return_value = False
+        self.mock_validator.authenticate_client_id.side_effect = set_mismatched_client
+        self.assertRaises(errors.ServerError,
                           self.auth.validate_token_request, self.request)
 
     def test_invalid_redirect_uri(self):

--- a/tests/oauth2/rfc6749/grant_types/test_refresh_token.py
+++ b/tests/oauth2/rfc6749/grant_types/test_refresh_token.py
@@ -15,6 +15,7 @@ class RefreshTokenGrantTest(TestCase):
     def setUp(self):
         mock_client = mock.MagicMock()
         mock_client.user.return_value = 'mocked user'
+        mock_client.client_id = 'abcdef'
         self.request = Request('http://a.b/path')
         self.request.grant_type = 'refresh_token'
         self.request.refresh_token = 'lsdkfhj230'
@@ -145,6 +146,16 @@ class RefreshTokenGrantTest(TestCase):
         self.request.client.client_id = 'foobar'
         self.auth.validate_token_request(self.request)
         self.request.client_id = 'foobar'
+
+    def test_client_id_discrepancy(self):
+        """ServerError raised when authenticate_client sets a different client_id."""
+        def set_mismatched_client(request):
+            request.client = mock.MagicMock()
+            request.client.client_id = 'different_from_abcdef'
+            return True
+        self.mock_validator.authenticate_client.side_effect = set_mismatched_client
+        self.assertRaises(errors.ServerError,
+                          self.auth.validate_token_request, self.request)
 
     def test_invalid_grant_type(self):
         self.request.grant_type = 'wrong_type'

--- a/tests/oauth2/rfc6749/test_server.py
+++ b/tests/oauth2/rfc6749/test_server.py
@@ -112,7 +112,7 @@ class TokenEndpointTest(TestCase):
         def set_user(request):
             request.user = mock.MagicMock()
             request.client = mock.MagicMock()
-            request.client.client_id = 'mocked_client_id'
+            request.client.client_id = request.client_id
             return True
 
         self.mock_validator = mock.MagicMock()
@@ -219,7 +219,7 @@ class SignedTokenEndpointTest(TestCase):
         def set_user(request):
             request.user = mock.MagicMock()
             request.client = mock.MagicMock()
-            request.client.client_id = 'mocked_client_id'
+            request.client.client_id = request.client_id
             return True
 
         self.mock_validator = mock.MagicMock()

--- a/tests/oauth2/rfc8628/grant_types/test_device_code.py
+++ b/tests/oauth2/rfc8628/grant_types/test_device_code.py
@@ -53,6 +53,7 @@ def test_custom_pre_and_post_token_validators():
 
     request: common.Request = create_request()
     request.client = client
+    client.client_id = request.client_id
 
     auth = DeviceCodeGrant(validator)
 
@@ -70,6 +71,7 @@ def test_create_token_response():
     validator = mock.MagicMock()
     request: common.Request = create_request()
     request.client = mock.Mock()
+    request.client.client_id = request.client_id
 
     auth = DeviceCodeGrant(validator)
 

--- a/tests/openid/connect/core/endpoints/test_claims_handling.py
+++ b/tests/openid/connect/core/endpoints/test_claims_handling.py
@@ -29,12 +29,12 @@ class TestClaimsHandling(TestCase):
         request.user = 'foo'
         request.client_id = 'bar'
         request.client = mock.MagicMock()
-        request.client.client_id = 'mocked'
+        request.client.client_id = request.client_id
         return True
 
     def set_client(self, request):
         request.client = mock.MagicMock()
-        request.client.client_id = 'mocked'
+        request.client.client_id = request.client_id
         return True
 
     def save_claims_with_code(self, client_id, code, request, *args, **kwargs):

--- a/tests/openid/connect/core/endpoints/test_refresh_token.py
+++ b/tests/openid/connect/core/endpoints/test_refresh_token.py
@@ -19,6 +19,13 @@ class TestRefreshToken(TestCase):
         self.validator = mock.MagicMock(spec=RequestValidator)
         self.validator.get_id_token.return_value='id_token'
 
+        def set_client(request):
+            request.client = mock.MagicMock()
+            request.client.client_id = request.client_id
+            return True
+
+        self.validator.authenticate_client.side_effect = set_client
+
         self.server = Server(self.validator)
 
     def test_refresh_token_with_openid(self):

--- a/tests/openid/connect/core/grant_types/test_authorization_code.py
+++ b/tests/openid/connect/core/grant_types/test_authorization_code.py
@@ -54,7 +54,7 @@ class OpenIDAuthCodeTest(TestCase):
 
     def set_client(self, request):
         request.client = mock.MagicMock()
-        request.client.client_id = 'mocked'
+        request.client.client_id = request.client_id
         return True
 
     @mock.patch('oauthlib.common.generate_token')


### PR DESCRIPTION
Adds a helper method for validating client authentication and use it in `AuthorizationCodeGrant`, `DeviceCodeGrant`, `RefreshTokenGrant`, and `ResourceOwnerPasswordCredentialsGrant`.

Putting the helper method in `DeviceCodeGrant` also fixes an issue where the client being public/confidential was not being taken into consideration.

Add some missing imports to the oauth2 __init__.py that I noticed weren't there when implementing changes in my own code.

Resolves https://github.com/oauthlib/oauthlib/issues/919