### PR TITLE
Add project URLs to this project's PyPI page

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
     author='The OAuthlib Community',
     maintainer='Jonathan Huot',
     maintainer_email='jonathan.huot@gmail.com',
-    url='https://github.com/oauthlib/oauthlib',
     platforms='any',
     license='BSD-3-Clause',
     packages=find_packages(exclude=('docs', 'examples', 'tests', 'tests.*')),
@@ -39,6 +38,15 @@ setup(
         'rsa': rsa_require,
         'signedtoken': signedtoken_require,
         'signals': signals_require,
+    },
+    url='https://github.com/oauthlib/oauthlib',
+    project_urls={
+        'Changelog': 'https://github.com/oauthlib/oauthlib/blob/master/CHANGELOG.rst',
+        'Documentation': 'https://oauthlib.readthedocs.io/',
+        'Gitter': 'https://gitter.im/oauthlib/Lobby',
+        'Issues': 'https://github.com/oauthlib/oauthlib/issues',
+        'Source': 'https://github.com/oauthlib/oauthlib',
+        'Sponsor': 'https://github.com/sponsors/JonathanHuot',
     },
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This is a small change that will add more links and icons to oauthlib's [PyPI page](https://pypi.org/project/oauthlib/) and [metadata](https://pypi.org/pypi/oauthlib/json). 

The icons will look like the icons in this demo page: https://pypi.org/project/links-demo/

I'm currently writing a script that automatically retrieves the changelogs of packages when updating them. The project URLs are conveniently included in the responses returned by PyPI's public API ([example](https://pypi.org/pypi/links-demo/json)). I noticed that oauthlib didn't have a changelog listed while working on this script, so I thought I would contribute a small fix.