### PR TITLE
Include any claims specified via request.claims in the JWT access token.

### DIFF
--- a/oauthlib/oauth2/rfc6749/tokens.py
+++ b/oauthlib/oauth2/rfc6749/tokens.py
@@ -227,7 +227,8 @@ def signed_token_generator(private_pem, **kwargs):
     :param private_pem:
     """
     def signed_token_generator(request):
-        request.claims = kwargs
+        request.claims = getattr(request, "claims", dict()) or dict()
+        request.claims.update(kwargs)
         return common.generate_signed_token(private_pem, request)
 
     return signed_token_generator


### PR DESCRIPTION
Per [the docs](https://oauthlib.readthedocs.io/en/latest/oauth2/tokens/bearer.html#generate-signed-jwt), it appears any claims added to the request in the request validator should appear in the JWT access token. Presently, these claims appear to be ignored.

Fixes #926 