### PR TITLE
Improve Content-Type Validation for Token Endpoint Requests

### DIFF
--- a/oauthlib/oauth2/rfc6749/endpoints/base.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/base.py
@@ -10,7 +10,7 @@ import logging
 
 from ..errors import (
     FatalClientError, InvalidClientError, InvalidRequestError, OAuth2Error,
-    ServerError, TemporarilyUnavailableError, UnsupportedTokenTypeError,
+    ServerError, TemporarilyUnavailableError, UnsupportedTokenTypeError, UnsupportedContentTypeError,
 )
 
 log = logging.getLogger(__name__)
@@ -87,6 +87,26 @@ class BaseEndpoint:
             if query_params:
                 raise InvalidRequestError(request=request,
                                           description=('URL query parameters are not allowed'))
+
+    def _raise_on_bad_content_type(self, request, allowed_type):
+        """
+        Raise `UnsupportedContentTypeError` if the request ``Content-Type`` header
+        does not match the expected value.
+
+        :param request: OAuthlib request.
+        :type request: oauthlib.common.Request
+        :param allowed_type: Expected Content-Type header value.
+        :type allowed_type: str
+        """
+        content_type_header = request.headers.get("Content-Type", "")
+        content_type = content_type_header.split(';')[0].strip().lower()
+        expected_type = allowed_type.strip().lower()
+
+        if content_type and content_type != expected_type:
+            raise UnsupportedContentTypeError(
+                request=request,
+                description=f"Invalid Content-Type. Must be: {allowed_type}"
+            )
 
 def catch_errors_and_unavailability(f):
     @functools.wraps(f)

--- a/oauthlib/oauth2/rfc6749/endpoints/token.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/token.py
@@ -117,3 +117,7 @@ class TokenEndpoint(BaseEndpoint):
     def validate_token_request(self, request):
         self._raise_on_bad_method(request)
         self._raise_on_bad_post_request(request)
+        self._raise_on_bad_content_type(
+            request,
+            allowed_type='application/x-www-form-urlencoded',
+        )

--- a/oauthlib/oauth2/rfc6749/errors.py
+++ b/oauthlib/oauth2/rfc6749/errors.py
@@ -309,6 +309,12 @@ class UnauthorizedClientError(OAuth2Error):
     """
     error = 'unauthorized_client'
 
+class UnsupportedContentTypeError(OAuth2Error):
+    """
+    The authorization server does not support the
+    media type transmitted in the request.
+    """
+    error = 'unsupported_content_type'
 
 class UnsupportedGrantTypeError(OAuth2Error):
     """

--- a/tests/oauth2/rfc6749/endpoints/test_error_responses.py
+++ b/tests/oauth2/rfc6749/endpoints/test_error_responses.py
@@ -465,6 +465,39 @@ class ErrorResponseTest(TestCase):
             except errors.InvalidRequestError as ire:
                 self.assertIn('Unsupported request method', ire.description)
 
+    def test_invalid_content_type(self):
+        """
+        Test that requests with invalid content-type raise UnsupportedContentTypeError
+        """
+        self.validator.authenticate_client.side_effect = self.set_client
+
+        uri = "http://i/b/token/"
+        expected_content_type = "application/x-www-form-urlencoded"
+        invalid_headers = {
+            'Content-Type': 'application/json'
+        }
+
+        try:
+            _, body, s = self.web.create_token_response(uri,
+                    body='grant_type=access_token&code=123', headers=invalid_headers)
+            self.fail('This should have failed with UnsupportedContentTypeError')
+        except errors.UnsupportedContentTypeError as ire:
+            self.assertIn(expected_content_type, ire.description)
+
+        try:
+            _, body, s = self.legacy.create_token_response(uri,
+                    body='grant_type=access_token&code=123', headers=invalid_headers)
+            self.fail('This should have failed with UnsupportedContentTypeError')
+        except errors.UnsupportedContentTypeError as ire:
+            self.assertIn(expected_content_type, ire.description)
+
+        try:
+            _, body, s = self.backend.create_token_response(uri,
+                    body='grant_type=access_token&code=123', headers=invalid_headers)
+            self.fail('This should have failed with UnsupportedContentTypeError')
+        except errors.UnsupportedContentTypeError as ire:
+            self.assertIn(expected_content_type, ire.description)
+
     def test_invalid_post_request(self):
         self.validator.authenticate_client.side_effect = self.set_client
         for param in ['token', 'secret', 'code', 'foo']:


### PR DESCRIPTION
This change introduces explicit validation of the Content-Type header for token endpoint requests. When the request’s Content-Type does not match the expected value, it now raises a clear and descriptive error.

[Issue #928 – oauthlib/oauthlib](https://github.com/oauthlib/oauthlib/issues/928)
