### PR TITLE
Fix `JWTToken.estimate_type` to defer JWT access tokens to `BearerToken`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -56,3 +56,4 @@ Nemanja Tozic
 Kohki Yamagiwa
 Arie Bovenberg
 Sebastian Chnelik
+Juan Gutierrez

--- a/oauthlib/openid/connect/core/tokens.py
+++ b/oauthlib/openid/connect/core/tokens.py
@@ -54,7 +54,9 @@ class JWTToken(TokenBase):
 def is_jwt_access_token(token):
     try:
         header_b64 = token.split('.')[0]
-        header_b64 += '=' * (-len(header_b64) % 4)  # add missing padding
+        rem = len(header_b64) % 4
+        if rem > 0:
+            header_b64 += "=" * (4 - rem)
         header = json.loads(base64.urlsafe_b64decode(header_b64))
         if header.get('typ', '').lower() in ('at+jwt', 'application/at+jwt',):
             return True

--- a/oauthlib/openid/connect/core/tokens.py
+++ b/oauthlib/openid/connect/core/tokens.py
@@ -42,6 +42,8 @@ class JWTToken(TokenBase):
             token, request.scopes, request)
 
     def estimate_type(self, request):
+        """Determine if a given token should be handled by JWTToken or BearerToken"""
+
         token = get_token_from_header(request)
         if token and token.startswith('ey') and token.count('.') in (2, 4):
             if is_jwt_access_token(token):
@@ -52,6 +54,7 @@ class JWTToken(TokenBase):
 
 
 def is_jwt_access_token(token):
+    """Determine if a given token is a JWT access token or ID token"""
     try:
         header_b64 = token.split('.')[0]
         rem = len(header_b64) % 4

--- a/oauthlib/openid/connect/core/tokens.py
+++ b/oauthlib/openid/connect/core/tokens.py
@@ -4,6 +4,9 @@ authlib.openid.connect.core.tokens
 
 This module contains methods for adding JWT tokens to requests.
 """
+import base64
+import json
+
 from oauthlib.oauth2.rfc6749.tokens import (
     TokenBase, get_token_from_header, random_token_generator,
 )
@@ -41,5 +44,20 @@ class JWTToken(TokenBase):
     def estimate_type(self, request):
         token = get_token_from_header(request)
         if token and token.startswith('ey') and token.count('.') in (2, 4):
+            if is_jwt_access_token(token):
+                # Let BearerToken handle it
+                return 0
             return 10
         return 0
+
+
+def is_jwt_access_token(token):
+    try:
+        header_b64 = token.split('.')[0]
+        header_b64 += '=' * (-len(header_b64) % 4)  # add missing padding
+        header = json.loads(base64.urlsafe_b64decode(header_b64))
+        if header.get('typ', '').lower() in ('at+jwt', 'application/at+jwt',):
+            return True
+    except (ValueError, KeyError):
+        return False
+    return False

--- a/tests/openid/connect/core/test_tokens.py
+++ b/tests/openid/connect/core/test_tokens.py
@@ -164,7 +164,7 @@ class JWTTokenTestCase(TestCase):
         """
         def test_token(token, expected_result):
             encoded_header = base64.urlsafe_b64encode(
-                json.dumps(token_header).encode()
+                json.dumps(token).encode()
             ).rstrip(b"=").decode()
             encoded_token = f'{encoded_header}.payload.signature'
 

--- a/tests/openid/connect/core/test_tokens.py
+++ b/tests/openid/connect/core/test_tokens.py
@@ -163,6 +163,11 @@ class JWTTokenTestCase(TestCase):
         JWT access tokens should be estimated 0, so they get handled by BearerToken
         """
         def test_token(token, expected_result):
+            encoded_header = base64.urlsafe_b64encode(
+                json.dumps(token_header).encode()
+            ).rstrip(b"=").decode()
+            encoded_token = f'{encoded_header}.payload.signature'
+
             with mock.patch('oauthlib.common.Request', autospec=True) as RequestMock:
                 jwt_token = JWTToken()
 
@@ -170,23 +175,20 @@ class JWTTokenTestCase(TestCase):
                 # Scopes is retrieved using the __call__ method which is not picked up correctly by mock.patch
                 # with autospec=True
                 request.headers = {
-                    'Authorization': 'Bearer {}'.format(token)
+                    'Authorization': 'Bearer {}'.format(encoded_token)
                 }
 
                 result = jwt_token.estimate_type(request=request)
 
-                self.assertEqual(result, expected_result)
+                self.assertEqual(result, expected_result, token)
 
         test_items = (
-            ({"alg": "RS256", "typ": "application/at+jwt"}, 0),
-            ({"alg": "RS256", "typ": "at+jwt"}, 0),
-            ({"alg": "RS256", "typ": "jwt"}, 10),
-            ({"alg": "RS256"}, 10),
+            ({"alg": "RS256", "kid": "12345", "typ": "application/at+jwt"}, 0),
+            ({"alg": "RS256", "kid": "12345", "typ": "at+jwt"}, 0),
+            ({"alg": "RS256", "kid": "12345", "typ": "jwt"}, 10),
+            ({"alg": "RS256", "kid": "12345"}, 10),
         )
 
         for token_header, expected_result in test_items:
             # base64 encoding without padding
-            encoded_header = base64.urlsafe_b64encode(
-                json.dumps(token_header).encode()
-            ).rstrip(b"=").decode()
-            test_token(f'{encoded_header}.payload.signature', expected_result)
+            test_token(token_header, expected_result)

--- a/tests/openid/connect/core/test_tokens.py
+++ b/tests/openid/connect/core/test_tokens.py
@@ -1,3 +1,5 @@
+import base64
+import json
 from unittest import mock
 
 from oauthlib.openid.connect.core.tokens import JWTToken
@@ -155,3 +157,36 @@ class JWTTokenTestCase(TestCase):
 
         for token, expected_result in test_items:
             test_token(token, expected_result)
+
+    def test_jwt_access_token(self):
+        """
+        JWT access tokens should be estimated 0, so they get handled by BearerToken
+        """
+        def test_token(token, expected_result):
+            with mock.patch('oauthlib.common.Request', autospec=True) as RequestMock:
+                jwt_token = JWTToken()
+
+                request = RequestMock('/uri')
+                # Scopes is retrieved using the __call__ method which is not picked up correctly by mock.patch
+                # with autospec=True
+                request.headers = {
+                    'Authorization': 'Bearer {}'.format(token)
+                }
+
+                result = jwt_token.estimate_type(request=request)
+
+                self.assertEqual(result, expected_result)
+
+        test_items = (
+            ({"alg": "RS256", "typ": "application/at+jwt"}, 0),
+            ({"alg": "RS256", "typ": "at+jwt"}, 0),
+            ({"alg": "RS256", "typ": "jwt"}, 10),
+            ({"alg": "RS256"}, 10),
+        )
+
+        for token_header, expected_result in test_items:
+            # base64 encoding without padding
+            encoded_header = base64.urlsafe_b64encode(
+                json.dumps(token_header).encode()
+            ).rstrip(b"=").decode()
+            test_token(f'{encoded_header}.payload.signature', expected_result)


### PR DESCRIPTION
Fixes #939

### Summary

- `JWTToken.estimate_type` now peeks at the unverified JOSE `typ` header and returns 0 for RFC 9068 JWT access tokens (`at+jwt`, `application/at+jwt`), allowing `BearerToken` to handle them
- Adds `is_jwt_access_token` helper using stdlib base64/json decoding (no new dependencies)
- Adds test cases covering both `at+jwt` tokens (should return 0) and regular JWTs (should still return 10)

### Test plan

- Existing `test_estimate_type` still passes (no regression for ID tokens / regular JWTs)
- New `test_jwt_access_token` verifies `at+jwt`` and `application/at+jwt`` tokens return 0
- `ruff check .` passes
- Full test suite passes across Python versions
