### PR TITLE
docs: Clarify return values of introspect_token()

### DIFF
--- a/oauthlib/oauth2/rfc6749/request_validator.py
+++ b/oauthlib/oauth2/rfc6749/request_validator.py
@@ -189,7 +189,11 @@ class RequestValidator:
         Called once the introspect request is validated. This method should
         validate the *token*. If the token is currently active, this should return
         a dictionary with the claims associated. If the token is for any reason
-        not active (expired, unknown, etc.), this should return `None`.
+        not active (expired, unknown, etc.), this should return `None`. The
+        introspection endpoint will then treat any non-``None`` return value as
+        an active token, force ``"active": true`` in the response, and ignore or
+        remove any ``"active"`` key provided by this method (so returning
+        ``{"active": false, ...}`` will not work to mark a token as inactive).
 
         Below the list of registered claims you should be interested in:
 

--- a/oauthlib/oauth2/rfc6749/request_validator.py
+++ b/oauthlib/oauth2/rfc6749/request_validator.py
@@ -187,8 +187,9 @@ class RequestValidator:
         """Introspect an access or refresh token.
 
         Called once the introspect request is validated. This method should
-        verify the *token* and either return a dictionary with the list of
-        claims associated, or `None` in case the token is unknown.
+        validate the *token*. If the token is currently active, this should return
+        a dictionary with the claims associated. If the token is for any reason
+        not active (expired, unknown, etc.), this should return `None`.
 
         Below the list of registered claims you should be interested in:
 


### PR DESCRIPTION
I was trying to implement a token introspection endpoint with the following flavor:

* For debuggability, I wanted to return metadata about tokens that are expired now but were once valid. I acknowledge that this is discouraged (`SHOULD NOT`) in https://datatracker.ietf.org/doc/html/rfc7662.
* I wanted to return metadata about refresh tokens, but with `"active": false` to prevent downstream resource servers from misinterpreting them as valid access tokens. (The RFC leaves it unclear how the token introspection endpoint ought to distinguish refresh tokens from access tokens. This was just my guess. Maybe there's a better way.)

Here was my implementation attempt, which has a bug:

```python
class RequestValidator(oauthlib.oauth2.RequestValidator):
    ...
    
    def introspect_token(
        self,
        token: str,
        token_type_hint: str | None,
        request: oauthlib.common.Request,
    ) -> dict[str, str] | None:
        """Return information about an access or refresh token (if it exists)."""
        found_token_info = ...   # Implementation omitted.

        if found_token is None:
            return None
        else:
            active = (
                found_token_info.type == "access"  # not "refresh"
                and found_token.expires_at > datetime.now()
            )
            return {
                "active": active  # <-- Bug!
                "scope": found_token_info.scope,
                "username": found_token_info.username,
            }
```

The bug in that code is that returning `active: False` does not actually do anything. oauthlib always overrides `active` to `True`. The only way to return `"active": false` over HTTP is for the Python code to return `None`.

https://github.com/oauthlib/oauthlib/blob/a4689bedd616597f7fc4d5b0a7070f64a0d5feff/oauthlib/oauth2/rfc6749/endpoints/introspect.py#L76-L80

That wasn't clear in the oauthlib documentation, so this updates it.

(Documentation aside, I think this behavior is unfortunate because it prevents us from deliberately returning extra information about inactive tokens, but maybe that's just a bad thing to want to do.)