### PR TITLE
Fix #776: raise_from_error raises base class, not a random subclass

### DIFF
--- a/oauthlib/oauth2/rfc6749/errors.py
+++ b/oauthlib/oauth2/rfc6749/errors.py
@@ -394,6 +394,6 @@ def raise_from_error(error, params=None):
         'state': params.get('state')
     }
     for _, cls in inspect.getmembers(sys.modules[__name__], inspect.isclass):
-        if cls.error == error:
+        if cls.__dict__.get('error') == error:
             raise cls(**kwargs)
     raise CustomOAuth2Error(error=error, **kwargs)

--- a/tests/oauth2/rfc6749/test_parameters.py
+++ b/tests/oauth2/rfc6749/test_parameters.py
@@ -219,7 +219,7 @@ class ParameterTests(TestCase):
                 self.error_nocode)
         self.assertRaises(AccessDeniedError, parse_authorization_code_response,
                 self.error_denied)
-        self.assertRaises(InvalidRequestFatalError, parse_authorization_code_response,
+        self.assertRaises(InvalidRequestError, parse_authorization_code_response,
                 self.error_invalid)
         self.assertRaises(MismatchingStateError, parse_authorization_code_response,
                 self.error_nostate, state=self.state)
@@ -329,3 +329,12 @@ class ParameterTests(TestCase):
                     "expires_at": arg[1]
                 }
                 self.assertEqual(expected, parse_expires(params))
+
+    def test_raise_from_error_base_class_only(self):
+        # raise_from_error should raise the base class for the given error
+        # code, not a random subclass that happens to inherit it.
+        # InvalidClientIdError(InvalidRequestFatalError) was being raised
+        # for 'invalid_request' because it sorts first alphabetically.
+        self.assertRaises(InvalidRequestError, raise_from_error, 'invalid_request', {})
+        self.assertRaises(AccessDeniedError, raise_from_error, 'access_denied', {})
+        self.assertRaises(InvalidClientError, raise_from_error, 'invalid_client', {})


### PR DESCRIPTION
Fixes #776.

`raise_from_error` iterates all classes in the module with `inspect.getmembers` and raises the first one where `cls.error == error`. The problem is that subclasses inherit the `error` attribute from their parent, so subclasses like `InvalidClientIdError` and `MissingRedirectURIError` all match `invalid_request` just as well as `InvalidRequestError` does.

`inspect.getmembers` returns names in alphabetical order, so `InvalidClientIdError` (C < R) ends up getting raised for a generic `invalid_request` response - which is both confusing and wrong.

The fix is one character: `cls.__dict__.get("error")` instead of `cls.error`. This only matches classes that define the attribute directly, so subclasses that merely inherit it are skipped. For `invalid_request`, that leaves `InvalidRequestError` and `InvalidRequestFatalError` as candidates; `InvalidRequestError` is raised since it sorts first.

Updated the existing assertion in `test_grant_response` which was inadvertently passing (it checked for `InvalidRequestFatalError`, which is a superclass of `InvalidClientIdError`). Added `test_raise_from_error_base_class_only` to directly cover the behavior.
