### PR TITLE
fix(errors): prefer leaf exception classes in raise_from_error for shared error codes

### DIFF
--- a/oauthlib/oauth2/rfc6749/errors.py
+++ b/oauthlib/oauth2/rfc6749/errors.py
@@ -398,8 +398,9 @@ def raise_from_error(error, params=None):
         if cls.error == error
     ]
     # When multiple classes share the same error code (e.g. invalid_request),
-    # prefer leaf classes over base classes to avoid raising a misleading
-    # exception like InvalidClientIdError for an unrelated invalid_request.
+    # filter out base classes if more specific subclasses also match. If
+    # multiple leaf classes still match, the later selection remains dependent
+    # on inspect.getmembers ordering.
     if len(matching) > 1:
         matching_names = {cls.__name__ for cls in matching}
         matching = [

--- a/oauthlib/oauth2/rfc6749/errors.py
+++ b/oauthlib/oauth2/rfc6749/errors.py
@@ -393,7 +393,20 @@ def raise_from_error(error, params=None):
         'uri': params.get('error_uri'),
         'state': params.get('state')
     }
-    for _, cls in inspect.getmembers(sys.modules[__name__], inspect.isclass):
-        if cls.error == error:
-            raise cls(**kwargs)
+    matching = [
+        cls for _, cls in inspect.getmembers(sys.modules[__name__], inspect.isclass)
+        if cls.error == error
+    ]
+    # When multiple classes share the same error code (e.g. invalid_request),
+    # prefer leaf classes over base classes to avoid raising a misleading
+    # exception like InvalidClientIdError for an unrelated invalid_request.
+    if len(matching) > 1:
+        matching_names = {cls.__name__ for cls in matching}
+        matching = [
+            cls for cls in matching
+            if not any(issubclass(sub, cls) and sub.__name__ in matching_names and sub is not cls
+                       for sub in matching)
+        ]
+    for cls in matching:
+        raise cls(**kwargs)
     raise CustomOAuth2Error(error=error, **kwargs)


### PR DESCRIPTION
## Summary

When multiple OAuth2 error classes share the same error code (e.g. `invalid_request`), `raise_from_error` would raise whichever class it encountered first during `inspect.getmembers` iteration. This could produce misleading exceptions — for instance, raising `InvalidClientIdError` for an `invalid_request` error that is actually about a missing parameter.

Fixes #776

## Details

The error class hierarchy has two base classes that define `error = 'invalid_request'`:

- `InvalidRequestFatalError` (fatal) with subclasses: InvalidRedirectURIError, MissingRedirectURIError, MismatchingRedirectURIError, InvalidClientIdError, MissingClientIdError
- `InvalidRequestError` (non-fatal) with subclasses: MissingResponseTypeError, MissingCodeChallengeError, MissingCodeVerifierError, UnsupportedCodeChallengeMethodError

Since all these classes share the same error code, the original code would raise a semi-random one depending on iteration order. The fix collects all matching classes and filters to prefer leaf (most specific) classes over base classes, so the caller gets a more accurate exception type.