### PR TITLE
Remove JSONP support from token revocation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,9 @@ Changelog
 
 WIP
 ---
+OAuth2.0 Provider:
+* **Breaking**: Removed JSONP support from token revocation endpoint. JSONP has been superseded by CORS for cross-origin requests. The ``enable_jsonp`` parameter has been removed from ``RevocationEndpoint`` and the ``callback`` parameter has been removed from ``prepare_token_revocation_request``.
+
 Misc:
 * #930: Add devcontainer, Add Python3.14, Python3.14t.
 

--- a/oauthlib/oauth2/rfc6749/clients/base.py
+++ b/oauthlib/oauth2/rfc6749/clients/base.py
@@ -350,6 +350,9 @@ class Client:
         if not is_secure_transport(revocation_url):
             raise InsecureTransportError()
 
+        if 'callback' in kwargs:
+            raise TypeError("prepare_token_revocation_request() got an unexpected keyword argument 'callback'")
+
         return prepare_token_revocation_request(revocation_url, token,
                                                 token_type_hint=token_type_hint, body=body,
                                                 **kwargs)

--- a/oauthlib/oauth2/rfc6749/clients/base.py
+++ b/oauthlib/oauth2/rfc6749/clients/base.py
@@ -320,7 +320,7 @@ class Client:
         return token_url, FORM_ENC_HEADERS, body
 
     def prepare_token_revocation_request(self, revocation_url, token,
-                                         token_type_hint="access_token", body='', callback=None, **kwargs):
+                                         token_type_hint="access_token", body='', **kwargs):
         """Prepare a token revocation request.
 
         :param revocation_url: Provider token revocation endpoint URL.
@@ -329,13 +329,8 @@ class Client:
             ``"refresh_token"``. This is optional and if you wish to not pass it you
             must provide ``token_type_hint=None``.
         :param body:
-        :param callback: A jsonp callback such as ``package.callback`` to be invoked
-            upon receiving the response. Not that it should not include a () suffix.
         :param kwargs: Additional parameters to included in the request.
         :returns: The prepared request tuple with (url, headers, body).
-
-        Note that JSONP request may use GET requests as the parameters will
-        be added to the request URL query as opposed to the request body.
 
         An example of a revocation request
 
@@ -348,21 +343,6 @@ class Client:
 
             token=45ghiukldjahdnhzdauz&token_type_hint=refresh_token
 
-        An example of a jsonp revocation request
-
-        .. code-block:: http
-
-            GET /revoke?token=agabcdefddddafdd&callback=package.myCallback HTTP/1.1
-            Host: server.example.com
-            Content-Type: application/x-www-form-urlencoded
-            Authorization: Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW
-
-        and an error response
-
-        .. code-block:: javascript
-
-            package.myCallback({"error":"unsupported_token_type"});
-
         Note that these requests usually require client credentials, client_id in
         the case for public clients and provider specific authentication
         credentials for confidential clients.
@@ -371,7 +351,7 @@ class Client:
             raise InsecureTransportError()
 
         return prepare_token_revocation_request(revocation_url, token,
-                                                token_type_hint=token_type_hint, body=body, callback=callback,
+                                                token_type_hint=token_type_hint, body=body,
                                                 **kwargs)
 
     def parse_request_body_response(self, body, scope=None, **kwargs):

--- a/oauthlib/oauth2/rfc6749/endpoints/revocation.py
+++ b/oauthlib/oauth2/rfc6749/endpoints/revocation.py
@@ -27,13 +27,11 @@ class RevocationEndpoint(BaseEndpoint):
     valid_token_types = ('access_token', 'refresh_token')
     valid_request_methods = ('POST',)
 
-    def __init__(self, request_validator, supported_token_types=None,
-            enable_jsonp=False):
+    def __init__(self, request_validator, supported_token_types=None):
         BaseEndpoint.__init__(self)
         self.request_validator = request_validator
         self.supported_token_types = (
             supported_token_types or self.valid_token_types)
-        self.enable_jsonp = enable_jsonp
 
     @catch_errors_and_unavailability
     def create_revocation_response(self, uri, http_method='POST', body=None,
@@ -69,18 +67,13 @@ class RevocationEndpoint(BaseEndpoint):
         except OAuth2Error as e:
             log.debug('Client error during validation of %r. %r.', request, e)
             response_body = e.json
-            if self.enable_jsonp and request.callback:
-                response_body = '{}({});'.format(request.callback, response_body)
             resp_headers.update(e.headers)
             return resp_headers, response_body, e.status_code
 
         self.request_validator.revoke_token(request.token,
                                             request.token_type_hint, request)
 
-        response_body = ''
-        if self.enable_jsonp and request.callback:
-            response_body = request.callback + '();'
-        return {}, response_body, 200
+        return {}, '', 200
 
     def validate_revocation_request(self, request):
         """Ensure the request is valid.

--- a/oauthlib/oauth2/rfc6749/parameters.py
+++ b/oauthlib/oauth2/rfc6749/parameters.py
@@ -172,7 +172,7 @@ def prepare_token_request(grant_type, body='', include_client_id=True, code_veri
 
 
 def prepare_token_revocation_request(url, token, token_type_hint="access_token",
-        callback=None, body='', **kwargs):
+        body='', **kwargs):
     """Prepare a token revocation request.
 
     The client constructs the request by including the following parameters
@@ -222,11 +222,7 @@ def prepare_token_revocation_request(url, token, token_type_hint="access_token",
 
     headers = {'Content-Type': 'application/x-www-form-urlencoded'}
 
-    if callback:
-        params.append(('callback', callback))
-        return add_params_to_uri(url, params), headers, body
-    else:
-        return url, headers, add_params_to_qs(body, params)
+    return url, headers, add_params_to_qs(body, params)
 
 
 def parse_authorization_code_response(uri, state=None):

--- a/oauthlib/oauth2/rfc6749/parameters.py
+++ b/oauthlib/oauth2/rfc6749/parameters.py
@@ -216,6 +216,9 @@ def prepare_token_revocation_request(url, token, token_type_hint="access_token",
     if token_type_hint:
         params.append(('token_type_hint', token_type_hint))
 
+    if 'callback' in kwargs:
+        raise TypeError("prepare_token_revocation_request() got an unexpected keyword argument 'callback'")
+
     for k in kwargs:
         if kwargs[k]:
             params.append((str(k), kwargs[k]))

--- a/tests/oauth2/rfc6749/clients/test_base.py
+++ b/tests/oauth2/rfc6749/clients/test_base.py
@@ -237,13 +237,6 @@ class ClientTest(TestCase):
         self.assertEqual(h, {'Content-Type': 'application/x-www-form-urlencoded'})
         self.assertEqual(b, 'token=%s&token_type_hint=refresh_token' % token)
 
-        # JSONP
-        u, h, b = client.prepare_token_revocation_request(
-            url, token, callback='hello.world')
-        self.assertURLEqual(u, url + '?callback=hello.world&token=%s&token_type_hint=access_token' % token)
-        self.assertEqual(h, {'Content-Type': 'application/x-www-form-urlencoded'})
-        self.assertEqual(b, '')
-
     def test_prepare_authorization_request(self):
         redirect_url = 'https://example.com/callback/'
         scopes = 'read'

--- a/tests/oauth2/rfc6749/endpoints/test_revocation_endpoint.py
+++ b/tests/oauth2/rfc6749/endpoints/test_revocation_endpoint.py
@@ -88,19 +88,6 @@ class RevocationEndpointTest(TestCase):
         self.assertEqual(loads(b)['error'], 'invalid_client')
         self.assertEqual(s, 401)
 
-    def test_revoke_with_callback(self):
-        endpoint = RevocationEndpoint(self.validator, enable_jsonp=True)
-        callback = 'package.hello_world'
-        for token_type in ('access_token', 'refresh_token', 'invalid'):
-            body = urlencode([('token', 'foo'),
-                              ('token_type_hint', token_type),
-                              ('callback', callback)])
-            h, b, s = endpoint.create_revocation_response(self.uri,
-                    headers=self.headers, body=body)
-            self.assertEqual(h, {})
-            self.assertEqual(b, callback + '();')
-            self.assertEqual(s, 200)
-
     def test_revoke_unsupported_token(self):
         endpoint = RevocationEndpoint(self.validator,
                                       supported_token_types=['access_token'])

--- a/tests/oauth2/rfc6749/test_parameters.py
+++ b/tests/oauth2/rfc6749/test_parameters.py
@@ -208,6 +208,14 @@ class ParameterTests(TestCase):
         self.assertFormBodyEqual(prepare_token_request(**self.cred_grant), self.cred_body)
         self.assertFormBodyEqual(prepare_token_request(**self.grant_body_pkce), self.auth_grant_body_pkce)
 
+    def test_prepare_token_revocation_request_rejects_callback(self):
+        with self.assertRaisesRegex(
+                TypeError,
+                "prepare_token_revocation_request\\(\\) got an unexpected keyword argument 'callback'"):
+            prepare_token_revocation_request(
+                "https://server.example.com/revoke", "token", callback="jsonp"
+            )
+
     def test_grant_response(self):
         """Verify correct parameter parsing and validation for auth code responses."""
         params = parse_authorization_code_response(self.grant_response)


### PR DESCRIPTION
JSONP was useful in the past for cross-origin requests but has been superseded by CORS browser protections. This change removes the outdated JSONP functionality.

## Breaking Changes
- Remove `enable_jsonp` parameter from `RevocationEndpoint`
- Remove `callback` parameter from `prepare_token_revocation_request`
- Remove JSONP documentation and examples
- Remove JSONP tests

## Changes
- **RevocationEndpoint**: No longer accepts `enable_jsonp` parameter in constructor
- **Token revocation responses**: Returns empty string on success instead of JSONP-wrapped responses
- **Client API**: `prepare_token_revocation_request` no longer accepts `callback` parameter
- **Documentation**: Removed JSONP examples and references

## Migration Guide
If you were using JSONP:
```python
# Before
endpoint = RevocationEndpoint(validator, enable_jsonp=True)

# After
endpoint = RevocationEndpoint(validator)
# Use CORS headers instead of JSONP for cross-origin requests
```

## Rationale
Modern browsers have comprehensive CORS support, making JSONP unnecessary and potentially insecure. JSONP opens up security vulnerabilities that CORS specifically addresses.

## Tests
All existing tests pass with the JSONP-specific tests removed.