### PR TITLE
fix implicit grant: set response_mode before non-fatal errors

### DIFF
--- a/oauthlib/oauth2/rfc6749/grant_types/implicit.py
+++ b/oauthlib/oauth2/rfc6749/grant_types/implicit.py
@@ -305,6 +305,11 @@ class ImplicitGrant(GrantTypeBase):
         # https://tools.ietf.org/html/rfc6749#section-3.1.2
         self._handle_redirects(request)
 
+        # Non-fatal errors must be returned via the fragment per RFC 6749 section 4.2.2.1.
+        # Set the response_mode now so that any OAuth2Error raised below carries the
+        # correct mode when the caller uses error.in_uri() or error.response_mode.
+        request.response_mode = request.response_mode or self.default_response_mode
+
         # Then check for normal errors.
 
         request_info = self._run_custom_validators(request,

--- a/tests/oauth2/rfc6749/grant_types/test_implicit.py
+++ b/tests/oauth2/rfc6749/grant_types/test_implicit.py
@@ -64,8 +64,7 @@ class ImplicitGrantTest(TestCase):
 
     def test_validate_authorization_request_unauthorized_client_in_fragment(self):
         self.mock_validator.validate_response_type.return_value = False
-        try:
+        with self.assertRaises(errors.UnauthorizedClientError) as cm:
             self.auth.validate_authorization_request(self.request)
-        except errors.UnauthorizedClientError as e:
-            self.assertEqual(e.response_mode, 'fragment')
-            self.assertIn('#', e.in_uri(self.request.redirect_uri))
+        self.assertEqual(cm.exception.response_mode, 'fragment')
+        self.assertIn('#', cm.exception.in_uri(self.request.redirect_uri))

--- a/tests/oauth2/rfc6749/grant_types/test_implicit.py
+++ b/tests/oauth2/rfc6749/grant_types/test_implicit.py
@@ -2,6 +2,7 @@
 from unittest import mock
 
 from oauthlib.common import Request
+from oauthlib.oauth2.rfc6749 import errors
 from oauthlib.oauth2.rfc6749.grant_types import ImplicitGrant
 from oauthlib.oauth2.rfc6749.tokens import BearerToken
 
@@ -60,3 +61,11 @@ class ImplicitGrantTest(TestCase):
 
     def test_error_response(self):
         pass
+
+    def test_validate_authorization_request_unauthorized_client_in_fragment(self):
+        self.mock_validator.validate_response_type.return_value = False
+        try:
+            self.auth.validate_authorization_request(self.request)
+        except errors.UnauthorizedClientError as e:
+            self.assertEqual(e.response_mode, 'fragment')
+            self.assertIn('#', e.in_uri(self.request.redirect_uri))


### PR DESCRIPTION
Fixes #814

When `validate_authorization_request` raises a non-fatal `OAuth2Error` during the implicit grant flow, the error's `response_mode` was `None` because `request.response_mode` had not yet been set. Callers using `error.in_uri()` got the error in the query string instead of the fragment, violating RFC 6749 section 4.2.2.1.

The fix sets `request.response_mode` to the grant's `default_response_mode` ("fragment") right after `_handle_redirects`, before any non-fatal errors can be raised.