### PR TITLE
fix: merge signedtoken extras into rsa extras so RSA features work (closes #721)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ def fread(fn):
         return f.read()
 
 
-rsa_require = ['cryptography>=3.0.0']
-signedtoken_require = ['cryptography>=3.0.0', 'pyjwt>=2.0.0,<3']
+rsa_require = ['cryptography>=3.0.0', 'pyjwt>=2.0.0,<3']
+signedtoken_require = rsa_require
 signals_require = ['blinker>=1.4.0']
 
 setup(


### PR DESCRIPTION
## What

The `rsa` extras only installed `cryptography` but not `pyjwt`, which is required for the OAuth 1.0a RSA-SHA1 signature method and RS256 tokens (OAuth 2.0) to work. Users who installed `oauthlib[rsa]` would get a `ModuleNotFoundError: No module named 'jwt'` when trying to use RSA features.

## Fix

Merge `pyjwt` into the `rsa` extras so that `pip install oauthlib[rsa]` installs all dependencies needed for RSA features to work. The `signedtoken` extras is kept as an alias (pointing to the same requirements as `rsa`) for backwards compatibility with existing users who rely on it.

Closes #721