### PR TITLE
Reject duplicate authorization response parameters

### DIFF
--- a/oauthlib/oauth2/rfc6749/parameters.py
+++ b/oauthlib/oauth2/rfc6749/parameters.py
@@ -15,8 +15,9 @@ from oauthlib.common import add_params_to_qs, add_params_to_uri
 from oauthlib.signals import scope_changed
 
 from .errors import (
-    InsecureTransportError, MismatchingStateError, MissingCodeError,
-    MissingTokenError, MissingTokenTypeError, raise_from_error,
+    InsecureTransportError, InvalidRequestError, MismatchingStateError,
+    MissingCodeError, MissingTokenError, MissingTokenTypeError,
+    raise_from_error,
 )
 from .tokens import OAuth2Token
 from .utils import is_secure_transport, list_to_scope, scope_to_list
@@ -271,7 +272,23 @@ def parse_authorization_code_response(uri, state=None):
         raise InsecureTransportError()
 
     query = urlparse.urlparse(uri).query
-    params = dict(urlparse.parse_qsl(query))
+    pairs = urlparse.parse_qsl(query)
+
+    # Security-sensitive authorization response parameters are single-valued.
+    # A redirect URI that repeats one of them (for example two ``code`` or two
+    # ``state`` values) is ambiguous: ``dict(...)`` would silently keep just one
+    # value, which can disagree with what a proxy, log, or framework upstream
+    # treated as authoritative. Reject the response instead of collapsing it.
+    single_valued = ('code', 'state', 'error', 'error_description', 'error_uri')
+    seen = set()
+    for key, _value in pairs:
+        if key in single_valued:
+            if key in seen:
+                raise InvalidRequestError(
+                    description="Duplicate %s parameter in response." % key)
+            seen.add(key)
+
+    params = dict(pairs)
 
     if state and params.get('state') != state:
         raise MismatchingStateError()

--- a/tests/oauth2/rfc6749/test_parameters.py
+++ b/tests/oauth2/rfc6749/test_parameters.py
@@ -93,6 +93,12 @@ class ParameterTests(TestCase):
     error_wrongstate = 'https://client.example.com/cb?code=SplxlOBeZQQYbYS6WxSbIA&state=abc'
     error_denied = 'https://client.example.com/cb?error=access_denied&state=xyz'
     error_invalid = 'https://client.example.com/cb?error=invalid_request&state=xyz'
+    error_dup_code = ('https://client.example.com/cb?code=GOOD_CODE&'
+                      'code=EVIL_CODE&state=xyz')
+    error_dup_state = ('https://client.example.com/cb?'
+                       'code=SplxlOBeZQQYbYS6WxSbIA&state=xyz&state=abc')
+    error_dup_error = ('https://client.example.com/cb?error=access_denied&'
+                       'error=invalid_request&state=xyz')
 
     implicit_base = 'https://example.com/cb#access_token=2YotnFZFEjr1zCsicMWpAA&scope=abc&'
     implicit_response = implicit_base + 'state={}&token_type=example&expires_in=3600'.format(state)
@@ -225,6 +231,16 @@ class ParameterTests(TestCase):
                 self.error_nostate, state=self.state)
         self.assertRaises(MismatchingStateError, parse_authorization_code_response,
                 self.error_wrongstate, state=self.state)
+
+        # Duplicate security-sensitive response parameters are ambiguous and
+        # must be rejected instead of being collapsed to a single value. See
+        # https://github.com/oauthlib/oauthlib/issues/948
+        self.assertRaises(InvalidRequestError, parse_authorization_code_response,
+                self.error_dup_code)
+        self.assertRaises(InvalidRequestError, parse_authorization_code_response,
+                self.error_dup_state)
+        self.assertRaises(InvalidRequestError, parse_authorization_code_response,
+                self.error_dup_error)
 
     def test_implicit_token_response(self):
         """Verify correct parameter parsing and validation for implicit responses."""


### PR DESCRIPTION
Fixes #948

## Problem

`parse_authorization_code_response` (used by `WebApplicationClient.parse_request_uri_response`) builds its result with `dict(parse_qsl(query))`. Because `dict()` collapses repeated keys with last-wins semantics, a redirect URI that repeats a security-sensitive parameter is silently accepted and one value is kept with no error.

Reproduction on the current `master` (and on released 3.3.1):

```python
from oauthlib.oauth2 import WebApplicationClient

uri = "https://client.example/callback?code=GOOD_CODE&code=EVIL_CODE&state=EXPECTED_STATE"
client = WebApplicationClient(client_id="client-id")
print(client.parse_request_uri_response(uri, state="EXPECTED_STATE"))
# -> {'code': 'EVIL_CODE', 'state': 'EXPECTED_STATE'}
```

The second `code` wins and nothing is raised. This is the hardening gap described in #948: when a duplicated parameter is collapsed silently, different components in the request path (a reverse proxy, a logger, the web framework, and oauthlib) can disagree about which `code`/`state`/`error` value is authoritative, which makes the callback harder to audit and can lead to integration mistakes.

## Fix

Before constructing the result dict, walk the parsed `(key, value)` pairs and reject the response if any single-valued authorization response parameter appears more than once. The set matches the issue's suggestion: `code`, `state`, `error`, `error_description`, `error_uri`.

A repeated parameter now raises `InvalidRequestError` (the error class the issue suggested, whose `invalid_request` code already covers a request that "includes a parameter more than once"). Responses that carry each parameter at most once are unaffected, so existing valid flows keep working.

## Before / after

Before: `?code=GOOD_CODE&code=EVIL_CODE&state=xyz` parses to `{'code': 'EVIL_CODE', 'state': 'xyz'}` with no error.

After: the same URI raises `InvalidRequestError("(invalid_request) Duplicate code parameter in response.")`. A normal single-value response such as `?code=GOOD_CODE&state=xyz` still returns `{'code': 'GOOD_CODE', 'state': 'xyz'}`.

## Tests

Added duplicate-`code`, duplicate-`state`, and duplicate-`error` rejection cases to `test_grant_response` in `tests/oauth2/rfc6749/test_parameters.py`, alongside the existing valid-path assertions. Reverting the source change makes the new assertions fail, and the full `tests/oauth2/rfc6749/` suite passes with the change in place.

## Notes

This only changes the authorization-code response parser. The implicit and token-response parsers were left as-is to keep the change focused on the reported path; happy to extend the same check to those if you would prefer it applied consistently.
