### PR TITLE
Return a fresh headers dict from prepare_*_request

### DIFF
--- a/oauthlib/oauth2/rfc6749/clients/base.py
+++ b/oauthlib/oauth2/rfc6749/clients/base.py
@@ -32,6 +32,16 @@ FORM_ENC_HEADERS = {
 }
 
 
+def _form_enc_headers():
+    """Return a fresh copy of the form-encoded headers.
+
+    A new dict is returned on every call so that callers mutating the
+    headers they receive from ``prepare_*_request`` do not corrupt the
+    shared module-level constant or leak into later calls (see #873).
+    """
+    return dict(FORM_ENC_HEADERS)
+
+
 class Client:
     """Base OAuth2 client responsible for access token management.
 
@@ -254,7 +264,7 @@ class Client:
         auth_url = self.prepare_request_uri(
             authorization_url, redirect_uri=self.redirect_url,
             scope=scope, state=self.state, **kwargs)
-        return auth_url, FORM_ENC_HEADERS, ''
+        return auth_url, _form_enc_headers(), ''
 
     def prepare_token_request(self, token_url, authorization_response=None,
                               redirect_url=None, state=None, body='', **kwargs):
@@ -288,7 +298,7 @@ class Client:
         body = self.prepare_request_body(body=body,
                                          redirect_uri=self.redirect_url, **kwargs)
 
-        return token_url, FORM_ENC_HEADERS, body
+        return token_url, _form_enc_headers(), body
 
     def prepare_refresh_token_request(self, token_url, refresh_token=None,
                                       body='', scope=None, **kwargs):
@@ -317,7 +327,7 @@ class Client:
         scope = self.scope if scope is None else scope
         body = self.prepare_refresh_body(body=body,
                                          refresh_token=refresh_token, scope=scope, **kwargs)
-        return token_url, FORM_ENC_HEADERS, body
+        return token_url, _form_enc_headers(), body
 
     def prepare_token_revocation_request(self, revocation_url, token,
                                          token_type_hint="access_token", body='', callback=None, **kwargs):

--- a/tests/oauth2/rfc6749/clients/test_base.py
+++ b/tests/oauth2/rfc6749/clients/test_base.py
@@ -304,6 +304,24 @@ class ClientTest(TestCase):
         self.assertEqual(h, {'Content-Type': 'application/x-www-form-urlencoded'})
         self.assertFormBodyEqual(b, 'grant_type=refresh_token&scope={}&refresh_token={}'.format(scope, token))
 
+    def test_prepare_request_headers_are_not_shared(self):
+        # Regression test for #873: mutating the headers dict returned by a
+        # prepare_*_request method must not affect the headers returned by
+        # later calls (the methods used to return a shared module-level dict).
+        client = Client(self.client_id)
+        url = 'https://example.com/token'
+        token = 'foobar'
+
+        _, first_headers, _ = client.prepare_refresh_token_request(url, token)
+        first_headers['Content-Length'] = '0'
+
+        _, second_headers, _ = client.prepare_refresh_token_request(url, token)
+        self.assertEqual(
+            second_headers,
+            {'Content-Type': 'application/x-www-form-urlencoded'})
+        self.assertNotIn('Content-Length', second_headers)
+        self.assertIsNot(first_headers, second_headers)
+
     def test_create_code_verifier_min_length(self):
         client = Client(self.client_id)
         length = 43


### PR DESCRIPTION
Fixes #873

## Problem

`Client.prepare_authorization_request`, `Client.prepare_token_request` and `Client.prepare_refresh_token_request` all returned the module-level `FORM_ENC_HEADERS` constant directly. Since the same dict object was handed back on every call, mutating the headers returned by one call leaked into the headers returned by later calls, and even corrupted the shared module-level constant for the rest of the process.

Reproduction from the issue (before the fix):

```python
>>> import oauthlib.oauth2
>>> client = oauthlib.oauth2.WebApplicationClient('my client id')
>>> _, headers, _ = client.prepare_authorization_request('https://example.com')
>>> headers['Content-Length'] = '0'
>>> _, headers, _ = client.prepare_authorization_request('https://example.com')
>>> headers
{'Content-Type': 'application/x-www-form-urlencoded', 'Content-Length': '0'}
>>> _, headers, _ = client.prepare_token_request('https://example.com')
>>> headers
{'Content-Type': 'application/x-www-form-urlencoded', 'Content-Length': '0'}
```

The mutation persists across calls and across the three different `prepare_*` methods because they share one dict.

## Fix

Return a fresh copy of the form-encoded headers on every call. A small helper `_form_enc_headers()` returns `dict(FORM_ENC_HEADERS)`, and the three `prepare_*_request` methods use it instead of returning the constant by reference. Behavior is otherwise unchanged: the headers content is identical, only the object identity is now per-call.

After the fix:

```python
>>> _, headers, _ = client.prepare_authorization_request('https://example.com')
>>> headers['Content-Length'] = '0'
>>> _, headers, _ = client.prepare_authorization_request('https://example.com')
>>> headers
{'Content-Type': 'application/x-www-form-urlencoded'}
>>> _, headers, _ = client.prepare_token_request('https://example.com')
>>> headers
{'Content-Type': 'application/x-www-form-urlencoded'}
```

The module-level `FORM_ENC_HEADERS` constant also stays intact across calls.

## Tests

Added `test_prepare_request_headers_are_not_shared` in `tests/oauth2/rfc6749/clients/test_base.py`: it mutates the headers from one `prepare_refresh_token_request` call and asserts a later call returns the unmodified headers and a distinct object. The test fails on the current code and passes with this change. The full oauth2 test suite remains green.
