### PR TITLE
fix: remove stale entry in CaseInsensitiveDict when key casing changes

### DIFF
--- a/oauthlib/common.py
+++ b/oauthlib/common.py
@@ -319,13 +319,20 @@ class CaseInsensitiveDict(dict):
         return self[k] if k in self else default  # noqa: SIM401
 
     def __setitem__(self, k, v):
+        # Remove stale entry for a different-cased key that maps to the same
+        # lowercase key, so the underlying dict never holds duplicates.
+        if k.lower() in self.proxy:
+            old_key = self.proxy[k.lower()]
+            if old_key != k:
+                super().__delitem__(old_key)
         super().__setitem__(k, v)
         self.proxy[k.lower()] = k
 
     def update(self, *args, **kwargs):
-        super().update(*args, **kwargs)
-        for k in dict(*args, **kwargs):
-            self.proxy[k.lower()] = k
+        # Route through __setitem__ so different-cased overwrites are handled
+        # correctly (super().update() bypasses __setitem__ in CPython).
+        for k, v in dict(*args, **kwargs).items():
+            self[k] = v
 
 
 class Request:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -257,3 +257,20 @@ class CaseInsensitiveDictTest(TestCase):
         cid = CaseInsensitiveDict({})
         cid.update({'KeY': 'value'})
         self.assertEqual(cid['kEy'], 'value')
+
+    def test_setitem_different_case_no_duplicate(self):
+        # Overwriting a key with different casing must not leave a stale entry
+        # in the underlying dict (which would corrupt len/iteration).
+        cid = CaseInsensitiveDict({'Content-Type': 'text/plain'})
+        cid['content-type'] = 'application/json'
+        self.assertEqual(len(cid), 1)
+        self.assertEqual(list(cid.keys()), ['content-type'])
+        self.assertEqual(cid['Content-Type'], 'application/json')
+
+    def test_update_different_case_no_duplicate(self):
+        # Same contract for update().
+        cid = CaseInsensitiveDict({'Content-Type': 'text/plain'})
+        cid.update({'content-type': 'application/json'})
+        self.assertEqual(len(cid), 1)
+        self.assertEqual(list(cid.keys()), ['content-type'])
+        self.assertEqual(cid['Content-Type'], 'application/json')


### PR DESCRIPTION
## Problem

`CaseInsensitiveDict.__setitem__` calls `super().__setitem__` directly, so when
a key is written with a different capitalisation than the one already stored, the
old-cased entry is never removed from the underlying `dict`.  The same issue
exists in `update()`, which called `super().update()` (which bypasses
`__setitem__` in CPython) before patching `self.proxy`.

Concrete wrong behaviour:

```python
d = CaseInsensitiveDict({'Content-Type': 'text/plain'})
d['content-type'] = 'application/json'

len(d)         # 2 — should be 1
list(d.keys()) # ['Content-Type', 'content-type'] — duplicate!
list(d.values())  # ['text/plain', 'application/json'] — stale value visible
```

This affects the `Request.headers` object used throughout oauthlib: if a
caller sets a header with a casing that differs from how it was initially
stored, both variants appear in iteration and `len()`, which can cause
incorrect behaviour in middleware that relies on iterating headers.

## Fix

* `__setitem__`: before inserting the new key, delete the old-cased entry
  when the lower-cased key already exists under a different spelling.
* `update`: delegate to `self[k] = v` (our own `__setitem__`) instead of
  `super().update()`, so the cleanup applies uniformly.

## Tests

Two new test cases verify that `len` stays at 1 and `keys()` contains only
the new casing after a mixed-case overwrite via `__setitem__` and `update`.
All 435 existing tests continue to pass.

This pull request was prepared with the assistance of AI, under my direction and review.