### PR TITLE
Fix typos: mimiced -> mimicked, implementor -> implementer

### DIFF
--- a/docs/oauth2/grants/custom_grant.rst
+++ b/docs/oauth2/grants/custom_grant.rst
@@ -47,7 +47,7 @@ This example shows how to add a simple extension to the `Token endpoint`:
 
 * creation of a new class ``MyCustomGrant``, and implement ``create_token_response``.
 * do basics and custom request validations, then call a custom method
-  of `Request Validator` to extend the interface for the implementor.
+  of `Request Validator` to extend the interface for the implementer.
 * instantiate the new grant, and bind it with an existing ``Server``.
 
 .. code-block:: python

--- a/oauthlib/oauth1/rfc5849/request_validator.py
+++ b/oauthlib/oauth1/rfc5849/request_validator.py
@@ -472,7 +472,7 @@ class RequestValidator:
         Note that if the dummy client is supplied it should validate in same
         or nearly the same amount of time as a valid one.
 
-        Ensure latency inducing tasks are mimiced even for dummy clients.
+        Ensure latency inducing tasks are mimicked even for dummy clients.
         For example, use::
 
             from your_datastore import Client
@@ -510,7 +510,7 @@ class RequestValidator:
         Note that if the dummy request_token is supplied it should validate in
         the same nearly the same amount of time as a valid one.
 
-        Ensure latency inducing tasks are mimiced even for dummy clients.
+        Ensure latency inducing tasks are mimicked even for dummy clients.
         For example, use::
 
             from your_datastore import RequestToken
@@ -545,7 +545,7 @@ class RequestValidator:
         Note that if the dummy access token is supplied it should validate in
         the same or nearly the same amount of time as a valid one.
 
-        Ensure latency inducing tasks are mimiced even for dummy clients.
+        Ensure latency inducing tasks are mimicked even for dummy clients.
         For example, use::
 
             from your_datastore import AccessToken


### PR DESCRIPTION
Fix two spelling mistakes found in docstrings and docs:

- `mimiced` → `mimicked` (3 occurrences in `oauthlib/oauth1/rfc5849/request_validator.py`)
- `implementor` → `implementer` (1 occurrence in `docs/oauth2/grants/custom_grant.rst`)

These are straightforward typo corrections in comments/docstrings with no functional impact.